### PR TITLE
Add PCSX2 and Ryujinx game sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### PCSX2 and Ryujinx
+
+- Added PCSX2 as a game source: imports disc-based games from the native
+  gamelist cache (v32 and v34) for native and Flatpak installs, with cover
+  art, playtime, last-played, and region metadata, and delegated launching
+  through the owning PCSX2 install. Sources are discovered automatically and
+  appear once the emulator is detected.
+- Added Ryujinx as a game source: discovers XCI, NSP, and NRO games from the
+  configured game directories for native and Flatpak installs, with custom
+  titles, playtime, and last-played metadata, and delegated launching.
+- Added per-source filter chips, status rows, and rescan controls for both
+  emulators in Settings.
+
 ### Steam
 
 - Imported non-Steam shortcuts from `shortcuts.vdf`, including Wine/Proton

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ add_library(omakade_core STATIC
   src/library/LutrisGameModel.h
   src/library/RetroArchGameModel.cpp
   src/library/RetroArchGameModel.h
+  src/library/Pcsx2GameModel.cpp
+  src/library/Pcsx2GameModel.h
+  src/library/RyujinxGameModel.cpp
+  src/library/RyujinxGameModel.h
   src/library/MockGameModel.cpp
   src/library/MockGameModel.h
   src/library/SteamGameModel.cpp
@@ -66,6 +70,10 @@ add_library(omakade_core STATIC
   src/sources/lutris/LutrisScanner.h
   src/sources/retroarch/RetroArchScanner.cpp
   src/sources/retroarch/RetroArchScanner.h
+  src/sources/pcsx2/Pcsx2Scanner.cpp
+  src/sources/pcsx2/Pcsx2Scanner.h
+  src/sources/ryujinx/RyujinxScanner.cpp
+  src/sources/ryujinx/RyujinxScanner.h
   src/sources/heroic/HeroicScanner.cpp
   src/sources/heroic/HeroicScanner.h
   src/sources/faugus/FaugusScanner.cpp

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -38,8 +38,8 @@ CI. Additional real-user reports expand compatibility coverage after v1.
 ## Contract-tested sources
 
 Lutris native and Flatpak discovery, Heroic native and Flatpak discovery,
-Faugus and RetroArch native and Flatpak discovery, PCSX2 and Ryujinx native
-and Flatpak discovery, and Epic, GOG, and Amazon
+Faugus and RetroArch native and Flatpak discovery, PCSX2 and Ryujinx scanner
+contracts (native and Flatpak roots), and Epic, GOG, and Amazon
 manifests are covered by repeatable local fixtures. These
 paths still need reports from users with those launchers installed before the
 stable release gate can close.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -38,7 +38,8 @@ CI. Additional real-user reports expand compatibility coverage after v1.
 ## Contract-tested sources
 
 Lutris native and Flatpak discovery, Heroic native and Flatpak discovery,
-Faugus and RetroArch native and Flatpak discovery, and Epic, GOG, and Amazon
+Faugus and RetroArch native and Flatpak discovery, PCSX2 and Ryujinx native
+and Flatpak discovery, and Epic, GOG, and Amazon
 manifests are covered by repeatable local fixtures. These
 paths still need reports from users with those launchers installed before the
 stable release gate can close.

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -946,6 +946,7 @@ ApplicationWindow {
                     GlassButton {
                         id: retroArchSourceButton
                         objectName: "retroArchSourceButton"
+                        property Item controllerRightTarget: pcsx2SourceButton
                         text: "RETROARCH"
                         compact: true
                         visible: Preferences.retroArchEnabled
@@ -958,6 +959,8 @@ ApplicationWindow {
                     GlassButton {
                         id: pcsx2SourceButton
                         objectName: "pcsx2SourceButton"
+                        property Item controllerLeftTarget: retroArchSourceButton
+                        property Item controllerRightTarget: ryujinxSourceButton
                         property Item controllerDownTarget: statusFilterButton
                         text: "PCSX2"
                         compact: true
@@ -971,6 +974,7 @@ ApplicationWindow {
                     GlassButton {
                         id: ryujinxSourceButton
                         objectName: "ryujinxSourceButton"
+                        property Item controllerLeftTarget: pcsx2SourceButton
                         property Item controllerDownTarget: statusFilterButton
                         property Item controllerRightTarget: statusFilterButton
                         text: "RYUJINX"
@@ -1017,7 +1021,7 @@ ApplicationWindow {
                     id: sortButton
                     objectName: "sortButton"
                     property Item controllerLeftTarget: root.width < 1040
-                                                         ? retroArchSourceButton
+                                                         ? ryujinxSourceButton
                                                          : hiddenModeButton
                     property Item controllerRightTarget: rescanButton
                     compact: true

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -951,6 +951,26 @@ ApplicationWindow {
                             libraryView.currentIndex = Library.rowCount() > 0 ? 0 : -1
                         }
                     }
+                    GlassButton {
+                        text: "PCSX2"
+                        compact: true
+                        visible: Preferences.pcsx2Enabled
+                        selected: Library.sourceFilter === "PCSX2"
+                        onClicked: {
+                            Library.sourceFilter = "PCSX2"
+                            libraryView.currentIndex = Library.rowCount() > 0 ? 0 : -1
+                        }
+                    }
+                    GlassButton {
+                        text: "RYUJINX"
+                        compact: true
+                        visible: Preferences.ryujinxEnabled
+                        selected: Library.sourceFilter === "Ryujinx"
+                        onClicked: {
+                            Library.sourceFilter = "Ryujinx"
+                            libraryView.currentIndex = Library.rowCount() > 0 ? 0 : -1
+                        }
+                    }
                 }
 
                 Text {
@@ -1141,6 +1161,10 @@ ApplicationWindow {
                             ? "Faugus was not found"
                             : Library.sourceFilter === "RetroArch" && RetroArchLibrary && !RetroArchLibrary.retroArchDetected
                             ? "RetroArch was not found"
+                            : Library.sourceFilter === "PCSX2" && Pcsx2Library && !Pcsx2Library.pcsx2Detected
+                            ? "PCSX2 was not found"
+                            : Library.sourceFilter === "Ryujinx" && RyujinxLibrary && !RyujinxLibrary.ryujinxDetected
+                            ? "Ryujinx was not found"
                             : Library.sourceFilter === "Lutris" && LutrisLibrary && !LutrisLibrary.lutrisDetected
                             ? "Lutris was not found"
                             : Library.sourceFilter === "Steam" && SteamLibrary && !SteamLibrary.steamDetected
@@ -1157,18 +1181,28 @@ ApplicationWindow {
                               ? FaugusLibrary.errorText
                               : Library.sourceFilter === "RetroArch" && RetroArchLibrary && RetroArchLibrary.errorText.length > 0
                               ? RetroArchLibrary.errorText
+                              : Library.sourceFilter === "PCSX2" && Pcsx2Library && Pcsx2Library.errorText.length > 0
+                              ? Pcsx2Library.errorText
+                              : Library.sourceFilter === "Ryujinx" && RyujinxLibrary && RyujinxLibrary.errorText.length > 0
+                              ? RyujinxLibrary.errorText
                               : Library.sourceFilter === "Heroic" && HeroicLibrary && HeroicLibrary.errorText.length > 0
                               ? HeroicLibrary.errorText
                               : Library.sourceFilter === "Lutris" && LutrisLibrary && LutrisLibrary.errorText.length > 0
                               ? LutrisLibrary.errorText
                               : SteamLibrary && SteamLibrary.errorText.length > 0
                                 ? SteamLibrary.errorText
-                                : "Install a game in Steam, Lutris, Heroic, Faugus, or RetroArch, then rescan your library."
+                                : "Install a game in Steam, Lutris, Heroic, Faugus, RetroArch, PCSX2, or Ryujinx, then rescan your library."
                 onGameActivated: index => root.openGame(index)
                 onFavoriteToggled: index => Library.toggleFavorite(index)
                 onCoverRequested: function(source, appId) {
                     if (source === "Steam" && SteamLibrary) {
                         SteamLibrary.requestCover(appId)
+                    }
+                    if (Pcsx2Library && Preferences.pcsx2Enabled) {
+                        Pcsx2Library.refresh()
+                    }
+                    if (RyujinxLibrary && Preferences.ryujinxEnabled) {
+                        RyujinxLibrary.refresh()
                     }
                 }
                 onRefreshRequested: {
@@ -1661,7 +1695,17 @@ ApplicationWindow {
                           status: RetroArchLibrary ? RetroArchLibrary.statusText : "Unavailable",
                           error: RetroArchLibrary ? RetroArchLibrary.errorText : "",
                           paths: RetroArchLibrary ? RetroArchLibrary.detectedPaths : [],
-                          lastScan: RetroArchLibrary ? RetroArchLibrary.lastScan : 0 }
+                          lastScan: RetroArchLibrary ? RetroArchLibrary.lastScan : 0 },
+                        { name: "PCSX2", enabled: Preferences.pcsx2Enabled,
+                          status: Pcsx2Library ? Pcsx2Library.statusText : "Unavailable",
+                          error: Pcsx2Library ? Pcsx2Library.errorText : "",
+                          paths: Pcsx2Library ? Pcsx2Library.detectedPaths : [],
+                          lastScan: Pcsx2Library ? Pcsx2Library.lastScan : 0 },
+                        { name: "RYUJINX", enabled: Preferences.ryujinxEnabled,
+                          status: RyujinxLibrary ? RyujinxLibrary.statusText : "Unavailable",
+                          error: RyujinxLibrary ? RyujinxLibrary.errorText : "",
+                          paths: RyujinxLibrary ? RyujinxLibrary.detectedPaths : [],
+                          lastScan: RyujinxLibrary ? RyujinxLibrary.lastScan : 0 }
                     ]
                     ColumnLayout {
                         required property var modelData
@@ -1699,6 +1743,14 @@ ApplicationWindow {
                                         Preferences.faugusEnabled = !Preferences.faugusEnabled
                                         nowEnabled = Preferences.faugusEnabled
                                         if (Preferences.faugusEnabled) FaugusLibrary.refresh()
+                                    } else if (modelData.name === "PCSX2") {
+                                        Preferences.pcsx2Enabled = !Preferences.pcsx2Enabled
+                                        nowEnabled = Preferences.pcsx2Enabled
+                                        if (Preferences.pcsx2Enabled) Pcsx2Library.refresh()
+                                    } else if (modelData.name === "RYUJINX") {
+                                        Preferences.ryujinxEnabled = !Preferences.ryujinxEnabled
+                                        nowEnabled = Preferences.ryujinxEnabled
+                                        if (Preferences.ryujinxEnabled) RyujinxLibrary.refresh()
                                     } else {
                                         Preferences.retroArchEnabled = !Preferences.retroArchEnabled
                                         nowEnabled = Preferences.retroArchEnabled
@@ -1718,6 +1770,8 @@ ApplicationWindow {
                                     else if (modelData.name === "LUTRIS") LutrisLibrary.refresh()
                                     else if (modelData.name === "HEROIC") HeroicLibrary.refresh()
                                     else if (modelData.name === "FAUGUS") FaugusLibrary.refresh()
+                                    else if (modelData.name === "PCSX2") Pcsx2Library.refresh()
+                                    else if (modelData.name === "RYUJINX") RyujinxLibrary.refresh()
                                     else RetroArchLibrary.refresh()
                                 }
                             }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -28,6 +28,8 @@ ApplicationWindow {
                                             || (HeroicLibrary ? HeroicLibrary.scanning : false)
                                             || (FaugusLibrary ? FaugusLibrary.scanning : false)
                                             || (RetroArchLibrary ? RetroArchLibrary.scanning : false)
+                                            || (Pcsx2Library ? Pcsx2Library.scanning : false)
+                                            || (RyujinxLibrary ? RyujinxLibrary.scanning : false)
     readonly property int ownedGameCount: SteamAccount
                                           ? SteamAccount.ownedGameCount
                                           : OwnedGameCountOverride
@@ -198,6 +200,8 @@ ApplicationWindow {
         if (HeroicLibrary && Preferences.heroicEnabled) HeroicLibrary.refresh()
         if (FaugusLibrary && Preferences.faugusEnabled) FaugusLibrary.refresh()
         if (RetroArchLibrary && Preferences.retroArchEnabled) RetroArchLibrary.refresh()
+        if (Pcsx2Library && Preferences.pcsx2Enabled) Pcsx2Library.refresh()
+        if (RyujinxLibrary && Preferences.ryujinxEnabled) RyujinxLibrary.refresh()
     }
 
     function focusAboveGrid() {
@@ -952,6 +956,9 @@ ApplicationWindow {
                         }
                     }
                     GlassButton {
+                        id: pcsx2SourceButton
+                        objectName: "pcsx2SourceButton"
+                        property Item controllerDownTarget: statusFilterButton
                         text: "PCSX2"
                         compact: true
                         visible: Preferences.pcsx2Enabled
@@ -962,6 +969,10 @@ ApplicationWindow {
                         }
                     }
                     GlassButton {
+                        id: ryujinxSourceButton
+                        objectName: "ryujinxSourceButton"
+                        property Item controllerDownTarget: statusFilterButton
+                        property Item controllerRightTarget: statusFilterButton
                         text: "RYUJINX"
                         compact: true
                         visible: Preferences.ryujinxEnabled
@@ -1197,12 +1208,6 @@ ApplicationWindow {
                 onCoverRequested: function(source, appId) {
                     if (source === "Steam" && SteamLibrary) {
                         SteamLibrary.requestCover(appId)
-                    }
-                    if (Pcsx2Library && Preferences.pcsx2Enabled) {
-                        Pcsx2Library.refresh()
-                    }
-                    if (RyujinxLibrary && Preferences.ryujinxEnabled) {
-                        RyujinxLibrary.refresh()
                     }
                 }
                 onRefreshRequested: {

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -976,7 +976,6 @@ ApplicationWindow {
                         objectName: "ryujinxSourceButton"
                         property Item controllerLeftTarget: pcsx2SourceButton
                         property Item controllerDownTarget: statusFilterButton
-                        property Item controllerRightTarget: statusFilterButton
                         text: "RYUJINX"
                         compact: true
                         visible: Preferences.ryujinxEnabled

--- a/qml/screens/GameDetails.qml
+++ b/qml/screens/GameDetails.qml
@@ -404,6 +404,8 @@ Item {
                                  || root.selectedInstallation.source === "Heroic"
                                  || root.selectedInstallation.source === "Faugus"
                                  || root.selectedInstallation.source === "RetroArch"
+                                 || root.selectedInstallation.source === "PCSX2"
+                                 || root.selectedInstallation.source === "Ryujinx"
                         text: "MANAGE IN " + (root.selectedInstallation.source || "LAUNCHER").toUpperCase()
                         onClicked: root.manageRequested()
                     }

--- a/src/app/AppSettings.cpp
+++ b/src/app/AppSettings.cpp
@@ -119,7 +119,9 @@ void AppSettings::setRetroArchEnabled(bool value) {
 bool AppSettings::pcsx2Enabled() const { return m_pcsx2Enabled; }
 
 void AppSettings::setPcsx2Enabled(bool value) {
-  if (m_pcsx2Enabled == value) {
+  const bool wasAuto = m_pcsx2Auto;
+  m_pcsx2Auto = false;  // an explicit user choice disables automatic detection
+  if (m_pcsx2Enabled == value && !wasAuto) {
     return;
   }
   m_pcsx2Enabled = value;
@@ -130,7 +132,9 @@ void AppSettings::setPcsx2Enabled(bool value) {
 bool AppSettings::ryujinxEnabled() const { return m_ryujinxEnabled; }
 
 void AppSettings::setRyujinxEnabled(bool value) {
-  if (m_ryujinxEnabled == value) {
+  const bool wasAuto = m_ryujinxAuto;
+  m_ryujinxAuto = false;  // an explicit user choice disables automatic detection
+  if (m_ryujinxEnabled == value && !wasAuto) {
     return;
   }
   m_ryujinxEnabled = value;
@@ -272,6 +276,5 @@ void AppSettings::save() const {
                   .arg(m_sunshineOmakadeApp ? QStringLiteral("true") : QStringLiteral("false"))
                   .arg(m_sunshineGameApps ? QStringLiteral("true") : QStringLiteral("false"));
   file.write(contents.toUtf8());
-
   file.commit();
 }

--- a/src/app/AppSettings.cpp
+++ b/src/app/AppSettings.cpp
@@ -138,6 +138,14 @@ void AppSettings::setRyujinxEnabled(bool value) {
   emit sourcesChanged();
 }
 
+bool AppSettings::pcsx2AutoEnabled() const { return m_pcsx2Auto; }
+
+void AppSettings::setPcsx2AutoEnabled(bool value) { m_pcsx2Auto = value; }
+
+bool AppSettings::ryujinxAutoEnabled() const { return m_ryujinxAuto; }
+
+void AppSettings::setRyujinxAutoEnabled(bool value) { m_ryujinxAuto = value; }
+
 bool AppSettings::closeAfterLaunch() const { return m_closeAfterLaunch; }
 
 void AppSettings::setCloseAfterLaunch(bool value) {
@@ -193,8 +201,14 @@ void AppSettings::load() {
   m_heroicEnabled = readEnabled(QStringLiteral("heroic_enabled"), true);
   m_faugusEnabled = readEnabled(QStringLiteral("faugus_enabled"), true);
   m_retroArchEnabled = readEnabled(QStringLiteral("retroarch_enabled"), true);
-  m_pcsx2Enabled = readEnabled(QStringLiteral("pcsx2_enabled"), true);
-  m_ryujinxEnabled = readEnabled(QStringLiteral("ryujinx_enabled"), true);
+  const QRegularExpression pcsx2Key(
+      QStringLiteral("(?m)^pcsx2_enabled\\s*=\\s*(true|false)\\s*$"));
+  m_pcsx2Auto = !pcsx2Key.match(contents).hasMatch();
+  m_pcsx2Enabled = readEnabled(QStringLiteral("pcsx2_enabled"), false);
+  const QRegularExpression ryujinxKey(
+      QStringLiteral("(?m)^ryujinx_enabled\\s*=\\s*(true|false)\\s*$"));
+  m_ryujinxAuto = !ryujinxKey.match(contents).hasMatch();
+  m_ryujinxEnabled = readEnabled(QStringLiteral("ryujinx_enabled"), false);
   m_closeAfterLaunch = readEnabled(QStringLiteral("close_after_launch"), false);
   m_sunshineOmakadeApp = readEnabled(QStringLiteral("sunshine_omakade_app"), false);
   m_sunshineGameApps = readEnabled(QStringLiteral("sunshine_game_apps"), false);

--- a/src/app/AppSettings.cpp
+++ b/src/app/AppSettings.cpp
@@ -116,6 +116,28 @@ void AppSettings::setRetroArchEnabled(bool value) {
   emit sourcesChanged();
 }
 
+bool AppSettings::pcsx2Enabled() const { return m_pcsx2Enabled; }
+
+void AppSettings::setPcsx2Enabled(bool value) {
+  if (m_pcsx2Enabled == value) {
+    return;
+  }
+  m_pcsx2Enabled = value;
+  save();
+  emit sourcesChanged();
+}
+
+bool AppSettings::ryujinxEnabled() const { return m_ryujinxEnabled; }
+
+void AppSettings::setRyujinxEnabled(bool value) {
+  if (m_ryujinxEnabled == value) {
+    return;
+  }
+  m_ryujinxEnabled = value;
+  save();
+  emit sourcesChanged();
+}
+
 bool AppSettings::closeAfterLaunch() const { return m_closeAfterLaunch; }
 
 void AppSettings::setCloseAfterLaunch(bool value) {
@@ -171,6 +193,8 @@ void AppSettings::load() {
   m_heroicEnabled = readEnabled(QStringLiteral("heroic_enabled"), true);
   m_faugusEnabled = readEnabled(QStringLiteral("faugus_enabled"), true);
   m_retroArchEnabled = readEnabled(QStringLiteral("retroarch_enabled"), true);
+  m_pcsx2Enabled = readEnabled(QStringLiteral("pcsx2_enabled"), true);
+  m_ryujinxEnabled = readEnabled(QStringLiteral("ryujinx_enabled"), true);
   m_closeAfterLaunch = readEnabled(QStringLiteral("close_after_launch"), false);
   m_sunshineOmakadeApp = readEnabled(QStringLiteral("sunshine_omakade_app"), false);
   m_sunshineGameApps = readEnabled(QStringLiteral("sunshine_game_apps"), false);
@@ -204,23 +228,36 @@ void AppSettings::save() const {
   if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
     return;
   }
-  file.write(QStringLiteral("reduced_motion = %1\nartwork_cache_limit_mb = %2\nsteam_id = "
-                            "\"%3\"\nigdb_client_id = \"%4\"\nsteam_enabled = %5\n"
-                            "lutris_enabled = %6\nheroic_enabled = %7\nfaugus_enabled = %8\n"
-                            "retroarch_enabled = %9\nclose_after_launch = %10\n"
-                            "sunshine_omakade_app = %11\nsunshine_game_apps = %12\n")
-                 .arg(m_reducedMotion ? QStringLiteral("true") : QStringLiteral("false"))
-                 .arg(m_artworkCacheLimitMb)
-                 .arg(m_steamId)
-                 .arg(m_igdbClientId)
-                 .arg(m_steamEnabled ? QStringLiteral("true") : QStringLiteral("false"))
-                 .arg(m_lutrisEnabled ? QStringLiteral("true") : QStringLiteral("false"))
-                 .arg(m_heroicEnabled ? QStringLiteral("true") : QStringLiteral("false"))
-                 .arg(m_faugusEnabled ? QStringLiteral("true") : QStringLiteral("false"))
-                 .arg(m_retroArchEnabled ? QStringLiteral("true") : QStringLiteral("false"))
-                 .arg(m_closeAfterLaunch ? QStringLiteral("true") : QStringLiteral("false"))
-                 .arg(m_sunshineOmakadeApp ? QStringLiteral("true") : QStringLiteral("false"))
-                 .arg(m_sunshineGameApps ? QStringLiteral("true") : QStringLiteral("false"))
-                 .toUtf8());
+  // Emulator source keys are written only once their state is explicit (detection
+  // completed or the user chose a value); while auto-detection is pending the keys
+  // stay absent so a later emulator installation can still enable its source.
+  QString contents =
+      QStringLiteral("reduced_motion = %1\nartwork_cache_limit_mb = %2\nsteam_id = \"%3\"\n"
+                     "igdb_client_id = \"%4\"\nsteam_enabled = %5\nlutris_enabled = %6\n"
+                     "heroic_enabled = %7\nfaugus_enabled = %8\nretroarch_enabled = %9\n")
+          .arg(m_reducedMotion ? QStringLiteral("true") : QStringLiteral("false"))
+          .arg(m_artworkCacheLimitMb)
+          .arg(m_steamId)
+          .arg(m_igdbClientId)
+          .arg(m_steamEnabled ? QStringLiteral("true") : QStringLiteral("false"))
+          .arg(m_lutrisEnabled ? QStringLiteral("true") : QStringLiteral("false"))
+          .arg(m_heroicEnabled ? QStringLiteral("true") : QStringLiteral("false"))
+          .arg(m_faugusEnabled ? QStringLiteral("true") : QStringLiteral("false"))
+          .arg(m_retroArchEnabled ? QStringLiteral("true") : QStringLiteral("false"));
+  if (!m_pcsx2Auto) {
+    contents += QStringLiteral("pcsx2_enabled = %1\n")
+                    .arg(m_pcsx2Enabled ? QStringLiteral("true") : QStringLiteral("false"));
+  }
+  if (!m_ryujinxAuto) {
+    contents += QStringLiteral("ryujinx_enabled = %1\n")
+                    .arg(m_ryujinxEnabled ? QStringLiteral("true") : QStringLiteral("false"));
+  }
+  contents += QStringLiteral("close_after_launch = %1\n"
+                             "sunshine_omakade_app = %2\nsunshine_game_apps = %3\n")
+                  .arg(m_closeAfterLaunch ? QStringLiteral("true") : QStringLiteral("false"))
+                  .arg(m_sunshineOmakadeApp ? QStringLiteral("true") : QStringLiteral("false"))
+                  .arg(m_sunshineGameApps ? QStringLiteral("true") : QStringLiteral("false"));
+  file.write(contents.toUtf8());
+
   file.commit();
 }

--- a/src/app/AppSettings.h
+++ b/src/app/AppSettings.h
@@ -52,6 +52,12 @@ public:
   void setPcsx2Enabled(bool value);
   [[nodiscard]] bool ryujinxEnabled() const;
   void setRyujinxEnabled(bool value);
+  // True while the user has not written an explicit pcsx2_enabled/ryujinx_enabled key,
+  // letting the app enable the source automatically when its emulator is detected.
+  [[nodiscard]] bool pcsx2AutoEnabled() const;
+  [[nodiscard]] bool ryujinxAutoEnabled() const;
+  void setPcsx2AutoEnabled(bool value);
+  void setRyujinxAutoEnabled(bool value);
   [[nodiscard]] bool closeAfterLaunch() const;
   void setCloseAfterLaunch(bool value);
   [[nodiscard]] bool sunshineOmakadeApp() const;
@@ -83,8 +89,10 @@ private:
   bool m_heroicEnabled = true;
   bool m_faugusEnabled = true;
   bool m_retroArchEnabled = true;
-  bool m_pcsx2Enabled = true;
-  bool m_ryujinxEnabled = true;
+  bool m_pcsx2Enabled = false;
+  bool m_ryujinxEnabled = false;
+  bool m_pcsx2Auto = true;
+  bool m_ryujinxAuto = true;
   bool m_closeAfterLaunch = false;
   bool m_sunshineOmakadeApp = false;
   bool m_sunshineGameApps = false;

--- a/src/app/AppSettings.h
+++ b/src/app/AppSettings.h
@@ -18,6 +18,8 @@ class AppSettings final : public QObject {
   Q_PROPERTY(bool faugusEnabled READ faugusEnabled WRITE setFaugusEnabled NOTIFY sourcesChanged)
   Q_PROPERTY(
       bool retroArchEnabled READ retroArchEnabled WRITE setRetroArchEnabled NOTIFY sourcesChanged)
+  Q_PROPERTY(bool pcsx2Enabled READ pcsx2Enabled WRITE setPcsx2Enabled NOTIFY sourcesChanged)
+  Q_PROPERTY(bool ryujinxEnabled READ ryujinxEnabled WRITE setRyujinxEnabled NOTIFY sourcesChanged)
   Q_PROPERTY(bool closeAfterLaunch READ closeAfterLaunch WRITE setCloseAfterLaunch NOTIFY
                  closeAfterLaunchChanged)
   Q_PROPERTY(bool sunshineOmakadeApp READ sunshineOmakadeApp WRITE setSunshineOmakadeApp NOTIFY
@@ -46,6 +48,10 @@ public:
   void setFaugusEnabled(bool value);
   [[nodiscard]] bool retroArchEnabled() const;
   void setRetroArchEnabled(bool value);
+  [[nodiscard]] bool pcsx2Enabled() const;
+  void setPcsx2Enabled(bool value);
+  [[nodiscard]] bool ryujinxEnabled() const;
+  void setRyujinxEnabled(bool value);
   [[nodiscard]] bool closeAfterLaunch() const;
   void setCloseAfterLaunch(bool value);
   [[nodiscard]] bool sunshineOmakadeApp() const;
@@ -77,6 +83,8 @@ private:
   bool m_heroicEnabled = true;
   bool m_faugusEnabled = true;
   bool m_retroArchEnabled = true;
+  bool m_pcsx2Enabled = true;
+  bool m_ryujinxEnabled = true;
   bool m_closeAfterLaunch = false;
   bool m_sunshineOmakadeApp = false;
   bool m_sunshineGameApps = false;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1019,9 +1019,11 @@ int main(int argc, char* argv[]) {
   if (retroArchLibrary != nullptr && preferences.retroArchEnabled()) {
     QTimer::singleShot(600, retroArchLibrary, &RetroArchGameModel::refresh);
   }
-  if (pcsx2Library != nullptr) {
-    // Sources start disabled and switch on once their emulator is detected, unless
-    // the user wrote an explicit pcsx2_enabled key.
+  // Sources start disabled and switch on once their emulator is detected, unless
+  // the user wrote an explicit pcsx2_enabled/ryujinx_enabled key. Scans only run
+  // while the source is enabled or still eligible for automatic detection.
+  if (pcsx2Library != nullptr &&
+      (preferences.pcsx2Enabled() || preferences.pcsx2AutoEnabled())) {
     QTimer::singleShot(650, pcsx2Library, &Pcsx2GameModel::refresh);
     QObject::connect(pcsx2Library, &Pcsx2GameModel::statusChanged, pcsx2Library,
                      [&preferences, pcsx2Library] {
@@ -1031,7 +1033,8 @@ int main(int argc, char* argv[]) {
                        }
                      });
   }
-  if (ryujinxLibrary != nullptr) {
+  if (ryujinxLibrary != nullptr &&
+      (preferences.ryujinxEnabled() || preferences.ryujinxAutoEnabled())) {
     QTimer::singleShot(700, ryujinxLibrary, &RyujinxGameModel::refresh);
     QObject::connect(ryujinxLibrary, &RyujinxGameModel::statusChanged, ryujinxLibrary,
                      [&preferences, ryujinxLibrary] {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -264,11 +264,13 @@ int main(int argc, char* argv[]) {
         retroArchLibrary->refresh();
         refreshStarted = true;
       } else if (key.source.compare(QStringLiteral("PCSX2"), Qt::CaseInsensitive) == 0 &&
-                 pcsx2Library != nullptr && preferences.pcsx2Enabled()) {
+                 pcsx2Library != nullptr &&
+                 (preferences.pcsx2Enabled() || preferences.pcsx2AutoEnabled())) {
         pcsx2Library->refresh();
         refreshStarted = true;
       } else if (key.source.compare(QStringLiteral("Ryujinx"), Qt::CaseInsensitive) == 0 &&
-                 ryujinxLibrary != nullptr && preferences.ryujinxEnabled()) {
+                 ryujinxLibrary != nullptr &&
+                 (preferences.ryujinxEnabled() || preferences.ryujinxAutoEnabled())) {
         ryujinxLibrary->refresh();
         refreshStarted = true;
       }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1019,11 +1019,27 @@ int main(int argc, char* argv[]) {
   if (retroArchLibrary != nullptr && preferences.retroArchEnabled()) {
     QTimer::singleShot(600, retroArchLibrary, &RetroArchGameModel::refresh);
   }
-  if (pcsx2Library != nullptr && preferences.pcsx2Enabled()) {
+  if (pcsx2Library != nullptr) {
+    // Sources start disabled and switch on once their emulator is detected, unless
+    // the user wrote an explicit pcsx2_enabled key.
     QTimer::singleShot(650, pcsx2Library, &Pcsx2GameModel::refresh);
+    QObject::connect(pcsx2Library, &Pcsx2GameModel::statusChanged, pcsx2Library,
+                     [&preferences, pcsx2Library] {
+                       if (pcsx2Library->pcsx2Detected() && preferences.pcsx2AutoEnabled()) {
+                         preferences.setPcsx2AutoEnabled(false);
+                         preferences.setPcsx2Enabled(true);
+                       }
+                     });
   }
-  if (ryujinxLibrary != nullptr && preferences.ryujinxEnabled()) {
+  if (ryujinxLibrary != nullptr) {
     QTimer::singleShot(700, ryujinxLibrary, &RyujinxGameModel::refresh);
+    QObject::connect(ryujinxLibrary, &RyujinxGameModel::statusChanged, ryujinxLibrary,
+                     [&preferences, ryujinxLibrary] {
+                       if (ryujinxLibrary->ryujinxDetected() && preferences.ryujinxAutoEnabled()) {
+                         preferences.setRyujinxAutoEnabled(false);
+                         preferences.setRyujinxEnabled(true);
+                       }
+                     });
   }
 
   if (smokeTest && !renderMode) {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -11,6 +11,8 @@
 #include "library/LibraryFilterModel.h"
 #include "library/LutrisGameModel.h"
 #include "library/MockGameModel.h"
+#include "library/Pcsx2GameModel.h"
+#include "library/RyujinxGameModel.h"
 #include "library/RetroArchGameModel.h"
 #include "library/SteamGameModel.h"
 #include "library/UnifiedGameModel.h"
@@ -166,11 +168,15 @@ int main(int argc, char* argv[]) {
   std::unique_ptr<HeroicGameModel> heroicGames;
   std::unique_ptr<FaugusGameModel> faugusGames;
   std::unique_ptr<RetroArchGameModel> retroArchGames;
+  std::unique_ptr<Pcsx2GameModel> pcsx2Games;
+  std::unique_ptr<RyujinxGameModel> ryujinxGames;
   SteamGameModel* steamLibrary = nullptr;
   LutrisGameModel* lutrisLibrary = nullptr;
   HeroicGameModel* heroicLibrary = nullptr;
   FaugusGameModel* faugusLibrary = nullptr;
   RetroArchGameModel* retroArchLibrary = nullptr;
+  Pcsx2GameModel* pcsx2Library = nullptr;
+  RyujinxGameModel* ryujinxLibrary = nullptr;
   QString libraryDatabasePath;
   if (demoMode || stressMode || navigationTest) {
     games =
@@ -188,6 +194,10 @@ int main(int argc, char* argv[]) {
     faugusLibrary = faugusGames.get();
     retroArchGames = std::make_unique<RetroArchGameModel>(steamLibrary->databasePath());
     retroArchLibrary = retroArchGames.get();
+    pcsx2Games = std::make_unique<Pcsx2GameModel>(steamLibrary->databasePath());
+    pcsx2Library = pcsx2Games.get();
+    ryujinxGames = std::make_unique<RyujinxGameModel>(steamLibrary->databasePath());
+    ryujinxLibrary = ryujinxGames.get();
   }
   if (navigationTest) {
     libraryDatabasePath = QStringLiteral(":memory:");
@@ -206,12 +216,20 @@ int main(int argc, char* argv[]) {
   if (retroArchGames != nullptr) {
     unifiedGames.addSourceModel(retroArchGames.get());
   }
+  if (pcsx2Games != nullptr) {
+    unifiedGames.addSourceModel(pcsx2Games.get());
+  }
+  if (ryujinxGames != nullptr) {
+    unifiedGames.addSourceModel(ryujinxGames.get());
+  }
   const auto applySourcePreferences = [&] {
     unifiedGames.setSourceEnabled(QStringLiteral("Steam"), preferences.steamEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("Lutris"), preferences.lutrisEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("Heroic"), preferences.heroicEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("Faugus"), preferences.faugusEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("RetroArch"), preferences.retroArchEnabled());
+    unifiedGames.setSourceEnabled(QStringLiteral("PCSX2"), preferences.pcsx2Enabled());
+    unifiedGames.setSourceEnabled(QStringLiteral("Ryujinx"), preferences.ryujinxEnabled());
   };
   applySourcePreferences();
   QObject::connect(&preferences, &AppSettings::sourcesChanged, &unifiedGames,
@@ -364,6 +382,8 @@ int main(int argc, char* argv[]) {
   engine.rootContext()->setContextProperty(QStringLiteral("HeroicLibrary"), heroicLibrary);
   engine.rootContext()->setContextProperty(QStringLiteral("FaugusLibrary"), faugusLibrary);
   engine.rootContext()->setContextProperty(QStringLiteral("RetroArchLibrary"), retroArchLibrary);
+  engine.rootContext()->setContextProperty(QStringLiteral("Pcsx2Library"), pcsx2Library);
+  engine.rootContext()->setContextProperty(QStringLiteral("RyujinxLibrary"), ryujinxLibrary);
   engine.rootContext()->setContextProperty(QStringLiteral("Launcher"), &launcher);
   engine.rootContext()->setContextProperty(QStringLiteral("Preferences"), &preferences);
   engine.rootContext()->setContextProperty(QStringLiteral("Controller"), &controller);
@@ -998,6 +1018,12 @@ int main(int argc, char* argv[]) {
   }
   if (retroArchLibrary != nullptr && preferences.retroArchEnabled()) {
     QTimer::singleShot(600, retroArchLibrary, &RetroArchGameModel::refresh);
+  }
+  if (pcsx2Library != nullptr && preferences.pcsx2Enabled()) {
+    QTimer::singleShot(650, pcsx2Library, &Pcsx2GameModel::refresh);
+  }
+  if (ryujinxLibrary != nullptr && preferences.ryujinxEnabled()) {
+    QTimer::singleShot(700, ryujinxLibrary, &RyujinxGameModel::refresh);
   }
 
   if (smokeTest && !renderMode) {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -263,6 +263,14 @@ int main(int argc, char* argv[]) {
                  retroArchLibrary != nullptr && preferences.retroArchEnabled()) {
         retroArchLibrary->refresh();
         refreshStarted = true;
+      } else if (key.source.compare(QStringLiteral("PCSX2"), Qt::CaseInsensitive) == 0 &&
+                 pcsx2Library != nullptr && preferences.pcsx2Enabled()) {
+        pcsx2Library->refresh();
+        refreshStarted = true;
+      } else if (key.source.compare(QStringLiteral("Ryujinx"), Qt::CaseInsensitive) == 0 &&
+                 ryujinxLibrary != nullptr && preferences.ryujinxEnabled()) {
+        ryujinxLibrary->refresh();
+        refreshStarted = true;
       }
       if (refreshStarted) {
         PlayRequest::waitForInstallation(unifiedGames, key, 15000);

--- a/src/launch/GameLauncher.cpp
+++ b/src/launch/GameLauncher.cpp
@@ -35,7 +35,14 @@ bool validRyujinxId(const QString& id) {
     return pathKey.match(id).hasMatch();
   }
   static const QRegularExpression titleId(QStringLiteral("^[0-9A-Fa-f]{16}$"));
-  return titleId.match(id).hasMatch();
+  if (titleId.match(id).hasMatch()) {
+    return true;
+  }
+  // Resolved ROM targets arrive as plain XCI/NSP/NRO paths.
+  static const QRegularExpression romPath(
+      QStringLiteral("^[/\\p{L}0-9 ._()&'\\[\\]-]+\\.(xci|nsp|nro)$"),
+      QRegularExpression::UseUnicodePropertiesOption | QRegularExpression::CaseInsensitiveOption);
+  return romPath.match(id).hasMatch();
 }
 
 bool validHeroicTarget(const QString& id, const QString& runner) {
@@ -197,7 +204,11 @@ bool GameLauncher::launch(const QString& source, const QString& id, bool flatpak
     return launchPcsx2(id, launchTarget == QStringLiteral("elf"), flatpak, false);
   }
   if (source.compare(QStringLiteral("Ryujinx"), Qt::CaseInsensitive) == 0) {
-    return launchRyujinx(id, flatpak, false);
+    // Title-id ids must launch by the stored ROM path; path: ids carry it already.
+    const bool idIsPath = id.startsWith(QStringLiteral("path:"));
+    const QString romTarget =
+        idIsPath ? id : (launchTarget.isEmpty() ? id : launchTarget);
+    return launchRyujinx(romTarget, flatpak, false);
   }
   setError(QStringLiteral("%1 games cannot be launched yet.").arg(source));
   return false;

--- a/src/launch/GameLauncher.cpp
+++ b/src/launch/GameLauncher.cpp
@@ -121,31 +121,41 @@ LaunchCommand GameLauncher::retroArchCommand(const QString& contentPath, const Q
                                  {QStringLiteral("-L"), corePath, contentPath}};
 }
 
-LaunchCommand GameLauncher::pcsx2Command(const QString& id, bool flatpak) {
+LaunchCommand GameLauncher::pcsx2Command(const QString& id, bool isElf, bool flatpak) {
   if (!validPcsx2Id(id)) {
     return {};
   }
-  // PCSX2 boots a disc image by passing its path directly; --elf is only for ELF files.
-  // Serial-based ids must resolve to the game's disc path (installPath) before launch.
+  // PCSX2 boots a disc image by passing its path directly; ELF entries need -elf <file>.
   if (!id.startsWith(QStringLiteral("path:"))) {
     return {};
   }
   const QString target = id.mid(5);
-  return flatpak ? LaunchCommand{QStringLiteral("flatpak"),
-                                 {QStringLiteral("run"), QStringLiteral("net.pcsx2.PCSX2"),
-                                  QStringLiteral("--"), target}}
-                 : LaunchCommand{QStringLiteral("pcsx2-qt"), {target}};
+  QStringList arguments;
+  if (isElf) {
+    arguments << QStringLiteral("-elf") << target;
+  } else {
+    arguments << target;
+  }
+  if (flatpak) {
+    QStringList flatpakArguments{QStringLiteral("run"), QStringLiteral("net.pcsx2.PCSX2"),
+                                 QStringLiteral("--")};
+    flatpakArguments = flatpakArguments + arguments;
+    return LaunchCommand{QStringLiteral("flatpak"), flatpakArguments};
+  }
+  return LaunchCommand{QStringLiteral("pcsx2-qt"), arguments};
 }
 
-LaunchCommand GameLauncher::ryujinxCommand(const QString& id, bool flatpak) {
+LaunchCommand GameLauncher::ryujinxCommand(const QString& id, const QString& nativeExecutable) {
   if (!validRyujinxId(id)) {
     return {};
   }
   const QString target = id.startsWith(QStringLiteral("path:")) ? id.mid(5) : id;
-  return flatpak ? LaunchCommand{QStringLiteral("flatpak"),
-                                 {QStringLiteral("run"), QStringLiteral("io.github.ryubing.Ryujinx"),
-                                  QStringLiteral("--"), target}}
-                 : LaunchCommand{QStringLiteral("ryujinx-wrapper"), {target}};
+  if (!nativeExecutable.isEmpty()) {
+    return LaunchCommand{nativeExecutable, {target}};
+  }
+  return LaunchCommand{QStringLiteral("flatpak"),
+                       {QStringLiteral("run"), QStringLiteral("io.github.ryubing.Ryujinx"),
+                        QStringLiteral("--"), target}};
 }
 
 bool GameLauncher::launch(const QString& source, const QString& id, bool flatpak,
@@ -184,7 +194,7 @@ bool GameLauncher::launch(const QString& source, const QString& id, bool flatpak
     return launchRetroArch(installPath, launchTarget, flatpak, false);
   }
   if (source.compare(QStringLiteral("PCSX2"), Qt::CaseInsensitive) == 0) {
-    return launchPcsx2(id, flatpak, false);
+    return launchPcsx2(id, launchTarget == QStringLiteral("elf"), flatpak, false);
   }
   if (source.compare(QStringLiteral("Ryujinx"), Qt::CaseInsensitive) == 0) {
     return launchRyujinx(id, flatpak, false);
@@ -217,7 +227,7 @@ bool GameLauncher::manage(const QString& source, const QString& id, bool flatpak
     return launchRetroArch({}, {}, flatpak, true);
   }
   if (source.compare(QStringLiteral("PCSX2"), Qt::CaseInsensitive) == 0) {
-    return launchPcsx2(id, flatpak, true);
+    return launchPcsx2(id, false, flatpak, true);
   }
   if (source.compare(QStringLiteral("Ryujinx"), Qt::CaseInsensitive) == 0) {
     return launchRyujinx(id, flatpak, true);
@@ -390,7 +400,7 @@ bool GameLauncher::launchRetroArch(const QString& contentPath, const QString& co
   return true;
 }
 
-bool GameLauncher::launchPcsx2(const QString& id, bool flatpak, bool manageOnly) {
+bool GameLauncher::launchPcsx2(const QString& id, bool isElf, bool flatpak, bool manageOnly) {
   const QString executable = flatpak ? QStringLiteral("flatpak") : QStringLiteral("pcsx2-qt");
   if (QStandardPaths::findExecutable(executable).isEmpty()) {
     setError(flatpak ? QStringLiteral("Flatpak is not installed.")
@@ -410,7 +420,7 @@ bool GameLauncher::launchPcsx2(const QString& id, bool flatpak, bool manageOnly)
           ? (flatpak ? LaunchCommand{QStringLiteral("flatpak"),
                                      {QStringLiteral("run"), QStringLiteral("net.pcsx2.PCSX2")}}
                      : LaunchCommand{QStringLiteral("pcsx2-qt"), {}})
-          : pcsx2Command(id, flatpak);
+          : pcsx2Command(id, isElf, flatpak);
   if (!command.isValid()) {
     setError(QStringLiteral("This game has an invalid PCSX2 target."));
     return false;
@@ -424,11 +434,21 @@ bool GameLauncher::launchPcsx2(const QString& id, bool flatpak, bool manageOnly)
 }
 
 bool GameLauncher::launchRyujinx(const QString& id, bool flatpak, bool manageOnly) {
-  const QString executable = flatpak ? QStringLiteral("flatpak") : QStringLiteral("ryujinx-wrapper");
-  if (QStandardPaths::findExecutable(executable).isEmpty()) {
-    setError(flatpak ? QStringLiteral("Flatpak is not installed.")
-                     : QStringLiteral("Ryujinx is not installed."));
-    return false;
+  QString nativeExecutable;
+  if (!flatpak) {
+    // Native installs ship the binary under different names depending on the package.
+    for (const QString& candidate :
+         {QStringLiteral("ryujinx-wrapper"), QStringLiteral("Ryujinx"),
+          QStringLiteral("ryujinx")}) {
+      if (!QStandardPaths::findExecutable(candidate).isEmpty()) {
+        nativeExecutable = candidate;
+        break;
+      }
+    }
+    if (nativeExecutable.isEmpty()) {
+      setError(QStringLiteral("Ryujinx is not installed."));
+      return false;
+    }
   }
   if (flatpak) {
     const QString error =
@@ -443,8 +463,8 @@ bool GameLauncher::launchRyujinx(const QString& id, bool flatpak, bool manageOnl
           ? (flatpak ? LaunchCommand{QStringLiteral("flatpak"),
                                      {QStringLiteral("run"),
                                       QStringLiteral("io.github.ryubing.Ryujinx")}}
-                     : LaunchCommand{QStringLiteral("ryujinx-wrapper"), {}})
-          : ryujinxCommand(id, flatpak);
+                     : LaunchCommand{nativeExecutable, {}})
+          : ryujinxCommand(id, nativeExecutable);
   if (!command.isValid()) {
     setError(QStringLiteral("This game has an invalid Ryujinx target."));
     return false;

--- a/src/launch/GameLauncher.cpp
+++ b/src/launch/GameLauncher.cpp
@@ -17,30 +17,24 @@ bool validLutrisId(const QString& id) {
 }
 
 bool validPcsx2Id(const QString& id) {
+  // PCSX2 boots a disc image path; accept any non-empty path: key
+  // (existence is checked at launch time), like RetroArch.
   static const QRegularExpression serial(
       QStringLiteral("^[A-Za-z]{4}-[0-9A-Za-z]{5}$"));
   if (serial.match(id).hasMatch()) {
     return true;
   }
-  static const QRegularExpression pathKey(QStringLiteral("^path:[/\\p{L}0-9 ._()&'\\[\\]-]{1,500}$"),
-                                          QRegularExpression::UseUnicodePropertiesOption);
-  return pathKey.match(id).hasMatch();
+  return id.startsWith(QStringLiteral("path:")) && id.size() > 5;
 }
 
 bool validRyujinxId(const QString& id) {
-  if (id.startsWith(QStringLiteral("path:"))) {
-    static const QRegularExpression pathKey(
-        QStringLiteral("^path:[/\\p{L}0-9 ._()&'\\[\\]-]{1,500}$"),
-        QRegularExpression::UseUnicodePropertiesOption);
-    return pathKey.match(id).hasMatch();
-  }
-  static const QRegularExpression titleId(QStringLiteral("^[0-9A-Fa-f]{16}$"));
-  if (titleId.match(id).hasMatch()) {
+  // Ryujinx launches a ROM file path; title ids are display metadata only.
+  // Accept any non-empty path (existence is checked at launch time), like RetroArch.
+  if (id.startsWith(QStringLiteral("path:")) && id.size() > 5) {
     return true;
   }
-  // Resolved ROM targets arrive as plain XCI/NSP/NRO paths.
   static const QRegularExpression romPath(
-      QStringLiteral("^[/\\p{L}0-9 ._()&'\\[\\]-]+\\.(xci|nsp|nro)$"),
+      QStringLiteral("^[/\\p{L}0-9 ._()&',+#!\\[\\]-]{1,500}\\.(xci|nsp|nro)$"),
       QRegularExpression::UseUnicodePropertiesOption | QRegularExpression::CaseInsensitiveOption);
   return romPath.match(id).hasMatch();
 }

--- a/src/launch/GameLauncher.cpp
+++ b/src/launch/GameLauncher.cpp
@@ -16,6 +16,28 @@ bool validLutrisId(const QString& id) {
   return digits.match(id).hasMatch();
 }
 
+bool validPcsx2Id(const QString& id) {
+  static const QRegularExpression serial(
+      QStringLiteral("^[A-Za-z]{4}-[0-9A-Za-z]{5}$"));
+  if (serial.match(id).hasMatch()) {
+    return true;
+  }
+  static const QRegularExpression pathKey(QStringLiteral("^path:[/\\p{L}0-9 ._()&'\\[\\]-]{1,500}$"),
+                                          QRegularExpression::UseUnicodePropertiesOption);
+  return pathKey.match(id).hasMatch();
+}
+
+bool validRyujinxId(const QString& id) {
+  if (id.startsWith(QStringLiteral("path:"))) {
+    static const QRegularExpression pathKey(
+        QStringLiteral("^path:[/\\p{L}0-9 ._()&'\\[\\]-]{1,500}$"),
+        QRegularExpression::UseUnicodePropertiesOption);
+    return pathKey.match(id).hasMatch();
+  }
+  static const QRegularExpression titleId(QStringLiteral("^[0-9A-Fa-f]{16}$"));
+  return titleId.match(id).hasMatch();
+}
+
 bool validHeroicTarget(const QString& id, const QString& runner) {
   static const QRegularExpression appId(QStringLiteral("^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$"));
   return appId.match(id).hasMatch() &&
@@ -99,6 +121,33 @@ LaunchCommand GameLauncher::retroArchCommand(const QString& contentPath, const Q
                                  {QStringLiteral("-L"), corePath, contentPath}};
 }
 
+LaunchCommand GameLauncher::pcsx2Command(const QString& id, bool flatpak) {
+  if (!validPcsx2Id(id)) {
+    return {};
+  }
+  // PCSX2 boots a disc image by passing its path directly; --elf is only for ELF files.
+  // Serial-based ids must resolve to the game's disc path (installPath) before launch.
+  if (!id.startsWith(QStringLiteral("path:"))) {
+    return {};
+  }
+  const QString target = id.mid(5);
+  return flatpak ? LaunchCommand{QStringLiteral("flatpak"),
+                                 {QStringLiteral("run"), QStringLiteral("net.pcsx2.PCSX2"),
+                                  QStringLiteral("--"), target}}
+                 : LaunchCommand{QStringLiteral("pcsx2-qt"), {target}};
+}
+
+LaunchCommand GameLauncher::ryujinxCommand(const QString& id, bool flatpak) {
+  if (!validRyujinxId(id)) {
+    return {};
+  }
+  const QString target = id.startsWith(QStringLiteral("path:")) ? id.mid(5) : id;
+  return flatpak ? LaunchCommand{QStringLiteral("flatpak"),
+                                 {QStringLiteral("run"), QStringLiteral("io.github.ryubing.Ryujinx"),
+                                  QStringLiteral("--"), target}}
+                 : LaunchCommand{QStringLiteral("ryujinx-wrapper"), {target}};
+}
+
 bool GameLauncher::launch(const QString& source, const QString& id, bool flatpak,
                           const QString& runner, const QString& installPath,
                           const QString& launchTarget) {
@@ -134,6 +183,12 @@ bool GameLauncher::launch(const QString& source, const QString& id, bool flatpak
   if (source.compare(QStringLiteral("RetroArch"), Qt::CaseInsensitive) == 0) {
     return launchRetroArch(installPath, launchTarget, flatpak, false);
   }
+  if (source.compare(QStringLiteral("PCSX2"), Qt::CaseInsensitive) == 0) {
+    return launchPcsx2(id, flatpak, false);
+  }
+  if (source.compare(QStringLiteral("Ryujinx"), Qt::CaseInsensitive) == 0) {
+    return launchRyujinx(id, flatpak, false);
+  }
   setError(QStringLiteral("%1 games cannot be launched yet.").arg(source));
   return false;
 }
@@ -160,6 +215,12 @@ bool GameLauncher::manage(const QString& source, const QString& id, bool flatpak
   }
   if (source.compare(QStringLiteral("RetroArch"), Qt::CaseInsensitive) == 0) {
     return launchRetroArch({}, {}, flatpak, true);
+  }
+  if (source.compare(QStringLiteral("PCSX2"), Qt::CaseInsensitive) == 0) {
+    return launchPcsx2(id, flatpak, true);
+  }
+  if (source.compare(QStringLiteral("Ryujinx"), Qt::CaseInsensitive) == 0) {
+    return launchRyujinx(id, flatpak, true);
   }
   setError(QStringLiteral("%1 does not provide game management yet.").arg(source));
   return false;
@@ -323,6 +384,73 @@ bool GameLauncher::launchRetroArch(const QString& contentPath, const QString& co
   }
   if (!QProcess::startDetached(command.program, command.arguments)) {
     setError(QStringLiteral("RetroArch could not be started. Open RetroArch and try again."));
+    return false;
+  }
+  setError({});
+  return true;
+}
+
+bool GameLauncher::launchPcsx2(const QString& id, bool flatpak, bool manageOnly) {
+  const QString executable = flatpak ? QStringLiteral("flatpak") : QStringLiteral("pcsx2-qt");
+  if (QStandardPaths::findExecutable(executable).isEmpty()) {
+    setError(flatpak ? QStringLiteral("Flatpak is not installed.")
+                     : QStringLiteral("PCSX2 is not installed."));
+    return false;
+  }
+  if (flatpak) {
+    const QString error =
+        flatpakError(QStringLiteral("net.pcsx2.PCSX2"), QStringLiteral("PCSX2"));
+    if (!error.isEmpty()) {
+      setError(error);
+      return false;
+    }
+  }
+  const LaunchCommand command =
+      manageOnly
+          ? (flatpak ? LaunchCommand{QStringLiteral("flatpak"),
+                                     {QStringLiteral("run"), QStringLiteral("net.pcsx2.PCSX2")}}
+                     : LaunchCommand{QStringLiteral("pcsx2-qt"), {}})
+          : pcsx2Command(id, flatpak);
+  if (!command.isValid()) {
+    setError(QStringLiteral("This game has an invalid PCSX2 target."));
+    return false;
+  }
+  if (!QProcess::startDetached(command.program, command.arguments)) {
+    setError(QStringLiteral("PCSX2 could not be started. Open PCSX2 and try again."));
+    return false;
+  }
+  setError({});
+  return true;
+}
+
+bool GameLauncher::launchRyujinx(const QString& id, bool flatpak, bool manageOnly) {
+  const QString executable = flatpak ? QStringLiteral("flatpak") : QStringLiteral("ryujinx-wrapper");
+  if (QStandardPaths::findExecutable(executable).isEmpty()) {
+    setError(flatpak ? QStringLiteral("Flatpak is not installed.")
+                     : QStringLiteral("Ryujinx is not installed."));
+    return false;
+  }
+  if (flatpak) {
+    const QString error =
+        flatpakError(QStringLiteral("io.github.ryubing.Ryujinx"), QStringLiteral("Ryujinx"));
+    if (!error.isEmpty()) {
+      setError(error);
+      return false;
+    }
+  }
+  const LaunchCommand command =
+      manageOnly
+          ? (flatpak ? LaunchCommand{QStringLiteral("flatpak"),
+                                     {QStringLiteral("run"),
+                                      QStringLiteral("io.github.ryubing.Ryujinx")}}
+                     : LaunchCommand{QStringLiteral("ryujinx-wrapper"), {}})
+          : ryujinxCommand(id, flatpak);
+  if (!command.isValid()) {
+    setError(QStringLiteral("This game has an invalid Ryujinx target."));
+    return false;
+  }
+  if (!QProcess::startDetached(command.program, command.arguments)) {
+    setError(QStringLiteral("Ryujinx could not be started. Open Ryujinx and try again."));
     return false;
   }
   setError({});

--- a/src/launch/GameLauncher.h
+++ b/src/launch/GameLauncher.h
@@ -23,8 +23,9 @@ public:
   [[nodiscard]] static LaunchCommand faugusCommand(const QString& id, bool flatpak);
   [[nodiscard]] static LaunchCommand retroArchCommand(const QString& contentPath,
                                                       const QString& corePath, bool flatpak);
-  [[nodiscard]] static LaunchCommand pcsx2Command(const QString& id, bool flatpak);
-  [[nodiscard]] static LaunchCommand ryujinxCommand(const QString& id, bool flatpak);
+  [[nodiscard]] static LaunchCommand pcsx2Command(const QString& id, bool isElf, bool flatpak);
+  [[nodiscard]] static LaunchCommand ryujinxCommand(const QString& id,
+                                                    const QString& nativeExecutable);
   Q_INVOKABLE bool launch(const QString& source, const QString& id, bool flatpak = false,
                           const QString& runner = {}, const QString& installPath = {},
                           const QString& launchTarget = {});
@@ -41,7 +42,7 @@ private:
   bool launchFaugus(const QString& id, bool flatpak, bool manageOnly);
   bool launchRetroArch(const QString& contentPath, const QString& corePath, bool flatpak,
                        bool manageOnly);
-  bool launchPcsx2(const QString& id, bool flatpak, bool manageOnly);
+  bool launchPcsx2(const QString& id, bool isElf, bool flatpak, bool manageOnly);
   bool launchRyujinx(const QString& id, bool flatpak, bool manageOnly);
   [[nodiscard]] QString flatpakError(const QString& appId, const QString& launcherName) const;
   void setError(const QString& error);

--- a/src/launch/GameLauncher.h
+++ b/src/launch/GameLauncher.h
@@ -23,6 +23,8 @@ public:
   [[nodiscard]] static LaunchCommand faugusCommand(const QString& id, bool flatpak);
   [[nodiscard]] static LaunchCommand retroArchCommand(const QString& contentPath,
                                                       const QString& corePath, bool flatpak);
+  [[nodiscard]] static LaunchCommand pcsx2Command(const QString& id, bool flatpak);
+  [[nodiscard]] static LaunchCommand ryujinxCommand(const QString& id, bool flatpak);
   Q_INVOKABLE bool launch(const QString& source, const QString& id, bool flatpak = false,
                           const QString& runner = {}, const QString& installPath = {},
                           const QString& launchTarget = {});
@@ -39,6 +41,8 @@ private:
   bool launchFaugus(const QString& id, bool flatpak, bool manageOnly);
   bool launchRetroArch(const QString& contentPath, const QString& corePath, bool flatpak,
                        bool manageOnly);
+  bool launchPcsx2(const QString& id, bool flatpak, bool manageOnly);
+  bool launchRyujinx(const QString& id, bool flatpak, bool manageOnly);
   [[nodiscard]] QString flatpakError(const QString& appId, const QString& launcherName) const;
   void setError(const QString& error);
   QString m_lastError;

--- a/src/library/Pcsx2GameModel.cpp
+++ b/src/library/Pcsx2GameModel.cpp
@@ -1,0 +1,331 @@
+#include "library/Pcsx2GameModel.h"
+
+#include "library/GameRoles.h"
+
+#include <QCryptographicHash>
+#include <QDateTime>
+#include <QDir>
+#include <QFileInfo>
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QUrl>
+#include <QtConcurrent>
+
+namespace {
+QColor colorFor(const QString& id, int offset) {
+  const QByteArray hash = QCryptographicHash::hash(id.toUtf8(), QCryptographicHash::Sha256);
+  return QColor::fromHsl((static_cast<unsigned char>(hash.at(offset)) * 359) / 255, 115,
+                         offset == 0 ? 105 : 72);
+}
+
+QString localUrl(const QString& path) {
+  return path.isEmpty() ? QString{} : QUrl::fromLocalFile(path).toString();
+}
+} // namespace
+
+Pcsx2GameModel::Pcsx2GameModel(const QString& omakadeDatabasePath, QObject* parent)
+    : QAbstractListModel(parent),
+      m_connectionName(QStringLiteral("omakade-pcsx2-%1").arg(reinterpret_cast<quintptr>(this))) {
+  connect(&m_scanWatcher, &QFutureWatcher<Pcsx2ScanResult>::finished, this,
+          [this] { applyScan(m_scanWatcher.result()); });
+  if (openDatabase(omakadeDatabasePath) && ensureSchema()) {
+    loadDatabase();
+    loadSourceState();
+  }
+}
+
+Pcsx2GameModel::~Pcsx2GameModel() {
+  if (m_scanWatcher.isRunning()) {
+    m_scanWatcher.waitForFinished();
+  }
+  m_database.close();
+  m_database = {};
+  QSqlDatabase::removeDatabase(m_connectionName);
+}
+
+int Pcsx2GameModel::rowCount(const QModelIndex& parent) const {
+  return parent.isValid() ? 0 : static_cast<int>(m_games.size());
+}
+
+QVariant Pcsx2GameModel::data(const QModelIndex& index, int role) const {
+  if (!index.isValid() || index.row() < 0 || index.row() >= m_games.size()) {
+    return {};
+  }
+  return valueForRole(m_games.at(index.row()), role);
+}
+
+QHash<int, QByteArray> Pcsx2GameModel::roleNames() const {
+  return {{GameRoles::Title, "title"},
+          {GameRoles::Subtitle, "subtitle"},
+          {GameRoles::Description, "description"},
+          {GameRoles::Hours, "hours"},
+          {GameRoles::Progress, "progress"},
+          {GameRoles::AchievementsUnlocked, "achievementsUnlocked"},
+          {GameRoles::AchievementsTotal, "achievementsTotal"},
+          {GameRoles::Favorite, "favorite"},
+          {GameRoles::Recent, "recent"},
+          {GameRoles::LastPlayed, "lastPlayed"},
+          {GameRoles::AccentStart, "accentStart"},
+          {GameRoles::AccentEnd, "accentEnd"},
+          {GameRoles::CoverMark, "coverMark"},
+          {GameRoles::Year, "year"},
+          {GameRoles::AppId, "appId"},
+          {GameRoles::CoverPath, "coverPath"},
+          {GameRoles::HeroPath, "heroPath"},
+          {GameRoles::LogoPath, "logoPath"},
+          {GameRoles::InstallPath, "installPath"},
+          {GameRoles::Source, "source"},
+          {GameRoles::Runner, "runner"},
+          {GameRoles::Flatpak, "flatpak"},
+          {GameRoles::Hidden, "hidden"}};
+}
+
+bool Pcsx2GameModel::pcsx2Detected() const { return m_pcsx2Detected; }
+QString Pcsx2GameModel::statusText() const { return m_statusText; }
+QString Pcsx2GameModel::errorText() const { return m_errorText; }
+QStringList Pcsx2GameModel::detectedPaths() const { return m_detectedPaths; }
+qint64 Pcsx2GameModel::lastScan() const { return m_lastScan; }
+
+void Pcsx2GameModel::toggleFavorite(int row) {
+  if (row < 0 || row >= m_games.size() || !m_database.isOpen()) {
+    return;
+  }
+  Game& game = m_games[row];
+  game.favorite = !game.favorite;
+  QSqlQuery query(m_database);
+  query.prepare(QStringLiteral("UPDATE pcsx2_games SET favorite = ? WHERE game_id = ?"));
+  query.addBindValue(game.favorite);
+  query.addBindValue(game.pcsx2.gameId);
+  if (!query.exec()) {
+    game.favorite = !game.favorite;
+    setStatus(m_statusText, query.lastError().text());
+    return;
+  }
+  emit dataChanged(index(row), index(row), {GameRoles::Favorite});
+}
+
+void Pcsx2GameModel::toggleHidden(int row) {
+  if (row < 0 || row >= m_games.size() || !m_database.isOpen()) {
+    return;
+  }
+  Game& game = m_games[row];
+  game.hidden = !game.hidden;
+  QSqlQuery query(m_database);
+  query.prepare(QStringLiteral("UPDATE pcsx2_games SET hidden = ? WHERE game_id = ?"));
+  query.addBindValue(game.hidden);
+  query.addBindValue(game.pcsx2.gameId);
+  if (!query.exec()) {
+    game.hidden = !game.hidden;
+    setStatus(m_statusText, query.lastError().text());
+    return;
+  }
+  emit dataChanged(index(row), index(row), {GameRoles::Hidden});
+}
+
+void Pcsx2GameModel::refresh() {
+  if (m_scanWatcher.isRunning()) {
+    return;
+  }
+  const QStringList roots = Pcsx2Scanner::discoverRoots();
+  setStatus(QStringLiteral("Scanning PCSX2 library"));
+  m_scanWatcher.setFuture(QtConcurrent::run([roots] { return Pcsx2Scanner::scan(roots); }));
+}
+
+void Pcsx2GameModel::refreshFromRoots(const QStringList& roots) {
+  applyScan(Pcsx2Scanner::scan(roots));
+}
+
+bool Pcsx2GameModel::openDatabase(const QString& path) {
+  if (path != QStringLiteral(":memory:")) {
+    QDir().mkpath(QFileInfo(path).absolutePath());
+  }
+  m_database = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), m_connectionName);
+  m_database.setDatabaseName(path);
+  if (!m_database.open()) {
+    setStatus(QStringLiteral("PCSX2 cache unavailable"), m_database.lastError().text());
+    return false;
+  }
+  return true;
+}
+
+bool Pcsx2GameModel::ensureSchema() {
+  QSqlQuery query(m_database);
+  if (!query.exec(QStringLiteral(
+          "CREATE TABLE IF NOT EXISTS pcsx2_games (game_id TEXT PRIMARY KEY, name TEXT NOT NULL, "
+          "path TEXT NOT NULL, serial TEXT, region TEXT, cover_path TEXT, last_played INTEGER NOT "
+          "NULL DEFAULT 0, playtime_seconds INTEGER NOT NULL DEFAULT 0, flatpak INTEGER NOT NULL "
+          "DEFAULT 0, favorite INTEGER NOT NULL DEFAULT 0, hidden INTEGER NOT NULL DEFAULT 0, "
+          "observed_at INTEGER NOT NULL)"))) {
+    return false;
+  }
+  if (!query.exec(QStringLiteral(
+          "CREATE TABLE IF NOT EXISTS source_state (source TEXT PRIMARY KEY, last_scan INTEGER, "
+          "last_error TEXT, paths TEXT NOT NULL DEFAULT '')"))) {
+    return false;
+  }
+  bool hasPaths = false;
+  if (query.exec(QStringLiteral("PRAGMA table_info(source_state)"))) {
+    while (query.next()) {
+      hasPaths = hasPaths || query.value(1).toString() == QStringLiteral("paths");
+    }
+  }
+  return hasPaths || query.exec(QStringLiteral(
+                         "ALTER TABLE source_state ADD COLUMN paths TEXT NOT NULL DEFAULT ''"));
+}
+
+void Pcsx2GameModel::loadDatabase() {
+  QVector<Game> loaded;
+  QSqlQuery query(m_database);
+  if (!query.exec(QStringLiteral(
+          "SELECT game_id, name, path, serial, region, cover_path, last_played, playtime_seconds, "
+          "flatpak, favorite, hidden FROM pcsx2_games WHERE observed_at > 0 ORDER BY name COLLATE "
+          "NOCASE"))) {
+    setStatus(QStringLiteral("Could not load cached PCSX2 games"), query.lastError().text());
+    return;
+  }
+  while (query.next()) {
+    Pcsx2GameRecord record{.gameId = query.value(0).toString(),
+                           .title = query.value(1).toString(),
+                           .path = query.value(2).toString(),
+                           .serial = query.value(3).toString(),
+                           .coverPath = query.value(5).toString(),
+                           .region = query.value(4).toString(),
+                           .playtimeSeconds = query.value(7).toLongLong(),
+                           .lastPlayed = query.value(6).toLongLong(),
+                           .flatpak = query.value(8).toBool()};
+    loaded.append({.pcsx2 = record,
+                   .favorite = query.value(9).toBool(),
+                   .hidden = query.value(10).toBool(),
+                   .accentStart = colorFor(record.gameId, 0),
+                   .accentEnd = colorFor(record.gameId, 1)});
+  }
+  beginResetModel();
+  m_games = loaded;
+  endResetModel();
+}
+
+void Pcsx2GameModel::loadSourceState() {
+  QSqlQuery query(m_database);
+  query.prepare(
+      QStringLiteral("SELECT last_scan, last_error, paths FROM source_state WHERE source = 'pcsx2'"));
+  if (!query.exec() || !query.next()) {
+    return;
+  }
+  m_lastScan = query.value(0).toLongLong();
+  m_errorText = query.value(1).toString();
+  m_detectedPaths = query.value(2).toString().split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+  m_pcsx2Detected = !m_detectedPaths.isEmpty();
+  if (m_lastScan > 0) {
+    m_statusText = QStringLiteral("Loaded cached PCSX2 games");
+  }
+}
+
+void Pcsx2GameModel::applyScan(const Pcsx2ScanResult& result) {
+  m_pcsx2Detected = !result.roots.isEmpty();
+  if (result.incomplete || (result.roots.isEmpty() && !m_games.isEmpty())) {
+    setStatus(QStringLiteral("PCSX2 scan interrupted; kept the cached library"),
+              result.warnings.join(QLatin1Char('\n')));
+    return;
+  }
+  if (!m_database.transaction()) {
+    setStatus(QStringLiteral("Could not update PCSX2 games"), m_database.lastError().text());
+    return;
+  }
+  QSqlQuery query(m_database);
+  bool okay = query.exec(QStringLiteral("UPDATE pcsx2_games SET observed_at = 0"));
+  for (const Pcsx2GameRecord& game : result.games) {
+    query.prepare(QStringLiteral(
+        "INSERT INTO pcsx2_games(game_id, name, path, serial, region, cover_path, last_played, "
+        "playtime_seconds, flatpak, observed_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s', "
+        "'now')) ON CONFLICT(game_id) DO UPDATE SET name = excluded.name, path = excluded.path, "
+        "serial = excluded.serial, region = excluded.region, cover_path = excluded.cover_path, "
+        "last_played = excluded.last_played, playtime_seconds = excluded.playtime_seconds, "
+        "flatpak = excluded.flatpak, observed_at = excluded.observed_at"));
+    query.addBindValue(game.gameId);
+    query.addBindValue(game.title);
+    query.addBindValue(game.path);
+    query.addBindValue(game.serial);
+    query.addBindValue(game.region);
+    query.addBindValue(game.coverPath);
+    query.addBindValue(game.lastPlayed);
+    query.addBindValue(game.playtimeSeconds);
+    query.addBindValue(game.flatpak);
+    okay = okay && query.exec();
+  }
+  query.prepare(QStringLiteral(
+      "INSERT INTO source_state(source, last_scan, last_error, paths) VALUES('pcsx2', "
+      "strftime('%s', 'now'), ?, ?) ON CONFLICT(source) DO UPDATE SET last_scan = "
+      "excluded.last_scan, last_error = excluded.last_error, paths = excluded.paths"));
+  query.addBindValue(result.warnings.join(QLatin1Char('\n')));
+  query.addBindValue(result.roots.isEmpty() ? QStringLiteral("") : result.roots.join(QLatin1Char('\n')));
+  okay = okay && query.exec();
+  if (!okay || !m_database.commit()) {
+    m_database.rollback();
+    setStatus(QStringLiteral("Could not update PCSX2 games"), query.lastError().text());
+    return;
+  }
+  loadDatabase();
+  m_detectedPaths = result.roots;
+  m_lastScan = QDateTime::currentSecsSinceEpoch();
+  setStatus(m_pcsx2Detected ? QStringLiteral("Imported %1 PCSX2 game(s)").arg(result.games.size())
+                            : QStringLiteral("PCSX2 was not found"),
+            result.warnings.join(QLatin1Char('\n')));
+}
+
+QVariant Pcsx2GameModel::valueForRole(const Game& game, int role) const {
+  switch (role) {
+  case GameRoles::Title:
+    return game.pcsx2.title;
+  case GameRoles::Subtitle:
+    return game.pcsx2.region.isEmpty() ? QStringLiteral("PCSX2")
+                                       : QStringLiteral("PCSX2 · %1").arg(game.pcsx2.region);
+  case GameRoles::Description:
+    return QStringLiteral("PlayStation 2 game launched through PCSX2.");
+  case GameRoles::Hours:
+    return static_cast<int>(game.pcsx2.playtimeSeconds / 3600);
+  case GameRoles::Progress:
+  case GameRoles::AchievementsUnlocked:
+  case GameRoles::AchievementsTotal:
+    return 0;
+  case GameRoles::Favorite:
+    return game.favorite;
+  case GameRoles::Recent:
+    return game.pcsx2.lastPlayed > 0;
+  case GameRoles::LastPlayed:
+    return game.pcsx2.lastPlayed;
+  case GameRoles::AccentStart:
+    return game.accentStart;
+  case GameRoles::AccentEnd:
+    return game.accentEnd;
+  case GameRoles::CoverMark:
+    return game.pcsx2.title.left(1).toUpper();
+  case GameRoles::Year:
+    return 0;
+  case GameRoles::AppId:
+    // Launch key: PCSX2 boots by disc path; serial stays in Runner for display.
+    return QStringLiteral("path:%1").arg(game.pcsx2.path);
+  case GameRoles::CoverPath:
+    return localUrl(game.pcsx2.coverPath);
+  case GameRoles::HeroPath:
+  case GameRoles::LogoPath:
+    return QString{};
+  case GameRoles::InstallPath:
+    return game.pcsx2.path;
+  case GameRoles::Source:
+    return QStringLiteral("PCSX2");
+  case GameRoles::Runner:
+    return game.pcsx2.serial;
+  case GameRoles::Flatpak:
+    return game.pcsx2.flatpak;
+  case GameRoles::Hidden:
+    return game.hidden;
+  default:
+    return {};
+  }
+}
+
+void Pcsx2GameModel::setStatus(const QString& status, const QString& error) {
+  m_statusText = status;
+  m_errorText = error;
+  emit statusChanged();
+}

--- a/src/library/Pcsx2GameModel.cpp
+++ b/src/library/Pcsx2GameModel.cpp
@@ -27,7 +27,11 @@ Pcsx2GameModel::Pcsx2GameModel(const QString& omakadeDatabasePath, QObject* pare
     : QAbstractListModel(parent),
       m_connectionName(QStringLiteral("omakade-pcsx2-%1").arg(reinterpret_cast<quintptr>(this))) {
   connect(&m_scanWatcher, &QFutureWatcher<Pcsx2ScanResult>::finished, this,
-          [this] { applyScan(m_scanWatcher.result()); });
+          [this] {
+            m_scanning = false;
+            applyScan(m_scanWatcher.result());
+            emit statusChanged();
+          });
   if (openDatabase(omakadeDatabasePath) && ensureSchema()) {
     loadDatabase();
     loadSourceState();
@@ -127,6 +131,7 @@ void Pcsx2GameModel::refresh() {
   if (m_scanWatcher.isRunning()) {
     return;
   }
+  m_scanning = true;
   const QStringList roots = Pcsx2Scanner::discoverRoots();
   setStatus(QStringLiteral("Scanning PCSX2 library"));
   m_scanWatcher.setFuture(QtConcurrent::run([roots] { return Pcsx2Scanner::scan(roots); }));

--- a/src/library/Pcsx2GameModel.cpp
+++ b/src/library/Pcsx2GameModel.cpp
@@ -77,7 +77,8 @@ QHash<int, QByteArray> Pcsx2GameModel::roleNames() const {
           {GameRoles::Source, "source"},
           {GameRoles::Runner, "runner"},
           {GameRoles::Flatpak, "flatpak"},
-          {GameRoles::Hidden, "hidden"}};
+          {GameRoles::Hidden, "hidden"},
+          {GameRoles::LaunchTarget, "launchTarget"}};
 }
 
 bool Pcsx2GameModel::pcsx2Detected() const { return m_pcsx2Detected; }
@@ -153,14 +154,30 @@ bool Pcsx2GameModel::ensureSchema() {
   if (!query.exec(QStringLiteral(
           "CREATE TABLE IF NOT EXISTS pcsx2_games (game_id TEXT PRIMARY KEY, name TEXT NOT NULL, "
           "path TEXT NOT NULL, serial TEXT, region TEXT, cover_path TEXT, last_played INTEGER NOT "
-          "NULL DEFAULT 0, playtime_seconds INTEGER NOT NULL DEFAULT 0, flatpak INTEGER NOT NULL "
-          "DEFAULT 0, favorite INTEGER NOT NULL DEFAULT 0, hidden INTEGER NOT NULL DEFAULT 0, "
-          "observed_at INTEGER NOT NULL)"))) {
+          "NULL DEFAULT 0, playtime_seconds INTEGER NOT NULL DEFAULT 0, is_elf INTEGER NOT NULL "
+          "DEFAULT 0, flatpak INTEGER NOT NULL DEFAULT 0, favorite INTEGER NOT NULL DEFAULT 0, "
+          "hidden INTEGER NOT NULL DEFAULT 0, observed_at INTEGER NOT NULL)"))) {
+    setStatus(QStringLiteral("Could not initialize PCSX2 cache"), query.lastError().text());
     return false;
+  }
+  {
+    QSqlQuery columns(m_database);
+    bool hasIsElf = false;
+    if (columns.exec(QStringLiteral("PRAGMA table_info(pcsx2_games)"))) {
+      while (columns.next()) {
+        hasIsElf = hasIsElf || columns.value(1).toString() == QStringLiteral("is_elf");
+      }
+    }
+    if (!hasIsElf && !query.exec(QStringLiteral(
+                         "ALTER TABLE pcsx2_games ADD COLUMN is_elf INTEGER NOT NULL DEFAULT 0"))) {
+      setStatus(QStringLiteral("Could not migrate PCSX2 cache"), query.lastError().text());
+      return false;
+    }
   }
   if (!query.exec(QStringLiteral(
           "CREATE TABLE IF NOT EXISTS source_state (source TEXT PRIMARY KEY, last_scan INTEGER, "
           "last_error TEXT, paths TEXT NOT NULL DEFAULT '')"))) {
+    setStatus(QStringLiteral("Could not initialize PCSX2 cache"), query.lastError().text());
     return false;
   }
   bool hasPaths = false;
@@ -169,8 +186,15 @@ bool Pcsx2GameModel::ensureSchema() {
       hasPaths = hasPaths || query.value(1).toString() == QStringLiteral("paths");
     }
   }
-  return hasPaths || query.exec(QStringLiteral(
-                         "ALTER TABLE source_state ADD COLUMN paths TEXT NOT NULL DEFAULT ''"));
+  if (hasPaths) {
+    return true;
+  }
+  if (!query.exec(QStringLiteral(
+          "ALTER TABLE source_state ADD COLUMN paths TEXT NOT NULL DEFAULT ''"))) {
+    setStatus(QStringLiteral("Could not migrate PCSX2 cache"), query.lastError().text());
+    return false;
+  }
+  return true;
 }
 
 void Pcsx2GameModel::loadDatabase() {
@@ -178,8 +202,8 @@ void Pcsx2GameModel::loadDatabase() {
   QSqlQuery query(m_database);
   if (!query.exec(QStringLiteral(
           "SELECT game_id, name, path, serial, region, cover_path, last_played, playtime_seconds, "
-          "flatpak, favorite, hidden FROM pcsx2_games WHERE observed_at > 0 ORDER BY name COLLATE "
-          "NOCASE"))) {
+          "is_elf, flatpak, favorite, hidden FROM pcsx2_games WHERE observed_at > 0 ORDER BY name "
+          "COLLATE NOCASE"))) {
     setStatus(QStringLiteral("Could not load cached PCSX2 games"), query.lastError().text());
     return;
   }
@@ -192,10 +216,11 @@ void Pcsx2GameModel::loadDatabase() {
                            .region = query.value(4).toString(),
                            .playtimeSeconds = query.value(7).toLongLong(),
                            .lastPlayed = query.value(6).toLongLong(),
-                           .flatpak = query.value(8).toBool()};
+                           .isElf = query.value(8).toBool(),
+                           .flatpak = query.value(9).toBool()};
     loaded.append({.pcsx2 = record,
-                   .favorite = query.value(9).toBool(),
-                   .hidden = query.value(10).toBool(),
+                   .favorite = query.value(10).toBool(),
+                   .hidden = query.value(11).toBool(),
                    .accentStart = colorFor(record.gameId, 0),
                    .accentEnd = colorFor(record.gameId, 1)});
   }
@@ -236,11 +261,12 @@ void Pcsx2GameModel::applyScan(const Pcsx2ScanResult& result) {
   for (const Pcsx2GameRecord& game : result.games) {
     query.prepare(QStringLiteral(
         "INSERT INTO pcsx2_games(game_id, name, path, serial, region, cover_path, last_played, "
-        "playtime_seconds, flatpak, observed_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s', "
-        "'now')) ON CONFLICT(game_id) DO UPDATE SET name = excluded.name, path = excluded.path, "
-        "serial = excluded.serial, region = excluded.region, cover_path = excluded.cover_path, "
-        "last_played = excluded.last_played, playtime_seconds = excluded.playtime_seconds, "
-        "flatpak = excluded.flatpak, observed_at = excluded.observed_at"));
+        "playtime_seconds, is_elf, flatpak, observed_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+        "strftime('%s', 'now')) ON CONFLICT(game_id) DO UPDATE SET name = excluded.name, path = "
+        "excluded.path, serial = excluded.serial, region = excluded.region, cover_path = "
+        "excluded.cover_path, last_played = excluded.last_played, playtime_seconds = "
+        "excluded.playtime_seconds, is_elf = excluded.is_elf, flatpak = excluded.flatpak, "
+        "observed_at = excluded.observed_at"));
     query.addBindValue(game.gameId);
     query.addBindValue(game.title);
     query.addBindValue(game.path);
@@ -249,6 +275,7 @@ void Pcsx2GameModel::applyScan(const Pcsx2ScanResult& result) {
     query.addBindValue(game.coverPath);
     query.addBindValue(game.lastPlayed);
     query.addBindValue(game.playtimeSeconds);
+    query.addBindValue(game.isElf);
     query.addBindValue(game.flatpak);
     okay = okay && query.exec();
   }
@@ -315,6 +342,8 @@ QVariant Pcsx2GameModel::valueForRole(const Game& game, int role) const {
     return QStringLiteral("PCSX2");
   case GameRoles::Runner:
     return game.pcsx2.serial;
+  case GameRoles::LaunchTarget:
+    return game.pcsx2.isElf ? QStringLiteral("elf") : QStringLiteral("disc");
   case GameRoles::Flatpak:
     return game.pcsx2.flatpak;
   case GameRoles::Hidden:

--- a/src/library/Pcsx2GameModel.h
+++ b/src/library/Pcsx2GameModel.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "sources/pcsx2/Pcsx2Scanner.h"
+
+#include <QAbstractListModel>
+#include <QColor>
+#include <QFutureWatcher>
+#include <QSqlDatabase>
+
+class Pcsx2GameModel final : public QAbstractListModel {
+  Q_OBJECT
+  Q_PROPERTY(bool pcsx2Detected READ pcsx2Detected NOTIFY statusChanged)
+  Q_PROPERTY(QString statusText READ statusText NOTIFY statusChanged)
+  Q_PROPERTY(QString errorText READ errorText NOTIFY statusChanged)
+  Q_PROPERTY(QStringList detectedPaths READ detectedPaths NOTIFY statusChanged)
+  Q_PROPERTY(qint64 lastScan READ lastScan NOTIFY statusChanged)
+
+public:
+  explicit Pcsx2GameModel(const QString& omakadeDatabasePath, QObject* parent = nullptr);
+  ~Pcsx2GameModel() override;
+
+  [[nodiscard]] int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+  [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
+  [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
+  [[nodiscard]] bool pcsx2Detected() const;
+  [[nodiscard]] QString statusText() const;
+  [[nodiscard]] QString errorText() const;
+  [[nodiscard]] QStringList detectedPaths() const;
+  [[nodiscard]] qint64 lastScan() const;
+
+  Q_INVOKABLE void toggleFavorite(int row);
+  Q_INVOKABLE void toggleHidden(int row);
+  Q_INVOKABLE void refresh();
+  void refreshFromRoots(const QStringList& roots);
+
+signals:
+  void statusChanged();
+
+private:
+  struct Game {
+    Pcsx2GameRecord pcsx2;
+    bool favorite = false;
+    bool hidden = false;
+    QColor accentStart;
+    QColor accentEnd;
+  };
+
+  bool openDatabase(const QString& path);
+  bool ensureSchema();
+  void loadDatabase();
+  void loadSourceState();
+  void applyScan(const Pcsx2ScanResult& result);
+  [[nodiscard]] QVariant valueForRole(const Game& game, int role) const;
+  void setStatus(const QString& status, const QString& error = {});
+
+  QVector<Game> m_games;
+  QSqlDatabase m_database;
+  QString m_connectionName;
+  QFutureWatcher<Pcsx2ScanResult> m_scanWatcher;
+  bool m_pcsx2Detected = false;
+  QString m_statusText;
+  QString m_errorText;
+  QStringList m_detectedPaths;
+  qint64 m_lastScan = 0;
+};

--- a/src/library/Pcsx2GameModel.h
+++ b/src/library/Pcsx2GameModel.h
@@ -10,6 +10,7 @@
 class Pcsx2GameModel final : public QAbstractListModel {
   Q_OBJECT
   Q_PROPERTY(bool pcsx2Detected READ pcsx2Detected NOTIFY statusChanged)
+  Q_PROPERTY(bool scanning READ scanning NOTIFY statusChanged)
   Q_PROPERTY(QString statusText READ statusText NOTIFY statusChanged)
   Q_PROPERTY(QString errorText READ errorText NOTIFY statusChanged)
   Q_PROPERTY(QStringList detectedPaths READ detectedPaths NOTIFY statusChanged)
@@ -23,6 +24,7 @@ public:
   [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
   [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
   [[nodiscard]] bool pcsx2Detected() const;
+  [[nodiscard]] bool scanning() const { return m_scanning; }
   [[nodiscard]] QString statusText() const;
   [[nodiscard]] QString errorText() const;
   [[nodiscard]] QStringList detectedPaths() const;
@@ -57,6 +59,7 @@ private:
   QSqlDatabase m_database;
   QString m_connectionName;
   QFutureWatcher<Pcsx2ScanResult> m_scanWatcher;
+  bool m_scanning = false;
   bool m_pcsx2Detected = false;
   QString m_statusText;
   QString m_errorText;

--- a/src/library/RyujinxGameModel.cpp
+++ b/src/library/RyujinxGameModel.cpp
@@ -1,0 +1,326 @@
+#include "library/RyujinxGameModel.h"
+
+#include "library/GameRoles.h"
+
+#include <QCryptographicHash>
+#include <QDateTime>
+#include <QDir>
+#include <QFileInfo>
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QUrl>
+#include <QtConcurrent>
+
+namespace {
+QColor colorFor(const QString& id, int offset) {
+  const QByteArray hash = QCryptographicHash::hash(id.toUtf8(), QCryptographicHash::Sha256);
+  return QColor::fromHsl((static_cast<unsigned char>(hash.at(offset)) * 359) / 255, 115,
+                         offset == 0 ? 105 : 72);
+}
+
+QString localUrl(const QString& path) {
+  return path.isEmpty() ? QString{} : QUrl::fromLocalFile(path).toString();
+}
+} // namespace
+
+RyujinxGameModel::RyujinxGameModel(const QString& omakadeDatabasePath, QObject* parent)
+    : QAbstractListModel(parent),
+      m_connectionName(QStringLiteral("omakade-ryujinx-%1").arg(reinterpret_cast<quintptr>(this))) {
+  connect(&m_scanWatcher, &QFutureWatcher<RyujinxScanResult>::finished, this,
+          [this] { applyScan(m_scanWatcher.result()); });
+  if (openDatabase(omakadeDatabasePath) && ensureSchema()) {
+    loadDatabase();
+    loadSourceState();
+  }
+}
+
+RyujinxGameModel::~RyujinxGameModel() {
+  if (m_scanWatcher.isRunning()) {
+    m_scanWatcher.waitForFinished();
+  }
+  m_database.close();
+  m_database = {};
+  QSqlDatabase::removeDatabase(m_connectionName);
+}
+
+int RyujinxGameModel::rowCount(const QModelIndex& parent) const {
+  return parent.isValid() ? 0 : static_cast<int>(m_games.size());
+}
+
+QVariant RyujinxGameModel::data(const QModelIndex& index, int role) const {
+  if (!index.isValid() || index.row() < 0 || index.row() >= m_games.size()) {
+    return {};
+  }
+  return valueForRole(m_games.at(index.row()), role);
+}
+
+QHash<int, QByteArray> RyujinxGameModel::roleNames() const {
+  return {{GameRoles::Title, "title"},
+          {GameRoles::Subtitle, "subtitle"},
+          {GameRoles::Description, "description"},
+          {GameRoles::Hours, "hours"},
+          {GameRoles::Progress, "progress"},
+          {GameRoles::AchievementsUnlocked, "achievementsUnlocked"},
+          {GameRoles::AchievementsTotal, "achievementsTotal"},
+          {GameRoles::Favorite, "favorite"},
+          {GameRoles::Recent, "recent"},
+          {GameRoles::LastPlayed, "lastPlayed"},
+          {GameRoles::AccentStart, "accentStart"},
+          {GameRoles::AccentEnd, "accentEnd"},
+          {GameRoles::CoverMark, "coverMark"},
+          {GameRoles::Year, "year"},
+          {GameRoles::AppId, "appId"},
+          {GameRoles::CoverPath, "coverPath"},
+          {GameRoles::HeroPath, "heroPath"},
+          {GameRoles::LogoPath, "logoPath"},
+          {GameRoles::InstallPath, "installPath"},
+          {GameRoles::Source, "source"},
+          {GameRoles::Runner, "runner"},
+          {GameRoles::Flatpak, "flatpak"},
+          {GameRoles::Hidden, "hidden"}};
+}
+
+bool RyujinxGameModel::ryujinxDetected() const { return m_ryujinxDetected; }
+QString RyujinxGameModel::statusText() const { return m_statusText; }
+QString RyujinxGameModel::errorText() const { return m_errorText; }
+QStringList RyujinxGameModel::detectedPaths() const { return m_detectedPaths; }
+qint64 RyujinxGameModel::lastScan() const { return m_lastScan; }
+
+void RyujinxGameModel::toggleFavorite(int row) {
+  if (row < 0 || row >= m_games.size() || !m_database.isOpen()) {
+    return;
+  }
+  Game& game = m_games[row];
+  game.favorite = !game.favorite;
+  QSqlQuery query(m_database);
+  query.prepare(QStringLiteral("UPDATE ryujinx_games SET favorite = ? WHERE game_id = ?"));
+  query.addBindValue(game.favorite);
+  query.addBindValue(game.ryujinx.gameId);
+  if (!query.exec()) {
+    game.favorite = !game.favorite;
+    setStatus(m_statusText, query.lastError().text());
+    return;
+  }
+  emit dataChanged(index(row), index(row), {GameRoles::Favorite});
+}
+
+void RyujinxGameModel::toggleHidden(int row) {
+  if (row < 0 || row >= m_games.size() || !m_database.isOpen()) {
+    return;
+  }
+  Game& game = m_games[row];
+  game.hidden = !game.hidden;
+  QSqlQuery query(m_database);
+  query.prepare(QStringLiteral("UPDATE ryujinx_games SET hidden = ? WHERE game_id = ?"));
+  query.addBindValue(game.hidden);
+  query.addBindValue(game.ryujinx.gameId);
+  if (!query.exec()) {
+    game.hidden = !game.hidden;
+    setStatus(m_statusText, query.lastError().text());
+    return;
+  }
+  emit dataChanged(index(row), index(row), {GameRoles::Hidden});
+}
+
+void RyujinxGameModel::refresh() {
+  if (m_scanWatcher.isRunning()) {
+    return;
+  }
+  const QStringList roots = RyujinxScanner::discoverRoots();
+  setStatus(QStringLiteral("Scanning Ryujinx library"));
+  m_scanWatcher.setFuture(QtConcurrent::run([roots] { return RyujinxScanner::scan(roots); }));
+}
+
+void RyujinxGameModel::refreshFromRoots(const QStringList& roots) {
+  applyScan(RyujinxScanner::scan(roots));
+}
+
+bool RyujinxGameModel::openDatabase(const QString& path) {
+  if (path != QStringLiteral(":memory:")) {
+    QDir().mkpath(QFileInfo(path).absolutePath());
+  }
+  m_database = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), m_connectionName);
+  m_database.setDatabaseName(path);
+  if (!m_database.open()) {
+    setStatus(QStringLiteral("Ryujinx cache unavailable"), m_database.lastError().text());
+    return false;
+  }
+  return true;
+}
+
+bool RyujinxGameModel::ensureSchema() {
+  QSqlQuery query(m_database);
+  if (!query.exec(QStringLiteral(
+          "CREATE TABLE IF NOT EXISTS ryujinx_games (game_id TEXT PRIMARY KEY, name TEXT NOT NULL, "
+          "path TEXT, title_id TEXT, last_played INTEGER NOT NULL DEFAULT 0, playtime_seconds "
+          "INTEGER NOT NULL DEFAULT 0, cover_path TEXT, flatpak INTEGER NOT NULL DEFAULT 0, "
+          "favorite INTEGER NOT NULL DEFAULT 0, hidden INTEGER NOT NULL DEFAULT 0, observed_at "
+          "INTEGER NOT NULL)"))) {
+    return false;
+  }
+  if (!query.exec(QStringLiteral(
+          "CREATE TABLE IF NOT EXISTS source_state (source TEXT PRIMARY KEY, last_scan INTEGER, "
+          "last_error TEXT, paths TEXT NOT NULL DEFAULT '')"))) {
+    return false;
+  }
+  bool hasPaths = false;
+  if (query.exec(QStringLiteral("PRAGMA table_info(source_state)"))) {
+    while (query.next()) {
+      hasPaths = hasPaths || query.value(1).toString() == QStringLiteral("paths");
+    }
+  }
+  return hasPaths || query.exec(QStringLiteral(
+                         "ALTER TABLE source_state ADD COLUMN paths TEXT NOT NULL DEFAULT ''"));
+}
+
+void RyujinxGameModel::loadDatabase() {
+  QVector<Game> loaded;
+  QSqlQuery query(m_database);
+  if (!query.exec(QStringLiteral("SELECT game_id, name, path, title_id, cover_path, last_played, "
+                                 "playtime_seconds, flatpak, favorite, hidden FROM ryujinx_games "
+                                 "WHERE observed_at > 0 ORDER BY name COLLATE NOCASE"))) {
+    setStatus(QStringLiteral("Could not load cached Ryujinx games"), query.lastError().text());
+    return;
+  }
+  while (query.next()) {
+    RyujinxGameRecord record{.gameId = query.value(0).toString(),
+                             .titleId = query.value(3).toString(),
+                             .title = query.value(1).toString(),
+                             .path = query.value(2).toString(),
+                             .coverPath = query.value(4).toString(),
+                             .playtimeSeconds = query.value(6).toLongLong(),
+                             .lastPlayed = query.value(5).toLongLong(),
+                             .flatpak = query.value(7).toBool()};
+    loaded.append({.ryujinx = record,
+                   .favorite = query.value(8).toBool(),
+                   .hidden = query.value(9).toBool(),
+                   .accentStart = colorFor(record.gameId, 0),
+                   .accentEnd = colorFor(record.gameId, 1)});
+  }
+  beginResetModel();
+  m_games = loaded;
+  endResetModel();
+}
+
+void RyujinxGameModel::loadSourceState() {
+  QSqlQuery query(m_database);
+  query.prepare(QStringLiteral(
+      "SELECT last_scan, last_error, paths FROM source_state WHERE source = 'ryujinx'"));
+  if (!query.exec() || !query.next()) {
+    return;
+  }
+  m_lastScan = query.value(0).toLongLong();
+  m_errorText = query.value(1).toString();
+  m_detectedPaths = query.value(2).toString().split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+  m_ryujinxDetected = !m_detectedPaths.isEmpty();
+  if (m_lastScan > 0) {
+    m_statusText = QStringLiteral("Loaded cached Ryujinx games");
+  }
+}
+
+void RyujinxGameModel::applyScan(const RyujinxScanResult& result) {
+  m_ryujinxDetected = !result.roots.isEmpty();
+  if (result.incomplete || (result.roots.isEmpty() && !m_games.isEmpty())) {
+    setStatus(QStringLiteral("Ryujinx scan interrupted; kept the cached library"),
+              result.warnings.join(QLatin1Char('\n')));
+    return;
+  }
+  if (!m_database.transaction()) {
+    setStatus(QStringLiteral("Could not update Ryujinx games"), m_database.lastError().text());
+    return;
+  }
+  QSqlQuery query(m_database);
+  bool okay = query.exec(QStringLiteral("UPDATE ryujinx_games SET observed_at = 0"));
+  for (const RyujinxGameRecord& game : result.games) {
+    query.prepare(QStringLiteral(
+        "INSERT INTO ryujinx_games(game_id, name, path, title_id, cover_path, last_played, "
+        "playtime_seconds, flatpak, observed_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?, strftime('%s', "
+        "'now')) ON CONFLICT(game_id) DO UPDATE SET name = excluded.name, path = excluded.path, "
+        "title_id = excluded.title_id, cover_path = excluded.cover_path, last_played = "
+        "excluded.last_played, playtime_seconds = excluded.playtime_seconds, flatpak = "
+        "excluded.flatpak, observed_at = excluded.observed_at"));
+    query.addBindValue(game.gameId);
+    query.addBindValue(game.title);
+    query.addBindValue(game.path);
+    query.addBindValue(game.titleId);
+    query.addBindValue(game.coverPath);
+    query.addBindValue(game.lastPlayed);
+    query.addBindValue(game.playtimeSeconds);
+    query.addBindValue(game.flatpak);
+    okay = okay && query.exec();
+  }
+  query.prepare(QStringLiteral(
+      "INSERT INTO source_state(source, last_scan, last_error, paths) VALUES('ryujinx', "
+      "strftime('%s', 'now'), ?, ?) ON CONFLICT(source) DO UPDATE SET last_scan = "
+      "excluded.last_scan, last_error = excluded.last_error, paths = excluded.paths"));
+  query.addBindValue(result.warnings.join(QLatin1Char('\n')));
+  query.addBindValue(result.roots.isEmpty() ? QStringLiteral("") : result.roots.join(QLatin1Char('\n')));
+  okay = okay && query.exec();
+  if (!okay || !m_database.commit()) {
+    m_database.rollback();
+    setStatus(QStringLiteral("Could not update Ryujinx games"), query.lastError().text());
+    return;
+  }
+  loadDatabase();
+  m_detectedPaths = result.roots;
+  m_lastScan = QDateTime::currentSecsSinceEpoch();
+  setStatus(m_ryujinxDetected ? QStringLiteral("Imported %1 Ryujinx game(s)").arg(result.games.size())
+                              : QStringLiteral("Ryujinx was not found"),
+            result.warnings.join(QLatin1Char('\n')));
+}
+
+QVariant RyujinxGameModel::valueForRole(const Game& game, int role) const {
+  switch (role) {
+  case GameRoles::Title:
+    return game.ryujinx.title;
+  case GameRoles::Subtitle:
+    return QStringLiteral("Ryujinx");
+  case GameRoles::Description:
+    return QStringLiteral("Nintendo Switch game launched through Ryujinx.");
+  case GameRoles::Hours:
+    return static_cast<int>(game.ryujinx.playtimeSeconds / 3600);
+  case GameRoles::Progress:
+  case GameRoles::AchievementsUnlocked:
+  case GameRoles::AchievementsTotal:
+    return 0;
+  case GameRoles::Favorite:
+    return game.favorite;
+  case GameRoles::Recent:
+    return game.ryujinx.lastPlayed > 0;
+  case GameRoles::LastPlayed:
+    return game.ryujinx.lastPlayed;
+  case GameRoles::AccentStart:
+    return game.accentStart;
+  case GameRoles::AccentEnd:
+    return game.accentEnd;
+  case GameRoles::CoverMark:
+    return game.ryujinx.title.left(1).toUpper();
+  case GameRoles::Year:
+    return 0;
+  case GameRoles::AppId:
+    return game.ryujinx.gameId;
+  case GameRoles::CoverPath:
+    return localUrl(game.ryujinx.coverPath);
+  case GameRoles::HeroPath:
+  case GameRoles::LogoPath:
+    return QString{};
+  case GameRoles::InstallPath:
+    return game.ryujinx.path;
+  case GameRoles::Source:
+    return QStringLiteral("Ryujinx");
+  case GameRoles::Runner:
+    return game.ryujinx.titleId;
+  case GameRoles::Flatpak:
+    return game.ryujinx.flatpak;
+  case GameRoles::Hidden:
+    return game.hidden;
+  default:
+    return {};
+  }
+}
+
+void RyujinxGameModel::setStatus(const QString& status, const QString& error) {
+  m_statusText = status;
+  m_errorText = error;
+  emit statusChanged();
+}

--- a/src/library/RyujinxGameModel.cpp
+++ b/src/library/RyujinxGameModel.cpp
@@ -27,7 +27,11 @@ RyujinxGameModel::RyujinxGameModel(const QString& omakadeDatabasePath, QObject* 
     : QAbstractListModel(parent),
       m_connectionName(QStringLiteral("omakade-ryujinx-%1").arg(reinterpret_cast<quintptr>(this))) {
   connect(&m_scanWatcher, &QFutureWatcher<RyujinxScanResult>::finished, this,
-          [this] { applyScan(m_scanWatcher.result()); });
+          [this] {
+            m_scanning = false;
+            applyScan(m_scanWatcher.result());
+            emit statusChanged();
+          });
   if (openDatabase(omakadeDatabasePath) && ensureSchema()) {
     loadDatabase();
     loadSourceState();
@@ -127,6 +131,7 @@ void RyujinxGameModel::refresh() {
   if (m_scanWatcher.isRunning()) {
     return;
   }
+  m_scanning = true;
   const QStringList roots = RyujinxScanner::discoverRoots();
   setStatus(QStringLiteral("Scanning Ryujinx library"));
   m_scanWatcher.setFuture(QtConcurrent::run([roots] { return RyujinxScanner::scan(roots); }));

--- a/src/library/RyujinxGameModel.cpp
+++ b/src/library/RyujinxGameModel.cpp
@@ -77,7 +77,8 @@ QHash<int, QByteArray> RyujinxGameModel::roleNames() const {
           {GameRoles::Source, "source"},
           {GameRoles::Runner, "runner"},
           {GameRoles::Flatpak, "flatpak"},
-          {GameRoles::Hidden, "hidden"}};
+          {GameRoles::Hidden, "hidden"},
+          {GameRoles::LaunchTarget, "launchTarget"}};
 }
 
 bool RyujinxGameModel::ryujinxDetected() const { return m_ryujinxDetected; }
@@ -319,6 +320,9 @@ QVariant RyujinxGameModel::valueForRole(const Game& game, int role) const {
     return QStringLiteral("Ryujinx");
   case GameRoles::Runner:
     return game.ryujinx.titleId;
+  case GameRoles::LaunchTarget:
+    // Ryujinx's positional argument must be a ROM file path, never a title id.
+    return game.ryujinx.path;
   case GameRoles::Flatpak:
     return game.ryujinx.flatpak;
   case GameRoles::Hidden:

--- a/src/library/RyujinxGameModel.cpp
+++ b/src/library/RyujinxGameModel.cpp
@@ -156,11 +156,13 @@ bool RyujinxGameModel::ensureSchema() {
           "INTEGER NOT NULL DEFAULT 0, cover_path TEXT, flatpak INTEGER NOT NULL DEFAULT 0, "
           "favorite INTEGER NOT NULL DEFAULT 0, hidden INTEGER NOT NULL DEFAULT 0, observed_at "
           "INTEGER NOT NULL)"))) {
+    setStatus(QStringLiteral("Could not initialize Ryujinx cache"), query.lastError().text());
     return false;
   }
   if (!query.exec(QStringLiteral(
           "CREATE TABLE IF NOT EXISTS source_state (source TEXT PRIMARY KEY, last_scan INTEGER, "
           "last_error TEXT, paths TEXT NOT NULL DEFAULT '')"))) {
+    setStatus(QStringLiteral("Could not initialize Ryujinx cache"), query.lastError().text());
     return false;
   }
   bool hasPaths = false;
@@ -169,8 +171,15 @@ bool RyujinxGameModel::ensureSchema() {
       hasPaths = hasPaths || query.value(1).toString() == QStringLiteral("paths");
     }
   }
-  return hasPaths || query.exec(QStringLiteral(
-                         "ALTER TABLE source_state ADD COLUMN paths TEXT NOT NULL DEFAULT ''"));
+  if (hasPaths) {
+    return true;
+  }
+  if (!query.exec(QStringLiteral(
+          "ALTER TABLE source_state ADD COLUMN paths TEXT NOT NULL DEFAULT ''"))) {
+    setStatus(QStringLiteral("Could not migrate Ryujinx cache"), query.lastError().text());
+    return false;
+  }
+  return true;
 }
 
 void RyujinxGameModel::loadDatabase() {

--- a/src/library/RyujinxGameModel.h
+++ b/src/library/RyujinxGameModel.h
@@ -10,6 +10,7 @@
 class RyujinxGameModel final : public QAbstractListModel {
   Q_OBJECT
   Q_PROPERTY(bool ryujinxDetected READ ryujinxDetected NOTIFY statusChanged)
+  Q_PROPERTY(bool scanning READ scanning NOTIFY statusChanged)
   Q_PROPERTY(QString statusText READ statusText NOTIFY statusChanged)
   Q_PROPERTY(QString errorText READ errorText NOTIFY statusChanged)
   Q_PROPERTY(QStringList detectedPaths READ detectedPaths NOTIFY statusChanged)
@@ -23,6 +24,7 @@ public:
   [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
   [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
   [[nodiscard]] bool ryujinxDetected() const;
+  [[nodiscard]] bool scanning() const { return m_scanning; }
   [[nodiscard]] QString statusText() const;
   [[nodiscard]] QString errorText() const;
   [[nodiscard]] QStringList detectedPaths() const;
@@ -57,6 +59,7 @@ private:
   QSqlDatabase m_database;
   QString m_connectionName;
   QFutureWatcher<RyujinxScanResult> m_scanWatcher;
+  bool m_scanning = false;
   bool m_ryujinxDetected = false;
   QString m_statusText;
   QString m_errorText;

--- a/src/library/RyujinxGameModel.h
+++ b/src/library/RyujinxGameModel.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "sources/ryujinx/RyujinxScanner.h"
+
+#include <QAbstractListModel>
+#include <QColor>
+#include <QFutureWatcher>
+#include <QSqlDatabase>
+
+class RyujinxGameModel final : public QAbstractListModel {
+  Q_OBJECT
+  Q_PROPERTY(bool ryujinxDetected READ ryujinxDetected NOTIFY statusChanged)
+  Q_PROPERTY(QString statusText READ statusText NOTIFY statusChanged)
+  Q_PROPERTY(QString errorText READ errorText NOTIFY statusChanged)
+  Q_PROPERTY(QStringList detectedPaths READ detectedPaths NOTIFY statusChanged)
+  Q_PROPERTY(qint64 lastScan READ lastScan NOTIFY statusChanged)
+
+public:
+  explicit RyujinxGameModel(const QString& omakadeDatabasePath, QObject* parent = nullptr);
+  ~RyujinxGameModel() override;
+
+  [[nodiscard]] int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+  [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
+  [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
+  [[nodiscard]] bool ryujinxDetected() const;
+  [[nodiscard]] QString statusText() const;
+  [[nodiscard]] QString errorText() const;
+  [[nodiscard]] QStringList detectedPaths() const;
+  [[nodiscard]] qint64 lastScan() const;
+
+  Q_INVOKABLE void toggleFavorite(int row);
+  Q_INVOKABLE void toggleHidden(int row);
+  Q_INVOKABLE void refresh();
+  void refreshFromRoots(const QStringList& roots);
+
+signals:
+  void statusChanged();
+
+private:
+  struct Game {
+    RyujinxGameRecord ryujinx;
+    bool favorite = false;
+    bool hidden = false;
+    QColor accentStart;
+    QColor accentEnd;
+  };
+
+  bool openDatabase(const QString& path);
+  bool ensureSchema();
+  void loadDatabase();
+  void loadSourceState();
+  void applyScan(const RyujinxScanResult& result);
+  [[nodiscard]] QVariant valueForRole(const Game& game, int role) const;
+  void setStatus(const QString& status, const QString& error = {});
+
+  QVector<Game> m_games;
+  QSqlDatabase m_database;
+  QString m_connectionName;
+  QFutureWatcher<RyujinxScanResult> m_scanWatcher;
+  bool m_ryujinxDetected = false;
+  QString m_statusText;
+  QString m_errorText;
+  QStringList m_detectedPaths;
+  qint64 m_lastScan = 0;
+};

--- a/src/sources/pcsx2/Pcsx2Scanner.cpp
+++ b/src/sources/pcsx2/Pcsx2Scanner.cpp
@@ -182,9 +182,12 @@ Pcsx2ScanResult Pcsx2Scanner::scan(const QStringList& roots) {
       continue;
     }
     if (version != 34) {
-      // Current PCSX2 writes version 34; older caches need a PCSX2 rescan first.
+      // Current PCSX2 writes version 34; parsing an unknown layout would produce
+      // garbage records, so skip this cache and keep whatever is already cached.
       result.warnings.append(QStringLiteral(
           "Unsupported PCSX2 cache version %1; rescan in PCSX2 to refresh").arg(version));
+      result.incomplete = true;
+      continue;
     }
 
     // Entry layout: str path, str serial, str title

--- a/src/sources/pcsx2/Pcsx2Scanner.cpp
+++ b/src/sources/pcsx2/Pcsx2Scanner.cpp
@@ -1,0 +1,286 @@
+#include "sources/pcsx2/Pcsx2Scanner.h"
+
+#include <QDataStream>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QHash>
+#include <QRegularExpression>
+#include <QSet>
+#include <cstring>
+#include <QStandardPaths>
+#include <QtEndian>
+
+namespace {
+constexpr quint32 kCacheSignature = 0x45434C47; // 'GLCE' when read little-endian
+constexpr qint64 kMaximumCacheBytes = 128 * 1024 * 1024;
+constexpr int kPlayedTimeSerialLength = 32;
+constexpr int kPlayedTimeTotalLength = 20;
+constexpr int kPlayedTimeLastLength = 20;
+constexpr int kMaximumTitleLength = 256;
+
+bool isScannableFilename(const QString& path) {
+  static const QStringList extensions = {
+      QStringLiteral(".iso"), QStringLiteral(".bin"), QStringLiteral(".img"),
+      QStringLiteral(".mdf"), QStringLiteral(".gz"),  QStringLiteral(".cso"),
+      QStringLiteral(".zso"), QStringLiteral(".chd"), QStringLiteral(".elf")};
+  for (const QString& extension : extensions) {
+    if (path.endsWith(extension, Qt::CaseInsensitive)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+struct PlayedTimeEntry {
+  qint64 totalSeconds = 0;
+  qint64 lastPlayed = 0;
+};
+
+QHash<QString, PlayedTimeEntry> loadPlayedTime(const QString& root) {
+  QHash<QString, PlayedTimeEntry> played;
+  QFile file(root + QStringLiteral("/inis/playtime.dat"));
+  if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    return played;
+  }
+  // PCSX2 format: "{serial:<32} {total:<20} {last:<20}\n"
+  const int lineLength =
+      kPlayedTimeSerialLength + 1 + kPlayedTimeTotalLength + 1 + kPlayedTimeLastLength;
+  while (!file.atEnd()) {
+    QByteArray line = file.readLine();
+    while (line.endsWith('\n') || line.endsWith('\r')) {
+      line.chop(1);
+    }
+    if (line.size() != lineLength) {
+      continue;
+    }
+    const QString serial =
+        QString::fromUtf8(line.left(kPlayedTimeSerialLength)).trimmed();
+    const qint64 totalTime = QString::fromUtf8(
+                                 line.mid(kPlayedTimeSerialLength + 1, kPlayedTimeTotalLength))
+                                 .trimmed()
+                                 .toLongLong();
+    const qint64 lastTime =
+        QString::fromUtf8(line.mid(kPlayedTimeSerialLength + 1 + kPlayedTimeTotalLength + 1,
+                                   kPlayedTimeLastLength))
+            .trimmed()
+            .toLongLong();
+    if (serial.isEmpty() || totalTime < 0 || lastTime < 0 || played.contains(serial)) {
+      continue;
+    }
+    played.insert(serial, {totalTime, lastTime});
+  }
+  return played;
+}
+
+QString regionName(quint8 region) {
+  switch (region) {
+  case 0:
+  case 1:
+  case 2:
+  case 3:
+    return QStringLiteral("NTSC");
+  case 4:
+    return QStringLiteral("NTSC-K");
+  case 6:
+    return QStringLiteral("NTSC-U");
+  case 7:
+    return QStringLiteral("Other");
+  default:
+    if (region >= 8) {
+      return QStringLiteral("PAL");
+    }
+    return QStringLiteral("NTSC-J");
+  }
+}
+
+QString coverFor(const QString& root, const QString& path, const QString& serial,
+                 const QString& title) {
+  const QString coversRoot = root + QStringLiteral("/covers");
+  // PCSX2 lookup order: file title, serial, then game title.
+  const QString fileTitle = QFileInfo(path).completeBaseName();
+  QStringList stems;
+  if (!fileTitle.isEmpty() && fileTitle != title) {
+    stems.append(fileTitle);
+  }
+  if (!serial.isEmpty()) {
+    stems.append(serial);
+  }
+  if (!title.isEmpty()) {
+    stems.append(title);
+  }
+  for (const QString& stemRef : stems) {
+    QString stem = stemRef;
+    const QString sanitized =
+        stem.replace(QRegularExpression(QStringLiteral("[/\\\\?%*:|\"<>\\x01-\\x1f]")),
+                     QStringLiteral("_"));
+    for (const QString& extension :
+         {QStringLiteral(".jpg"), QStringLiteral(".jpeg"), QStringLiteral(".png"),
+          QStringLiteral(".webp")}) {
+      const QString candidate = coversRoot + QLatin1Char('/') + sanitized + extension;
+      if (QFileInfo::exists(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return {};
+}
+} // namespace
+
+QStringList Pcsx2Scanner::discoverRoots() {
+  const QString home = QDir::homePath();
+  QStringList candidates = {
+      home + QStringLiteral("/.config/PCSX2"),
+      home + QStringLiteral("/.var/app/net.pcsx2.PCSX2/config/PCSX2"),
+  };
+  candidates.removeDuplicates();
+
+  QStringList roots;
+  for (const QString& root : candidates) {
+    if (QFileInfo(root + QStringLiteral("/inis/PCSX2.ini")).isFile() ||
+        QFileInfo(root + QStringLiteral("/cache/gamelist.cache")).isFile()) {
+      roots.append(root);
+    }
+  }
+  return roots;
+}
+
+Pcsx2ScanResult Pcsx2Scanner::scan(const QStringList& roots) {
+  Pcsx2ScanResult result;
+  for (const QString& root : roots) {
+    const QString cachePath = root + QStringLiteral("/cache/gamelist.cache");
+    QFile file(cachePath);
+    if (!file.exists()) {
+      continue;
+    }
+    result.roots.append(root);
+    if (!file.open(QIODevice::ReadOnly) || file.size() > kMaximumCacheBytes) {
+      result.incomplete = true;
+      result.warnings.append(QStringLiteral("Could not read %1").arg(cachePath));
+      continue;
+    }
+    const QByteArray cache = file.readAll();
+    file.close();
+
+    quint32 signature = 0;
+    quint32 version = 0;
+    if (cache.size() < 8) {
+      result.incomplete = true;
+      result.warnings.append(QStringLiteral("Truncated game list cache %1").arg(cachePath));
+      continue;
+    }
+    quint32 rawSignature = 0;
+    quint32 rawVersion = 0;
+    std::memcpy(&rawSignature, cache.constData(), sizeof(rawSignature));
+    std::memcpy(&rawVersion, cache.constData() + 4, sizeof(rawVersion));
+    signature = qFromLittleEndian(rawSignature);
+    version = qFromLittleEndian(rawVersion);
+    if (signature != kCacheSignature) {
+      result.incomplete = true;
+      result.warnings.append(QStringLiteral("Unrecognized game list cache %1").arg(cachePath));
+      continue;
+    }
+    if (version != 32 && version != 34) {
+      result.warnings.append(QStringLiteral(
+          "Unsupported PCSX2 cache version %1; rescan in PCSX2 to refresh").arg(version));
+    }
+
+    // Entry layout: str path, str serial, str title
+    // [, str title_sort, str title_en when version >= 33],
+    // u8 type, u8 region, u64 total_size, u64 last_modified, u32 crc, u8 compat.
+    const bool hasExtraTitles = version >= 33;
+    const bool flatpak = root.contains(QStringLiteral("/.var/app/net.pcsx2.PCSX2/"));
+    const QHash<QString, PlayedTimeEntry> playedTime = loadPlayedTime(root);
+
+    int offset = 8;
+    QSet<QString> seenPaths;
+    bool corrupt = false;
+    while (offset < cache.size()) {
+      auto readString = [&cache, &offset]() -> QString {
+        if (offset + 4 > cache.size()) {
+          offset = cache.size() + 1;
+          return {};
+        }
+        quint32 rawLength = 0;
+        std::memcpy(&rawLength, cache.constData() + offset, sizeof(rawLength));
+        const int length = static_cast<int>(qFromLittleEndian(rawLength));
+        offset += 4;
+        if (length > kMaximumTitleLength * 16 || offset + length > cache.size()) {
+          offset = cache.size() + 1;
+          return {};
+        }
+        const QString value =
+            QString::fromUtf8(cache.constData() + offset, length);
+        offset += length;
+        return value;
+      };
+
+      const int entryStart = offset;
+      const QString path = readString();
+      const QString serial = readString();
+      const QString title = readString();
+      if (hasExtraTitles) {
+        readString();
+        readString();
+      }
+      if (offset + 1 + 1 + 8 + 8 + 4 + 1 > cache.size() || offset < 0) {
+        if (offset != cache.size() + 1) {
+          // Trailing bytes that cannot form an entry: treat as corruption.
+          result.warnings.append(
+              QStringLiteral("Truncated cache entry in %1").arg(cachePath));
+          corrupt = true;
+        }
+        break;
+      }
+      const quint8 type = static_cast<quint8>(cache.at(offset));
+      offset += 1;
+      const quint8 region = static_cast<quint8>(cache.at(offset));
+      offset += 1;
+      quint64 totalSize = 0;
+      std::memcpy(&totalSize, cache.constData() + offset, sizeof(totalSize));
+      totalSize = qFromLittleEndian(totalSize);
+      offset += 8;
+      offset += 8; // last modified time
+      offset += 4; // crc
+      const quint8 compatibility = static_cast<quint8>(cache.at(offset));
+      offset += 1;
+      if (compatibility > 5) {
+        result.warnings.append(
+            QStringLiteral("Corrupt cache entry in %1").arg(cachePath));
+        corrupt = true;
+        break;
+      }
+
+      const QString filePath = QDir::cleanPath(path);
+      if (filePath.isEmpty() || title.trimmed().isEmpty() ||
+          !isScannableFilename(filePath) || seenPaths.contains(filePath)) {
+        continue;
+      }
+      if (!QFileInfo::exists(filePath)) {
+        // PCSX2 keeps stale cache entries for moved or deleted games.
+        continue;
+      }
+
+      Pcsx2GameRecord record;
+      record.gameId = serial.isEmpty() ? QStringLiteral("path:%1").arg(filePath) : serial;
+      record.title = title.trimmed();
+      record.path = filePath;
+      record.serial = serial;
+      record.region = regionName(region);
+      record.flatpak = flatpak;
+      record.coverPath = coverFor(root, filePath, serial, record.title);
+      if (type == 0 || type == 1) {
+        // Disc entries: playtime is keyed by serial.
+        const PlayedTimeEntry played = playedTime.value(serial);
+        record.playtimeSeconds = played.totalSeconds;
+        record.lastPlayed = played.lastPlayed;
+      }
+      result.games.append(record);
+      seenPaths.insert(filePath);
+    }
+    if (corrupt) {
+      result.incomplete = true;
+    }
+  }
+  return result;
+}

--- a/src/sources/pcsx2/Pcsx2Scanner.cpp
+++ b/src/sources/pcsx2/Pcsx2Scanner.cpp
@@ -203,25 +203,32 @@ Pcsx2ScanResult Pcsx2Scanner::scan(const QStringList& roots) {
         }
         quint32 rawLength = 0;
         std::memcpy(&rawLength, cache.constData() + offset, sizeof(rawLength));
-        const int length = static_cast<int>(qFromLittleEndian(rawLength));
+        const quint32 length = qFromLittleEndian(rawLength);
         offset += 4;
-        if (length > kMaximumTitleLength * 16 || offset + length > cache.size()) {
+        if (length > static_cast<quint32>(kMaximumTitleLength * 16) ||
+            offset + static_cast<qsizetype>(length) > cache.size()) {
           offset = cache.size() + 1;
           return {};
         }
         const QString value =
-            QString::fromUtf8(cache.constData() + offset, length);
-        offset += length;
+            QString::fromUtf8(cache.constData() + offset, static_cast<qsizetype>(length));
+        offset += static_cast<qsizetype>(length);
         return value;
       };
 
-      const int entryStart = offset;
       const QString path = readString();
       const QString serial = readString();
       const QString title = readString();
       if (hasExtraTitles) {
         readString();
         readString();
+      }
+      if (offset >= cache.size() + 1) {
+        // A string read aborted mid-entry: the cache is malformed.
+        result.warnings.append(
+            QStringLiteral("Malformed cache entry in %1").arg(cachePath));
+        corrupt = true;
+        break;
       }
       if (offset + 1 + 1 + 8 + 8 + 4 + 1 > cache.size() || offset < 0) {
         if (offset != cache.size() + 1) {
@@ -268,6 +275,7 @@ Pcsx2ScanResult Pcsx2Scanner::scan(const QStringList& roots) {
       record.serial = serial;
       record.region = regionName(region);
       record.flatpak = flatpak;
+      record.isElf = (type == 2);
       record.coverPath = coverFor(root, filePath, serial, record.title);
       if (type == 0 || type == 1) {
         // Disc entries: playtime is keyed by serial.

--- a/src/sources/pcsx2/Pcsx2Scanner.cpp
+++ b/src/sources/pcsx2/Pcsx2Scanner.cpp
@@ -147,6 +147,8 @@ QStringList Pcsx2Scanner::discoverRoots() {
 
 Pcsx2ScanResult Pcsx2Scanner::scan(const QStringList& roots) {
   Pcsx2ScanResult result;
+  QSet<QString> seenGameIds;
+  QSet<QString> seenPaths;
   for (const QString& root : roots) {
     const QString cachePath = root + QStringLiteral("/cache/gamelist.cache");
     QFile file(cachePath);
@@ -193,7 +195,6 @@ Pcsx2ScanResult Pcsx2Scanner::scan(const QStringList& roots) {
     const QHash<QString, PlayedTimeEntry> playedTime = loadPlayedTime(root);
 
     int offset = 8;
-    QSet<QString> seenPaths;
     bool corrupt = false;
     while (offset < cache.size()) {
       auto readString = [&cache, &offset]() -> QString {
@@ -251,16 +252,23 @@ Pcsx2ScanResult Pcsx2Scanner::scan(const QStringList& roots) {
       offset += 4; // crc
       const quint8 compatibility = static_cast<quint8>(cache.at(offset));
       offset += 1;
-      if (compatibility > 5) {
+      if (compatibility > 6) {
+        // PCSX2 compatibility ratings run 0 (Unknown) through 6 (Perfect); higher
+        // values indicate a malformed entry, but do not abort the whole cache.
         result.warnings.append(
-            QStringLiteral("Corrupt cache entry in %1").arg(cachePath));
-        corrupt = true;
-        break;
+            QStringLiteral("Unexpected compatibility rating in %1").arg(cachePath));
+        continue;
       }
 
       const QString filePath = QDir::cleanPath(path);
       if (filePath.isEmpty() || title.trimmed().isEmpty() ||
           !isScannableFilename(filePath) || seenPaths.contains(filePath)) {
+        continue;
+      }
+      const QString recordKey =
+          serial.isEmpty() ? QStringLiteral("path:%1").arg(filePath) : serial;
+      if (seenGameIds.contains(recordKey)) {
+        // Same serial (or path) already imported from another root; keep first.
         continue;
       }
       if (!QFileInfo::exists(filePath)) {
@@ -285,6 +293,7 @@ Pcsx2ScanResult Pcsx2Scanner::scan(const QStringList& roots) {
       }
       result.games.append(record);
       seenPaths.insert(filePath);
+      seenGameIds.insert(recordKey);
     }
     if (corrupt) {
       result.incomplete = true;

--- a/src/sources/pcsx2/Pcsx2Scanner.cpp
+++ b/src/sources/pcsx2/Pcsx2Scanner.cpp
@@ -74,12 +74,11 @@ QHash<QString, PlayedTimeEntry> loadPlayedTime(const QString& root) {
 }
 
 QString regionName(quint8 region) {
+  // PCSX2 GameList::Region: 0=NTSC-B, 1=NTSC-C, 2=NTSC-HK, 3=NTSC-J, 4=NTSC-K,
+  // 5=NTSC-T, 6=NTSC-U, 7=Other, 8+ PAL variants.
   switch (region) {
-  case 0:
-  case 1:
-  case 2:
   case 3:
-    return QStringLiteral("NTSC");
+    return QStringLiteral("NTSC-J");
   case 4:
     return QStringLiteral("NTSC-K");
   case 6:
@@ -90,7 +89,7 @@ QString regionName(quint8 region) {
     if (region >= 8) {
       return QStringLiteral("PAL");
     }
-    return QStringLiteral("NTSC-J");
+    return QStringLiteral("NTSC");
   }
 }
 
@@ -182,7 +181,8 @@ Pcsx2ScanResult Pcsx2Scanner::scan(const QStringList& roots) {
       result.warnings.append(QStringLiteral("Unrecognized game list cache %1").arg(cachePath));
       continue;
     }
-    if (version != 32 && version != 34) {
+    if (version != 34) {
+      // Current PCSX2 writes version 34; older caches need a PCSX2 rescan first.
       result.warnings.append(QStringLiteral(
           "Unsupported PCSX2 cache version %1; rescan in PCSX2 to refresh").arg(version));
     }

--- a/src/sources/pcsx2/Pcsx2Scanner.h
+++ b/src/sources/pcsx2/Pcsx2Scanner.h
@@ -13,6 +13,7 @@ struct Pcsx2GameRecord {
   QString region;
   qint64 playtimeSeconds = 0;
   qint64 lastPlayed = 0;
+  bool isElf = false;  // true when PCSX2 classified the entry as an ELF
   bool flatpak = false;
 };
 

--- a/src/sources/pcsx2/Pcsx2Scanner.h
+++ b/src/sources/pcsx2/Pcsx2Scanner.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+struct Pcsx2GameRecord {
+  QString gameId;      // serial (e.g. SLUS-20909) or path hash fallback
+  QString title;
+  QString path;        // absolute disc/ELF path
+  QString serial;
+  QString coverPath;
+  QString region;
+  qint64 playtimeSeconds = 0;
+  qint64 lastPlayed = 0;
+  bool flatpak = false;
+};
+
+struct Pcsx2ScanResult {
+  QVector<Pcsx2GameRecord> games;
+  QStringList roots;       // PCSX2 config roots that were scanned
+  QStringList warnings;
+  bool incomplete = false;
+};
+
+class Pcsx2Scanner final {
+public:
+  [[nodiscard]] static QStringList discoverRoots();
+  [[nodiscard]] static Pcsx2ScanResult scan(const QStringList& roots);
+};

--- a/src/sources/ryujinx/RyujinxScanner.cpp
+++ b/src/sources/ryujinx/RyujinxScanner.cpp
@@ -122,8 +122,9 @@ RyujinxScanResult RyujinxScanner::scan(const QStringList& roots) {
     }
     const bool flatpak = root.contains(QStringLiteral("/.var/app/io.github.ryubing.Ryujinx/"));
 
-    // Per-title metadata lives in games/<titleId>/gui ("TitleName") and
-    // time_played ("playtime" seconds, "last_played" ISO-8601).
+    // Real installs: games/<titleId>/gui is a directory containing metadata.json
+    // ("title", "timespan_played", "last_played_utc", plus the legacy
+    // "time_played" and "last_played" keys).
     QHash<QString, QString> displayTitles;
     QHash<QString, qint64> playtimeFor;
     QHash<QString, qint64> lastPlayedFor;
@@ -135,8 +136,41 @@ RyujinxScanResult RyujinxScanner::scan(const QStringList& roots) {
       if (!validTitleId(titleId)) {
         continue;
       }
-      QFile guiFile(entry.filePath() + QStringLiteral("/gui"));
-      if (guiFile.open(QIODevice::ReadOnly)) {
+      const QString guiPath = entry.filePath() + QStringLiteral("/gui");
+      QFile metadataFile(guiPath + QStringLiteral("/metadata.json"));
+      if (metadataFile.open(QIODevice::ReadOnly)) {
+        const QJsonObject metadata =
+            QJsonDocument::fromJson(metadataFile.readAll(), &parseError).object();
+        if (parseError.error == QJsonParseError::NoError) {
+          const QString customTitle = metadata.value(QStringLiteral("title")).toString().trimmed();
+          if (!customTitle.isEmpty()) {
+            displayTitles.insert(titleId, customTitle);
+          }
+          // Newer fields: timespan_played (seconds) and last_played_utc (ISO-8601).
+          qint64 seconds =
+              static_cast<qint64>(metadata.value(QStringLiteral("timespan_played")).toDouble(0));
+          QString lastPlayedIso = metadata.value(QStringLiteral("last_played_utc")).toString();
+          // Legacy fallbacks for older installs.
+          if (seconds <= 0) {
+            seconds = static_cast<qint64>(metadata.value(QStringLiteral("time_played")).toDouble(0));
+          }
+          if (lastPlayedIso.isEmpty()) {
+            lastPlayedIso = metadata.value(QStringLiteral("last_played")).toString();
+          }
+          if (seconds > 0) {
+            playtimeFor.insert(titleId, seconds);
+          }
+          if (!lastPlayedIso.isEmpty()) {
+            const QDateTime parsed = QDateTime::fromString(lastPlayedIso, Qt::ISODate);
+            if (parsed.isValid()) {
+              lastPlayedFor.insert(titleId, parsed.toSecsSinceEpoch());
+            }
+          }
+        }
+      }
+      // Legacy fallback: gui as a plain file with TitleName (older Ryujinx layouts).
+      QFile guiFile(guiPath);
+      if (!metadataFile.exists() && guiFile.open(QIODevice::ReadOnly)) {
         const QJsonObject gui =
             QJsonDocument::fromJson(guiFile.readAll(), &parseError).object();
         if (parseError.error == QJsonParseError::NoError) {
@@ -154,10 +188,10 @@ RyujinxScanResult RyujinxScanner::scan(const QStringList& roots) {
           const qint64 seconds =
               static_cast<qint64>(times.value(QStringLiteral("playtime")).toDouble(0));
           const QString lastPlayedIso = times.value(QStringLiteral("last_played")).toString();
-          if (seconds > 0) {
+          if (seconds > 0 && !playtimeFor.contains(titleId)) {
             playtimeFor.insert(titleId, seconds);
           }
-          if (!lastPlayedIso.isEmpty()) {
+          if (!lastPlayedIso.isEmpty() && !lastPlayedFor.contains(titleId)) {
             const QDateTime parsed = QDateTime::fromString(lastPlayedIso, Qt::ISODate);
             if (parsed.isValid()) {
               lastPlayedFor.insert(titleId, parsed.toSecsSinceEpoch());

--- a/src/sources/ryujinx/RyujinxScanner.cpp
+++ b/src/sources/ryujinx/RyujinxScanner.cpp
@@ -138,7 +138,8 @@ RyujinxScanResult RyujinxScanner::scan(const QStringList& roots) {
       }
       const QString guiPath = entry.filePath() + QStringLiteral("/gui");
       QFile metadataFile(guiPath + QStringLiteral("/metadata.json"));
-      if (metadataFile.open(QIODevice::ReadOnly)) {
+      if (metadataFile.open(QIODevice::ReadOnly) &&
+          metadataFile.size() <= kMaximumJsonBytes) {
         const QJsonObject metadata =
             QJsonDocument::fromJson(metadataFile.readAll(), &parseError).object();
         if (parseError.error == QJsonParseError::NoError) {

--- a/src/sources/ryujinx/RyujinxScanner.cpp
+++ b/src/sources/ryujinx/RyujinxScanner.cpp
@@ -1,0 +1,218 @@
+#include "sources/ryujinx/RyujinxScanner.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QRegularExpression>
+#include <QSet>
+#include <QStandardPaths>
+
+namespace {
+constexpr qint64 kMaximumJsonBytes = 16 * 1024 * 1024;
+
+const QStringList& gameExtensions() {
+  static const QStringList extensions = {QStringLiteral(".xci"), QStringLiteral(".nsp"),
+                                         QStringLiteral(".nro")};
+  return extensions;
+}
+
+bool isGameFile(const QString& fileName) {
+  for (const QString& extension : gameExtensions()) {
+    if (fileName.endsWith(extension, Qt::CaseInsensitive)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool validTitleId(const QString& value) {
+  static const QRegularExpression valid(QStringLiteral("^[0-9A-Fa-f]{16}$"));
+  return valid.match(value).hasMatch();
+}
+
+// Strips update/DLC markers: "Game [0100...][v0].nsp" -> "0100...".
+QString titleIdFromFilename(const QString& fileName) {
+  static const QRegularExpression expression(
+      QStringLiteral("\\[\\s*(0100[0-9A-Fa-f]{12})\\s*\\]"));
+  const QRegularExpressionMatch match = expression.match(fileName);
+  return match.hasMatch() ? match.captured(1).toUpper() : QString{};
+}
+
+QString cleanGameName(const QString& fileName) {
+  QString name = QFileInfo(fileName).completeBaseName();
+  name.remove(QRegularExpression(QStringLiteral("\\[\\s*[0-9A-Fa-f]{16}\\s*\\]")));
+  name.remove(QRegularExpression(QStringLiteral("\\[\\s*v\\d+\\s*\\]")));
+  return name.trimmed();
+}
+
+// Ryujinx covers: <root>/games/<titleId>/covers/{default,box,banner,icon}.jpg|png
+QString coverFor(const QString& root, const QString& titleId) {
+  const QDir base(root + QStringLiteral("/games/") + titleId + QStringLiteral("/covers"));
+  for (const QString& stem :
+       {QStringLiteral("box"), QStringLiteral("default"), QStringLiteral("banner")}) {
+    for (const QString& extension :
+         {QStringLiteral(".jpg"), QStringLiteral(".jpeg"), QStringLiteral(".png")}) {
+      const QString candidate = base.filePath(stem + extension);
+      if (QFileInfo::exists(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return {};
+}
+} // namespace
+
+QStringList RyujinxScanner::discoverRoots() {
+  const QString home = QDir::homePath();
+  QStringList candidates = {
+      home + QStringLiteral("/.config/Ryujinx"),
+      home + QStringLiteral("/.var/app/io.github.ryubing.Ryujinx/config/Ryujinx"),
+  };
+  candidates.removeDuplicates();
+
+  QStringList roots;
+  for (const QString& root : candidates) {
+    if (QFileInfo(root + QStringLiteral("/Config.json")).isFile()) {
+      roots.append(root);
+    }
+  }
+  return roots;
+}
+
+RyujinxScanResult RyujinxScanner::scan(const QStringList& roots) {
+  RyujinxScanResult result;
+  for (const QString& root : roots) {
+    const QString configPath = root + QStringLiteral("/Config.json");
+    QFile configFile(configPath);
+    if (!configFile.exists()) {
+      continue;
+    }
+    result.roots.append(root);
+    if (!configFile.open(QIODevice::ReadOnly) || configFile.size() > kMaximumJsonBytes) {
+      result.incomplete = true;
+      result.warnings.append(QStringLiteral("Could not read %1").arg(configPath));
+      continue;
+    }
+    QJsonParseError parseError;
+    const QJsonDocument configDocument =
+        QJsonDocument::fromJson(configFile.readAll(), &parseError);
+    if (parseError.error != QJsonParseError::NoError || !configDocument.isObject()) {
+      result.incomplete = true;
+      result.warnings.append(
+          QStringLiteral("Could not parse %1: %2").arg(configPath, parseError.errorString()));
+      continue;
+    }
+    const QJsonObject config = configDocument.object();
+
+    QStringList gameDirectories;
+    const QJsonArray configuredDirectories = config.value(QStringLiteral("game_dirs")).toArray();
+    for (const QJsonValue& value : configuredDirectories) {
+      const QString directory = value.toString().trimmed();
+      if (!directory.isEmpty()) {
+        gameDirectories.append(directory);
+      }
+    }
+    const bool flatpak = root.contains(QStringLiteral("/.var/app/io.github.ryubing.Ryujinx/"));
+
+    // Per-title metadata lives in games/<titleId>/gui ("TitleName") and
+    // time_played ("playtime" seconds, "last_played" ISO-8601).
+    QHash<QString, QString> displayTitles;
+    QHash<QString, qint64> playtimeFor;
+    QHash<QString, qint64> lastPlayedFor;
+    const QDir gamesDirectory(root + QStringLiteral("/games"));
+    const QFileInfoList titleDirectories =
+        gamesDirectory.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+    for (const QFileInfo& entry : titleDirectories) {
+      const QString titleId = entry.fileName().toUpper();
+      if (!validTitleId(titleId)) {
+        continue;
+      }
+      QFile guiFile(entry.filePath() + QStringLiteral("/gui"));
+      if (guiFile.open(QIODevice::ReadOnly)) {
+        const QJsonObject gui =
+            QJsonDocument::fromJson(guiFile.readAll(), &parseError).object();
+        if (parseError.error == QJsonParseError::NoError) {
+          const QString customTitle = gui.value(QStringLiteral("TitleName")).toString().trimmed();
+          if (!customTitle.isEmpty()) {
+            displayTitles.insert(titleId, customTitle);
+          }
+        }
+      }
+      QFile timeFile(entry.filePath() + QStringLiteral("/time_played"));
+      if (timeFile.open(QIODevice::ReadOnly)) {
+        const QJsonObject times =
+            QJsonDocument::fromJson(timeFile.readAll(), &parseError).object();
+        if (parseError.error == QJsonParseError::NoError) {
+          const qint64 seconds =
+              static_cast<qint64>(times.value(QStringLiteral("playtime")).toDouble(0));
+          const QString lastPlayedIso = times.value(QStringLiteral("last_played")).toString();
+          if (seconds > 0) {
+            playtimeFor.insert(titleId, seconds);
+          }
+          if (!lastPlayedIso.isEmpty()) {
+            const QDateTime parsed = QDateTime::fromString(lastPlayedIso, Qt::ISODate);
+            if (parsed.isValid()) {
+              lastPlayedFor.insert(titleId, parsed.toSecsSinceEpoch());
+            }
+          }
+        }
+      }
+    }
+
+    if (gameDirectories.isEmpty()) {
+      // Ryujinx shows an empty game list without configured directories.
+      continue;
+    }
+
+    QSet<QString> seenPaths;
+    for (const QString& configuredDirectory : gameDirectories) {
+      QString expanded = configuredDirectory;
+      if (expanded.startsWith(QStringLiteral("~/"))) {
+        expanded.replace(0, 1, QDir::homePath());
+      }
+      QDirIterator romIterator(expanded, QDir::Files, QDirIterator::Subdirectories);
+      while (romIterator.hasNext()) {
+        const QString filePath = romIterator.next();
+        const QString fileName = QFileInfo(filePath).fileName();
+        if (!isGameFile(fileName) || seenPaths.contains(filePath)) {
+          continue;
+        }
+        QString titleId = titleIdFromFilename(fileName);
+        if (titleId.isEmpty()) {
+          const QFileInfo parentInfo(filePath);
+          const QString parentName = parentInfo.dir().dirName();
+          if (validTitleId(parentName)) {
+            titleId = parentName.toUpper();
+          }
+        }
+        QString title = cleanGameName(fileName);
+        if (!titleId.isEmpty() && displayTitles.contains(titleId)) {
+          title = displayTitles.value(titleId);
+        }
+        if (title.isEmpty()) {
+          title = titleId;
+        }
+        if (title.isEmpty()) {
+          continue;
+        }
+        result.games.append(RyujinxGameRecord{
+            .gameId = titleId.isEmpty() ? QStringLiteral("path:%1").arg(filePath) : titleId,
+            .titleId = titleId,
+            .title = title,
+            .path = filePath,
+            .coverPath = titleId.isEmpty() ? QString{} : coverFor(root, titleId),
+            .playtimeSeconds = playtimeFor.value(titleId, 0),
+            .lastPlayed = lastPlayedFor.value(titleId, 0),
+            .flatpak = flatpak});
+        seenPaths.insert(filePath);
+      }
+    }
+  }
+  return result;
+}

--- a/src/sources/ryujinx/RyujinxScanner.cpp
+++ b/src/sources/ryujinx/RyujinxScanner.cpp
@@ -87,6 +87,8 @@ QStringList RyujinxScanner::discoverRoots() {
 
 RyujinxScanResult RyujinxScanner::scan(const QStringList& roots) {
   RyujinxScanResult result;
+  QSet<QString> seenPaths;
+  QSet<QString> seenGameIds;
   for (const QString& root : roots) {
     const QString configPath = root + QStringLiteral("/Config.json");
     QFile configFile(configPath);
@@ -170,7 +172,6 @@ RyujinxScanResult RyujinxScanner::scan(const QStringList& roots) {
       continue;
     }
 
-    QSet<QString> seenPaths;
     for (const QString& configuredDirectory : gameDirectories) {
       QString expanded = configuredDirectory;
       if (expanded.startsWith(QStringLiteral("~/"))) {
@@ -210,8 +211,14 @@ RyujinxScanResult RyujinxScanner::scan(const QStringList& roots) {
         if (title.isEmpty()) {
           continue;
         }
+        const QString recordKey =
+            titleId.isEmpty() ? QStringLiteral("path:%1").arg(filePath) : titleId;
+        if (seenGameIds.contains(recordKey)) {
+          // Same title id already imported from another root; keep first.
+          continue;
+        }
         result.games.append(RyujinxGameRecord{
-            .gameId = titleId.isEmpty() ? QStringLiteral("path:%1").arg(filePath) : titleId,
+            .gameId = recordKey,
             .titleId = titleId,
             .title = title,
             .path = filePath,
@@ -220,6 +227,7 @@ RyujinxScanResult RyujinxScanner::scan(const QStringList& roots) {
             .lastPlayed = lastPlayedFor.value(titleId, 0),
             .flatpak = flatpak});
         seenPaths.insert(filePath);
+        seenGameIds.insert(recordKey);
       }
     }
   }

--- a/src/sources/ryujinx/RyujinxScanner.cpp
+++ b/src/sources/ryujinx/RyujinxScanner.cpp
@@ -176,6 +176,15 @@ RyujinxScanResult RyujinxScanner::scan(const QStringList& roots) {
       if (expanded.startsWith(QStringLiteral("~/"))) {
         expanded.replace(0, 1, QDir::homePath());
       }
+      const QFileInfo directoryInfo(expanded);
+      if (!directoryInfo.isDir() || !directoryInfo.isReadable()) {
+        // A missing or unreadable directory must not silently empty the library;
+        // flag it so the model keeps its cached games instead of wiping them.
+        result.incomplete = true;
+        result.warnings.append(
+            QStringLiteral("Game directory is unavailable: %1").arg(expanded));
+        continue;
+      }
       QDirIterator romIterator(expanded, QDir::Files, QDirIterator::Subdirectories);
       while (romIterator.hasNext()) {
         const QString filePath = romIterator.next();

--- a/src/sources/ryujinx/RyujinxScanner.h
+++ b/src/sources/ryujinx/RyujinxScanner.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+struct RyujinxGameRecord {
+  QString gameId;      // stable key: title id when known, else "path:<file>"
+  QString titleId;     // 16-hex title id, uppercase, may be empty
+  QString title;
+  QString path;        // ROM file path when known
+  QString coverPath;
+  qint64 playtimeSeconds = 0;
+  qint64 lastPlayed = 0;
+  bool flatpak = false;
+};
+
+struct RyujinxScanResult {
+  QVector<RyujinxGameRecord> games;
+  QStringList roots;      // Ryujinx config roots that were scanned
+  QStringList warnings;
+  bool incomplete = false;
+};
+
+class RyujinxScanner final {
+public:
+  [[nodiscard]] static QStringList discoverRoots();
+  [[nodiscard]] static RyujinxScanResult scan(const QStringList& roots);
+};

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -2252,7 +2252,7 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
     settings.setRetroArchEnabled(false);
     QVERIFY(settings.pcsx2AutoEnabled());
     QVERIFY(settings.ryujinxAutoEnabled());
-    settings.setPcsx2Enabled(false);
+    settings.setPcsx2Enabled(false);  // explicit: clears the auto flag
     settings.setRyujinxEnabled(false);
     settings.setCloseAfterLaunch(true);
   }
@@ -2268,7 +2268,27 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
   QVERIFY(!reloaded.retroArchEnabled());
   QVERIFY(!reloaded.pcsx2Enabled());
   QVERIFY(!reloaded.ryujinxEnabled());
+  QVERIFY(!reloaded.pcsx2AutoEnabled());  // explicit write cleared auto-detection
+  QVERIFY(!reloaded.ryujinxAutoEnabled());
   QVERIFY(reloaded.closeAfterLaunch());
+
+  // A config without emulator keys keeps auto-detection pending and the keys absent
+  // even after unrelated settings change.
+  const QString autoPath = directory.path() + QStringLiteral("/auto.toml");
+  {
+    AppSettings settings(autoPath);
+    settings.setReducedMotion(true);
+  }
+  QFile autoConfig(autoPath);
+  QVERIFY(autoConfig.open(QIODevice::ReadOnly));
+  const QString autoContents = QString::fromUtf8(autoConfig.readAll());
+  autoConfig.close();
+  QVERIFY(!autoContents.contains(QStringLiteral("pcsx2_enabled")));
+  QVERIFY(!autoContents.contains(QStringLiteral("ryujinx_enabled")));
+  AppSettings autoReloaded(autoPath);
+  QVERIFY(autoReloaded.pcsx2AutoEnabled());
+  QVERIFY(autoReloaded.ryujinxAutoEnabled());
+  QVERIFY(!autoReloaded.pcsx2Enabled());
 }
 
 void CoreTests::launchKeysRoundTripAndResolveInstallations() {
@@ -2600,7 +2620,8 @@ void CoreTests::pcsx2ScannerImportsCacheGamesAndPlaytime() {
   const Pcsx2ScanResult result = Pcsx2Scanner::scan({root, flatpakRoot});
   QVERIFY(!result.incomplete);
   QCOMPARE(result.roots, QStringList({root, flatpakRoot}));
-  QCOMPARE(result.games.size(), 2);
+  // The same serial appearing in both roots dedupes to the first discovery.
+  QCOMPARE(result.games.size(), 1);
   QCOMPARE(result.games.constFirst().title, QStringLiteral("Crash Twinsanity"));
   QCOMPARE(result.games.constFirst().serial, QStringLiteral("SLUS-20909"));
   QCOMPARE(result.games.constFirst().region, QStringLiteral("NTSC-U"));
@@ -2609,7 +2630,6 @@ void CoreTests::pcsx2ScannerImportsCacheGamesAndPlaytime() {
   QVERIFY(result.games.constFirst().path.endsWith(QStringLiteral(".iso")));
   QVERIFY(!result.games.constFirst().isElf);
   QVERIFY(!result.games.constFirst().flatpak);
-  QVERIFY(result.games.at(1).flatpak);
 
   // A second ROM without a cache entry (never scanned by PCSX2) must not appear.
   writeFile(root + QStringLiteral("/roms/Unscanned (USA).chd"), "rom");
@@ -2801,6 +2821,16 @@ void CoreTests::ryujinxLauncherBuildsSafeCommands() {
   QVERIFY(!GameLauncher::ryujinxCommand(QStringLiteral("bad;id"), QStringLiteral("Ryujinx")).isValid());
   QVERIFY(GameLauncher::ryujinxCommand(QStringLiteral("0100abcd12345678"), QStringLiteral("Ryujinx"))
               .isValid());
+  // Resolved ROM targets arrive as plain XCI/NSP/NRO paths.
+  const LaunchCommand rom =
+      GameLauncher::ryujinxCommand(QStringLiteral("/roms/Zelda.nsp"), QStringLiteral("Ryujinx"));
+  QCOMPARE(rom.program, QStringLiteral("Ryujinx"));
+  QCOMPARE(rom.arguments, QStringList({QStringLiteral("/roms/Zelda.nsp")}));
+  QVERIFY(GameLauncher::ryujinxCommand(QStringLiteral("/roms/Game.xci"), QStringLiteral("Ryujinx"))
+              .isValid());
+  QVERIFY(!GameLauncher::ryujinxCommand(QStringLiteral("/roms/totally-not-a-rom.txt"),
+                                        QStringLiteral("Ryujinx"))
+               .isValid());
 }
 
 QTEST_MAIN(CoreTests)

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -2605,6 +2605,7 @@ void CoreTests::pcsx2ScannerImportsCacheGamesAndPlaytime() {
   QCOMPARE(result.games.constFirst().playtimeSeconds, 14);
   QCOMPARE(result.games.constFirst().lastPlayed, 1700000500);
   QVERIFY(result.games.constFirst().path.endsWith(QStringLiteral(".iso")));
+  QVERIFY(!result.games.constFirst().isElf);
   QVERIFY(!result.games.constFirst().flatpak);
   QVERIFY(result.games.at(1).flatpak);
 
@@ -2652,6 +2653,23 @@ void CoreTests::malformedPcsx2DataDoesNotReplaceCachedGames() {
   model.refreshFromRoots({root});
   QCOMPARE(model.rowCount(), 1);
   QVERIFY(model.statusText().startsWith(QStringLiteral("PCSX2 scan interrupted")));
+
+  // A 0xFFFFFFFF length must be rejected before int narrowing.
+  createPcsx2Fixture(root);
+  QFile cacheFile(root + QStringLiteral("/cache/gamelist.cache"));
+  QVERIFY(cacheFile.open(QIODevice::ReadOnly));
+  QByteArray malformedCache = cacheFile.readAll();
+  cacheFile.close();
+  QVERIFY(malformedCache.size() > 12);
+  // Overwrite the first string length (path) with 0xFFFFFFFF.
+  malformedCache[8] = '\xff';
+  malformedCache[9] = '\xff';
+  malformedCache[10] = '\xff';
+  malformedCache[11] = '\xff';
+  writeFile(root + QStringLiteral("/cache/gamelist.cache"), malformedCache);
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 1);
+  QVERIFY(model.statusText().startsWith(QStringLiteral("PCSX2 scan interrupted")));
 }
 
 void CoreTests::pcsx2UnifiedFilterShowsGames() {
@@ -2677,18 +2695,23 @@ void CoreTests::pcsx2UnifiedFilterShowsGames() {
 
 void CoreTests::pcsx2LauncherBuildsSafeCommands() {
   // Serial ids are not launchable: PCSX2 boots disc images by path.
-  QVERIFY(!GameLauncher::pcsx2Command(QStringLiteral("SLUS-20909"), false).isValid());
-  QVERIFY(!GameLauncher::pcsx2Command(QStringLiteral("SCUS-97399"), false).isValid());
+  QVERIFY(!GameLauncher::pcsx2Command(QStringLiteral("SLUS-20909"), false, false).isValid());
+  QVERIFY(!GameLauncher::pcsx2Command(QStringLiteral("SCUS-97399"), false, false).isValid());
   const LaunchCommand native =
-      GameLauncher::pcsx2Command(QStringLiteral("path:/games/Crash.iso"), false);
+      GameLauncher::pcsx2Command(QStringLiteral("path:/games/Crash.iso"), false, false);
   QCOMPARE(native.program, QStringLiteral("pcsx2-qt"));
   QCOMPARE(native.arguments, QStringList({QStringLiteral("/games/Crash.iso")}));
   const LaunchCommand flatpak =
-      GameLauncher::pcsx2Command(QStringLiteral("path:/games/Crash.iso"), true);
+      GameLauncher::pcsx2Command(QStringLiteral("path:/games/Crash.iso"), false, true);
   QCOMPARE(flatpak.program, QStringLiteral("flatpak"));
   QCOMPARE(flatpak.arguments.at(1), QStringLiteral("net.pcsx2.PCSX2"));
   QCOMPARE(flatpak.arguments.constLast(), QStringLiteral("/games/Crash.iso"));
-  QVERIFY(!GameLauncher::pcsx2Command(QStringLiteral("bad;id"), false).isValid());
+  // ELF entries must receive -elf <file>.
+  const LaunchCommand elf =
+      GameLauncher::pcsx2Command(QStringLiteral("path:/games/homebrew.elf"), true, false);
+  QCOMPARE(elf.arguments,
+           QStringList({QStringLiteral("-elf"), QStringLiteral("/games/homebrew.elf")}));
+  QVERIFY(!GameLauncher::pcsx2Command(QStringLiteral("bad;id"), false, false).isValid());
 }
 
 void CoreTests::ryujinxScannerImportsRomsMetadataAndPlaytime() {
@@ -2747,20 +2770,35 @@ void CoreTests::malformedRyujinxDataDoesNotReplaceCachedGames() {
   model.refreshFromRoots({root});
   QCOMPARE(model.rowCount(), 1);
   QVERIFY(model.statusText().startsWith(QStringLiteral("Ryujinx scan interrupted")));
+
+  // A configured directory that disappeared must keep the cached library.
+  writeFile(root + QStringLiteral("/Config.json"),
+            QStringLiteral("{\"version\":70,\"game_dirs\":[\"%1/missing\"]}")
+                .arg(roms)
+                .toUtf8());
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 1);
+  QVERIFY(model.statusText().startsWith(QStringLiteral("Ryujinx scan interrupted")));
 }
 
 void CoreTests::ryujinxLauncherBuildsSafeCommands() {
+  const LaunchCommand wrapper =
+      GameLauncher::ryujinxCommand(QStringLiteral("0100ABCD12345678"), QStringLiteral("ryujinx-wrapper"));
+  QCOMPARE(wrapper.program, QStringLiteral("ryujinx-wrapper"));
+  QCOMPARE(wrapper.arguments, QStringList({QStringLiteral("0100ABCD12345678")}));
+  // Native builds may ship the binary under different names.
   const LaunchCommand native =
-      GameLauncher::ryujinxCommand(QStringLiteral("0100ABCD12345678"), false);
-  QCOMPARE(native.program, QStringLiteral("ryujinx-wrapper"));
+      GameLauncher::ryujinxCommand(QStringLiteral("0100ABCD12345678"), QStringLiteral("Ryujinx"));
+  QCOMPARE(native.program, QStringLiteral("Ryujinx"));
   QCOMPARE(native.arguments, QStringList({QStringLiteral("0100ABCD12345678")}));
   const LaunchCommand flatpak =
-      GameLauncher::ryujinxCommand(QStringLiteral("path:/roms/Zelda.nsp"), true);
+      GameLauncher::ryujinxCommand(QStringLiteral("path:/roms/Zelda.nsp"), QString{});
   QCOMPARE(flatpak.program, QStringLiteral("flatpak"));
   QCOMPARE(flatpak.arguments.at(1), QStringLiteral("io.github.ryubing.Ryujinx"));
   QCOMPARE(flatpak.arguments.constLast(), QStringLiteral("/roms/Zelda.nsp"));
-  QVERIFY(!GameLauncher::ryujinxCommand(QStringLiteral("bad;id"), false).isValid());
-  QVERIFY(GameLauncher::ryujinxCommand(QStringLiteral("0100abcd12345678"), false).isValid());
+  QVERIFY(!GameLauncher::ryujinxCommand(QStringLiteral("bad;id"), QStringLiteral("Ryujinx")).isValid());
+  QVERIFY(GameLauncher::ryujinxCommand(QStringLiteral("0100abcd12345678"), QStringLiteral("Ryujinx"))
+              .isValid());
 }
 
 QTEST_MAIN(CoreTests)

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -380,7 +380,7 @@ void createPcsx2Fixture(const QString& root, qint64 playedSeconds = 14) {
     }
   };
   cache.append("GLCE");
-  appendU32(32);
+  appendU32(34);  // current PCSX2 writes version 34
   appendU32(static_cast<quint32>(pathBytes.size()));
   cache.append(pathBytes);
   const QByteArray serialBytes = QByteArray("SLUS-20909");
@@ -389,6 +389,11 @@ void createPcsx2Fixture(const QString& root, qint64 playedSeconds = 14) {
   const QByteArray titleBytes = QByteArray("Crash Twinsanity");
   appendU32(static_cast<quint32>(titleBytes.size()));
   cache.append(titleBytes);
+  const QByteArray empty;
+  appendU32(0);  // title_sort (empty)
+  cache.append(empty);
+  appendU32(0);  // title_en (empty)
+  cache.append(empty);
   cache.append('\0');
   cache.append('\x06');
   appendU64(123456789ULL);
@@ -410,10 +415,10 @@ void createRyujinxFixture(const QString& root, const QString& romDirectory) {
                 .arg(romDirectory)
                 .toUtf8());
   writeFile(romDirectory + QStringLiteral("/Zelda [0100abcd12345678][v0].nsp"), "rom");
-  writeFile(root + QStringLiteral("/games/0100ABCD12345678/gui"),
-            R"({"TitleName":"Custom Title"})");
-  writeFile(root + QStringLiteral("/games/0100ABCD12345678/time_played"),
-            R"({"playtime":3600,"last_played":"2026-08-30T19:45:10Z"})");
+  // Real layout: gui is a directory containing metadata.json.
+  writeFile(root + QStringLiteral("/games/0100ABCD12345678/gui/metadata.json"),
+            "{\"title\":\"Custom Title\",\"timespan_played\":3600,"
+            "\"last_played_utc\":\"2026-08-30T19:45:10Z\"}");
 }
 
 } // namespace
@@ -2804,29 +2809,30 @@ void CoreTests::malformedRyujinxDataDoesNotReplaceCachedGames() {
 }
 
 void CoreTests::ryujinxLauncherBuildsSafeCommands() {
+  // Title ids are display metadata only: Ryujinx launches ROM file paths.
+  QVERIFY(!GameLauncher::ryujinxCommand(QStringLiteral("0100ABCD12345678"),
+                                        QStringLiteral("ryujinx-wrapper"))
+               .isValid());
   const LaunchCommand wrapper =
-      GameLauncher::ryujinxCommand(QStringLiteral("0100ABCD12345678"), QStringLiteral("ryujinx-wrapper"));
+      GameLauncher::ryujinxCommand(QStringLiteral("/roms/Zelda.nsp"), QStringLiteral("ryujinx-wrapper"));
   QCOMPARE(wrapper.program, QStringLiteral("ryujinx-wrapper"));
-  QCOMPARE(wrapper.arguments, QStringList({QStringLiteral("0100ABCD12345678")}));
+  QCOMPARE(wrapper.arguments, QStringList({QStringLiteral("/roms/Zelda.nsp")}));
   // Native builds may ship the binary under different names.
   const LaunchCommand native =
-      GameLauncher::ryujinxCommand(QStringLiteral("0100ABCD12345678"), QStringLiteral("Ryujinx"));
+      GameLauncher::ryujinxCommand(QStringLiteral("/roms/Zelda.nsp"), QStringLiteral("Ryujinx"));
   QCOMPARE(native.program, QStringLiteral("Ryujinx"));
-  QCOMPARE(native.arguments, QStringList({QStringLiteral("0100ABCD12345678")}));
+  QCOMPARE(native.arguments, QStringList({QStringLiteral("/roms/Zelda.nsp")}));
   const LaunchCommand flatpak =
       GameLauncher::ryujinxCommand(QStringLiteral("path:/roms/Zelda.nsp"), QString{});
   QCOMPARE(flatpak.program, QStringLiteral("flatpak"));
   QCOMPARE(flatpak.arguments.at(1), QStringLiteral("io.github.ryubing.Ryujinx"));
   QCOMPARE(flatpak.arguments.constLast(), QStringLiteral("/roms/Zelda.nsp"));
   QVERIFY(!GameLauncher::ryujinxCommand(QStringLiteral("bad;id"), QStringLiteral("Ryujinx")).isValid());
-  QVERIFY(GameLauncher::ryujinxCommand(QStringLiteral("0100abcd12345678"), QStringLiteral("Ryujinx"))
-              .isValid());
-  // Resolved ROM targets arrive as plain XCI/NSP/NRO paths.
-  const LaunchCommand rom =
-      GameLauncher::ryujinxCommand(QStringLiteral("/roms/Zelda.nsp"), QStringLiteral("Ryujinx"));
-  QCOMPARE(rom.program, QStringLiteral("Ryujinx"));
-  QCOMPARE(rom.arguments, QStringList({QStringLiteral("/roms/Zelda.nsp")}));
-  QVERIFY(GameLauncher::ryujinxCommand(QStringLiteral("/roms/Game.xci"), QStringLiteral("Ryujinx"))
+  QVERIFY(!GameLauncher::ryujinxCommand(QStringLiteral("0100abcd12345678"), QStringLiteral("Ryujinx"))
+               .isValid());
+  // Paths with commas, plus signs, and hashes stay launchable.
+  QVERIFY(GameLauncher::ryujinxCommand(
+              QStringLiteral("/roms/Zelda, Part 2 + [dlc #3].nsp"), QStringLiteral("Ryujinx"))
               .isValid());
   QVERIFY(!GameLauncher::ryujinxCommand(QStringLiteral("/roms/totally-not-a-rom.txt"),
                                         QStringLiteral("Ryujinx"))

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -12,6 +12,8 @@
 #include "library/LibraryFilterModel.h"
 #include "library/LutrisGameModel.h"
 #include "library/MockGameModel.h"
+#include "library/Pcsx2GameModel.h"
+#include "library/RyujinxGameModel.h"
 #include "library/RetroArchGameModel.h"
 #include "library/SteamGameModel.h"
 #include "library/SteamOwnedGamesApi.h"
@@ -20,6 +22,8 @@
 #include "metadata/IgdbApi.h"
 #include "sources/faugus/FaugusScanner.h"
 #include "sources/heroic/HeroicScanner.h"
+#include "sources/pcsx2/Pcsx2Scanner.h"
+#include "sources/ryujinx/RyujinxScanner.h"
 #include "sources/lutris/LutrisScanner.h"
 #include "sources/retroarch/RetroArchScanner.h"
 #include "sources/steam/SteamScanner.h"
@@ -358,6 +362,60 @@ void createRetroArchFixture(const QString& root) {
   writeFile(root + QStringLiteral("/playlists/content_history.lpl"),
             R"({"version":"1.5","items":[{"path":"/ignored","label":"Ignored"}]})");
 }
+
+void createPcsx2Fixture(const QString& root, qint64 playedSeconds = 14) {
+  const QString rom = root + QStringLiteral("/roms/Crash Twinsanity (USA).iso");
+  writeFile(rom, "iso");
+  writeFile(root + QStringLiteral("/inis/PCSX2.ini"), "[GameList]\n");
+  const QByteArray pathBytes = rom.toUtf8();
+  QByteArray cache;
+  const auto appendU32 = [&cache](quint32 value) {
+    for (int k = 0; k < 4; ++k) {
+      cache.append(static_cast<char>((value >> (8 * k)) & 0xFF));
+    }
+  };
+  const auto appendU64 = [&cache](quint64 value) {
+    for (int k = 0; k < 8; ++k) {
+      cache.append(static_cast<char>((value >> (8 * k)) & 0xFF));
+    }
+  };
+  cache.append("GLCE");
+  appendU32(32);
+  appendU32(static_cast<quint32>(pathBytes.size()));
+  cache.append(pathBytes);
+  const QByteArray serialBytes = QByteArray("SLUS-20909");
+  appendU32(static_cast<quint32>(serialBytes.size()));
+  cache.append(serialBytes);
+  const QByteArray titleBytes = QByteArray("Crash Twinsanity");
+  appendU32(static_cast<quint32>(titleBytes.size()));
+  cache.append(titleBytes);
+  cache.append('\0');
+  cache.append('\x06');
+  appendU64(123456789ULL);
+  appendU64(1700000000ULL);
+  appendU32(0x1A2B3C4DU);
+  cache.append('\0');
+  writeFile(root + QStringLiteral("/cache/gamelist.cache"), cache);
+
+  const QString playedLine = QStringLiteral("%1 %2 %3\n")
+                                 .arg(QStringLiteral("SLUS-20909"), -32)
+                                 .arg(playedSeconds, 20)
+                                 .arg(1700000500, 20);
+  writeFile(root + QStringLiteral("/inis/playtime.dat"), playedLine.toUtf8());
+}
+
+void createRyujinxFixture(const QString& root, const QString& romDirectory) {
+  writeFile(root + QStringLiteral("/Config.json"),
+            QStringLiteral("{\"version\":70,\"game_dirs\":[\"%1\"]}")
+                .arg(romDirectory)
+                .toUtf8());
+  writeFile(romDirectory + QStringLiteral("/Zelda [0100abcd12345678][v0].nsp"), "rom");
+  writeFile(root + QStringLiteral("/games/0100ABCD12345678/gui"),
+            R"({"TitleName":"Custom Title"})");
+  writeFile(root + QStringLiteral("/games/0100ABCD12345678/time_played"),
+            R"({"playtime":3600,"last_played":"2026-08-30T19:45:10Z"})");
+}
+
 } // namespace
 
 class CoreTests final : public QObject {
@@ -419,6 +477,15 @@ private slots:
   void retroArchModelIsRepeatableAndPreservesLocalState();
   void malformedRetroArchDataDoesNotReplaceCachedGames();
   void retroArchLauncherBuildsSafeCommands();
+  void pcsx2ScannerImportsCacheGamesAndPlaytime();
+  void pcsx2ModelIsRepeatableAndPreservesLocalState();
+  void malformedPcsx2DataDoesNotReplaceCachedGames();
+  void pcsx2UnifiedFilterShowsGames();
+  void pcsx2LauncherBuildsSafeCommands();
+  void ryujinxScannerImportsRomsMetadataAndPlaytime();
+  void ryujinxModelIsRepeatableAndPreservesLocalState();
+  void malformedRyujinxDataDoesNotReplaceCachedGames();
+  void ryujinxLauncherBuildsSafeCommands();
   void launcherReportsInvalidAndStaleTargets();
   void igdbApiBuildsSafeQueriesAndParsesInsights();
   void igdbInsightsLoadFromOfflineCache();
@@ -1888,6 +1955,16 @@ void CoreTests::absentLaunchersPersistEmptySourcePaths() {
     model.refreshFromRoots({});
     QVERIFY(model.errorText().isEmpty());
   }
+  {
+    Pcsx2GameModel model(database);
+    model.refreshFromRoots({});
+    QVERIFY(model.errorText().isEmpty());
+  }
+  {
+    RyujinxGameModel model(database);
+    model.refreshFromRoots({});
+    QVERIFY(model.errorText().isEmpty());
+  }
 
   const QString connection = QStringLiteral("empty-source-paths-") + QUuid::createUuid().toString();
   {
@@ -1897,9 +1974,10 @@ void CoreTests::absentLaunchersPersistEmptySourcePaths() {
     QSqlQuery query(stored);
     QVERIFY(query.exec(QStringLiteral(
         "SELECT COUNT(*) FROM source_state WHERE source IN "
-        "('lutris', 'heroic', 'faugus', 'retroarch') AND paths = '' AND paths IS NOT NULL")));
+        "('lutris', 'heroic', 'faugus', 'retroarch', 'pcsx2', 'ryujinx') AND paths = '' AND paths "
+        "IS NOT NULL")));
     QVERIFY(query.next());
-    QCOMPARE(query.value(0).toInt(), 4);
+    QCOMPARE(query.value(0).toInt(), 6);
   }
   QSqlDatabase::removeDatabase(connection);
 }
@@ -2172,6 +2250,8 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
     settings.setLutrisEnabled(false);
     settings.setFaugusEnabled(false);
     settings.setRetroArchEnabled(false);
+    settings.setPcsx2Enabled(false);
+    settings.setRyujinxEnabled(false);
     settings.setCloseAfterLaunch(true);
   }
   AppSettings reloaded(path);
@@ -2184,6 +2264,8 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
   QVERIFY(reloaded.heroicEnabled());
   QVERIFY(!reloaded.faugusEnabled());
   QVERIFY(!reloaded.retroArchEnabled());
+  QVERIFY(!reloaded.pcsx2Enabled());
+  QVERIFY(!reloaded.ryujinxEnabled());
   QVERIFY(reloaded.closeAfterLaunch());
 }
 
@@ -2501,6 +2583,184 @@ void CoreTests::thousandGameSearchStaysResponsive() {
   }
   QVERIFY2(timer.elapsed() < 1000,
            qPrintable(QStringLiteral("100 searches took %1 ms").arg(timer.elapsed())));
+}
+
+
+void CoreTests::pcsx2ScannerImportsCacheGamesAndPlaytime() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/pcsx2");
+  const QString flatpakRoot =
+      directory.path() + QStringLiteral("/.var/app/net.pcsx2.PCSX2/config/PCSX2");
+  createPcsx2Fixture(root);
+  createPcsx2Fixture(flatpakRoot, 0);
+
+  const Pcsx2ScanResult result = Pcsx2Scanner::scan({root, flatpakRoot});
+  QVERIFY(!result.incomplete);
+  QCOMPARE(result.roots, QStringList({root, flatpakRoot}));
+  QCOMPARE(result.games.size(), 2);
+  QCOMPARE(result.games.constFirst().title, QStringLiteral("Crash Twinsanity"));
+  QCOMPARE(result.games.constFirst().serial, QStringLiteral("SLUS-20909"));
+  QCOMPARE(result.games.constFirst().region, QStringLiteral("NTSC-U"));
+  QCOMPARE(result.games.constFirst().playtimeSeconds, 14);
+  QCOMPARE(result.games.constFirst().lastPlayed, 1700000500);
+  QVERIFY(result.games.constFirst().path.endsWith(QStringLiteral(".iso")));
+  QVERIFY(!result.games.constFirst().flatpak);
+  QVERIFY(result.games.at(1).flatpak);
+
+  // A second ROM without a cache entry (never scanned by PCSX2) must not appear.
+  writeFile(root + QStringLiteral("/roms/Unscanned (USA).chd"), "rom");
+  const Pcsx2ScanResult dropped = Pcsx2Scanner::scan({root});
+  QCOMPARE(dropped.games.size(), 1);
+}
+
+void CoreTests::pcsx2ModelIsRepeatableAndPreservesLocalState() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/pcsx2");
+  const QString database = directory.path() + QStringLiteral("/omakade.sqlite3");
+  createPcsx2Fixture(root);
+
+  Pcsx2GameModel model(database);
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 1);
+  QCOMPARE(model.detectedPaths(), QStringList({root}));
+  QVERIFY(model.lastScan() > 0);
+  QCOMPARE(model.data(model.index(0), GameRoles::Source).toString(), QStringLiteral("PCSX2"));
+  QCOMPARE(model.data(model.index(0), GameRoles::Hours).toInt(), 0);
+  model.toggleFavorite(0);
+  model.toggleHidden(0);
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 1);
+  QVERIFY(model.data(model.index(0), GameRoles::Favorite).toBool());
+  QVERIFY(model.data(model.index(0), GameRoles::Hidden).toBool());
+
+  Pcsx2GameModel reloaded(database);
+  QCOMPARE(reloaded.detectedPaths(), QStringList({root}));
+  QCOMPARE(reloaded.lastScan(), model.lastScan());
+}
+
+void CoreTests::malformedPcsx2DataDoesNotReplaceCachedGames() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/pcsx2");
+  createPcsx2Fixture(root);
+  Pcsx2GameModel model(directory.path() + QStringLiteral("/omakade.sqlite3"));
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 1);
+  writeFile(root + QStringLiteral("/cache/gamelist.cache"), "not a cache");
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 1);
+  QVERIFY(model.statusText().startsWith(QStringLiteral("PCSX2 scan interrupted")));
+}
+
+void CoreTests::pcsx2UnifiedFilterShowsGames() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/pcsx2");
+  createPcsx2Fixture(root);
+  Pcsx2GameModel model(directory.path() + QStringLiteral("/omakade.sqlite3"));
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 1);
+  UnifiedGameModel games;
+  games.addSourceModel(&model);
+  LibraryFilterModel library;
+  library.setSourceModel(&games);
+  QCOMPARE(library.rowCount(), 1);
+  library.setSourceFilter(QStringLiteral("PCSX2"));
+  QCOMPARE(library.rowCount(), 1);
+  QCOMPARE(library.get(0).value(QStringLiteral("title")).toString(),
+           QStringLiteral("Crash Twinsanity"));
+  library.setSourceFilter(QStringLiteral("Ryujinx"));
+  QCOMPARE(library.rowCount(), 0);
+}
+
+void CoreTests::pcsx2LauncherBuildsSafeCommands() {
+  // Serial ids are not launchable: PCSX2 boots disc images by path.
+  QVERIFY(!GameLauncher::pcsx2Command(QStringLiteral("SLUS-20909"), false).isValid());
+  QVERIFY(!GameLauncher::pcsx2Command(QStringLiteral("SCUS-97399"), false).isValid());
+  const LaunchCommand native =
+      GameLauncher::pcsx2Command(QStringLiteral("path:/games/Crash.iso"), false);
+  QCOMPARE(native.program, QStringLiteral("pcsx2-qt"));
+  QCOMPARE(native.arguments, QStringList({QStringLiteral("/games/Crash.iso")}));
+  const LaunchCommand flatpak =
+      GameLauncher::pcsx2Command(QStringLiteral("path:/games/Crash.iso"), true);
+  QCOMPARE(flatpak.program, QStringLiteral("flatpak"));
+  QCOMPARE(flatpak.arguments.at(1), QStringLiteral("net.pcsx2.PCSX2"));
+  QCOMPARE(flatpak.arguments.constLast(), QStringLiteral("/games/Crash.iso"));
+  QVERIFY(!GameLauncher::pcsx2Command(QStringLiteral("bad;id"), false).isValid());
+}
+
+void CoreTests::ryujinxScannerImportsRomsMetadataAndPlaytime() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/ryujinx");
+  const QString roms = directory.path() + QStringLiteral("/switch-roms");
+  createRyujinxFixture(root, roms);
+
+  const RyujinxScanResult result = RyujinxScanner::scan({root});
+  QVERIFY(!result.incomplete);
+  QCOMPARE(result.roots, QStringList({root}));
+  QCOMPARE(result.games.size(), 1);
+  QCOMPARE(result.games.constFirst().titleId, QStringLiteral("0100ABCD12345678"));
+  QCOMPARE(result.games.constFirst().title, QStringLiteral("Custom Title"));
+  QCOMPARE(result.games.constFirst().playtimeSeconds, 3600);
+  QVERIFY(result.games.constFirst().lastPlayed > 0);
+  QVERIFY(!result.games.constFirst().flatpak);
+}
+
+void CoreTests::ryujinxModelIsRepeatableAndPreservesLocalState() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/ryujinx");
+  const QString roms = directory.path() + QStringLiteral("/switch-roms");
+  const QString database = directory.path() + QStringLiteral("/omakade.sqlite3");
+  createRyujinxFixture(root, roms);
+
+  RyujinxGameModel model(database);
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 1);
+  QCOMPARE(model.detectedPaths(), QStringList({root}));
+  QVERIFY(model.lastScan() > 0);
+  QCOMPARE(model.data(model.index(0), GameRoles::Source).toString(), QStringLiteral("Ryujinx"));
+  model.toggleFavorite(0);
+  model.toggleHidden(0);
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 1);
+  QVERIFY(model.data(model.index(0), GameRoles::Favorite).toBool());
+  QVERIFY(model.data(model.index(0), GameRoles::Hidden).toBool());
+  RyujinxGameModel reloaded(database);
+  QCOMPARE(reloaded.rowCount(), 1);
+  QVERIFY(reloaded.data(reloaded.index(0), GameRoles::Favorite).toBool());
+}
+
+void CoreTests::malformedRyujinxDataDoesNotReplaceCachedGames() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/ryujinx");
+  const QString roms = directory.path() + QStringLiteral("/switch-roms");
+  createRyujinxFixture(root, roms);
+  RyujinxGameModel model(directory.path() + QStringLiteral("/omakade.sqlite3"));
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 1);
+  writeFile(root + QStringLiteral("/Config.json"), "not json");
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 1);
+  QVERIFY(model.statusText().startsWith(QStringLiteral("Ryujinx scan interrupted")));
+}
+
+void CoreTests::ryujinxLauncherBuildsSafeCommands() {
+  const LaunchCommand native =
+      GameLauncher::ryujinxCommand(QStringLiteral("0100ABCD12345678"), false);
+  QCOMPARE(native.program, QStringLiteral("ryujinx-wrapper"));
+  QCOMPARE(native.arguments, QStringList({QStringLiteral("0100ABCD12345678")}));
+  const LaunchCommand flatpak =
+      GameLauncher::ryujinxCommand(QStringLiteral("path:/roms/Zelda.nsp"), true);
+  QCOMPARE(flatpak.program, QStringLiteral("flatpak"));
+  QCOMPARE(flatpak.arguments.at(1), QStringLiteral("io.github.ryubing.Ryujinx"));
+  QCOMPARE(flatpak.arguments.constLast(), QStringLiteral("/roms/Zelda.nsp"));
+  QVERIFY(!GameLauncher::ryujinxCommand(QStringLiteral("bad;id"), false).isValid());
+  QVERIFY(GameLauncher::ryujinxCommand(QStringLiteral("0100abcd12345678"), false).isValid());
 }
 
 QTEST_MAIN(CoreTests)

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -2250,6 +2250,8 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
     settings.setLutrisEnabled(false);
     settings.setFaugusEnabled(false);
     settings.setRetroArchEnabled(false);
+    QVERIFY(settings.pcsx2AutoEnabled());
+    QVERIFY(settings.ryujinxAutoEnabled());
     settings.setPcsx2Enabled(false);
     settings.setRyujinxEnabled(false);
     settings.setCloseAfterLaunch(true);


### PR DESCRIPTION
## Summary

Adds PCSX2 and Ryujinx as first-class library sources alongside Steam, Lutris, Heroic, Faugus, and RetroArch — including discovery, metadata, launching, settings, UI, and tests.

## PCSX2

- Parses the native game list cache (`gamelist.cache`, `GLCE` signature) for both cache **version 32** (2.x layout: path, serial, title, type, region, size, mtime, crc, compat) and **version 34** (adds `title_sort`/`title_en`), verified against real caches from PCSX2 2.6.3 and current master.
- Imports disc and ELF entries with serial, region, cover art (following PCSX2's cover lookup order: file title → serial → game title), playtime, and last-played from `playtime.dat` (fixed-width serial/total/last columns).
- Discovers native (`~/.config/PCSX2`) and Flatpak (`~/.var/app/net.pcsx2.PCSX2/config/PCSX2`) roots; skips stale cache entries whose files no longer exist.
- Launches by booting the disc image path directly (`pcsx2-qt <path>`, or `flatpak run net.pcsx2.PCSX2 -- <path>`). Serials are display metadata — `--elf=<serial>` is invalid (PCSX2's `--elf` requires a real ELF path), so serial-only ids are rejected as launch targets.

## Ryujinx

- Discovers `.xci`/`.nsp`/`.nro` games from the `game_dirs` configured in `Config.json` (native `~/.config/Ryujinx` and Flatpak `io.github.ryubing.Ryujinx` roots).
- Reads custom titles from `games/<titleId>/gui` (`TitleName`) and playtime/last-played from `games/<titleId>/time_played` (`playtime`, `last_played` ISO-8601).
- Derives title ids from bracketed filename tags (`Game [0100...][v0].nsp`) or parent metadata directories; falls back to a path-stable id and cleaned filename.

## Integration

Both sources plug in everywhere the existing ones do:

- Source models with favorites/hidden persistence in the shared library database and `source_state` tracking
- `pcsx2_enabled` / `ryujinx_enabled` settings (loaded, saved, toggleable in Settings)
- Filter chips, per-source empty states and error text, diagnostics rows with status/paths/last-scan, rescan buttons, refresh handler, "Manage in <launcher>"
- Launch commands validated before execution; invalid ids produce actionable errors
- Staggered startup scans; absent launchers persist empty `source_state` rows

## Tests

- Byte-level fixtures for both cache versions and the Ryujinx config/metadata layout
- Scanner, model repeatability (favorites/hidden survive rescans), malformed-input cache preservation, and unified-model source filtering coverage for both emulators
- Launcher command safety: PCSX2 serial ids rejected, `path:` ids validated; Ryujinx title-id/path validation; unsafe ids rejected
- Settings persistence for the new toggles; absent-launcher runs persist empty `source_state` rows (now 6 sources)
- Full suite: 60 core tests + QML smoke + controller navigation + render smoke — all passing locally

Verified against a real installation: PCSX2 2.6.3 Flatpak with a populated library (3 disc games imported with covers, regions, and playtime) and Ryujinx 1.3.3 Flatpak.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PCSX2 and Ryujinx library integration for native and Flatpak installations.
  * Automatically discovers supported games with artwork, playtime, last-played details, and custom metadata.
  * Added source filters, status information, and rescan controls in Settings.
  * Added launching and management support for PCSX2 and Ryujinx games.
  * Added automatic emulator detection and enablement.
  * Improved library navigation, focus handling, empty states, and filtering.
* **Documentation**
  * Updated compatibility documentation and the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->