### PR TITLE
steam: skip unavailable libraries instead of aborting scan

### DIFF
--- a/src/sources/steam/SteamScanner.cpp
+++ b/src/sources/steam/SteamScanner.cpp
@@ -319,8 +319,9 @@ SteamScanResult SteamScanner::scan(const QStringList& steamRoots) {
     for (const QString& library : discoveredLibraries) {
       QDir steamapps(library + QStringLiteral("/steamapps"));
       if (!steamapps.exists()) {
-        result.warnings.append(QStringLiteral("Steam library is unavailable: %1").arg(library));
-        result.incomplete = true;
+        // Skip stale entries (e.g. moved partition left in libraryfolders.vdf) - warn but don't abort scan.
+        // Steam doesn't clean up libraryfolders.vdf when a drive is moved without removal.
+        result.warnings.append(QStringLiteral("Steam library is unavailable, skipping: %1").arg(library));
         continue;
       }
       const QStringList manifests =


### PR DESCRIPTION
Have multiple Steam libraries on different partitions, but Steam doesn't clean up libraryfolders.vdf, so if you've changed some partition without first removing it from the list of storages in Steam, it doesn't actually update it which in turn causes this problem. Omakade currently marks the whole scan as `incomplete` on any missing `steamapps` folder and `SteamGameModel::applyScan` keeps the cached (often empty) library.

**Example:** 
- `libraryfolders.vdf` still has stale `/run/media/omu/44B23E48B23E3F2C/SteamLibrary` (apps {}) after drive remounted at `/mnt/games` (same UUID `44B23E48B23E3F2C`).
- Valid libraries at `/mnt/neutron/SteamLibrary` (14 manifests / 8 importable games) and `/mnt/games` are present.
- Stock `v1.2.3` -> `0 games`, `source_state` missing `steam` row, incomplete=true.
- With patch -> `8 games` imported, warning `Steam library is unavailable, skipping: /run/media/...`, `incomplete=false`.

**Fix:** In `SteamScanner.cpp` don't set `incomplete=true` for unavailable library paths, just warn + continue. Valid libraries still import. Diagnostics (Ctrl+D) still shows skipped path.

Fixes manual `libraryfolders.vdf` workaround being required. Tested on Arch/Omarchy 4.0 with btrfs + ntfs mounts, all 4 tests pass.

Fixes the ghost-library case described above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Steam library scans now continue when a configured library folder is missing.
  * Added a warning indicating that the unavailable library was skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->