### PR TITLE
steam: show owned games alongside installed ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Added owned Steam games to the library through the Steam Web API, marked
+  NOT INSTALLED and installable through Steam.
+- Added an INSTALLED ONLY setting to hide games that are owned but not installed.
+
 ## 1.2.3
 
 - Restored controller navigation on game details.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ add_library(omakade_core STATIC
   src/metadata/GameInsightsService.h
   src/sources/steam/SteamScanner.cpp
   src/sources/steam/SteamScanner.h
+  src/sources/steam/SteamOwnedGames.cpp
+  src/sources/steam/SteamOwnedGames.h
   src/sources/steam/ValveKeyValues.cpp
   src/sources/steam/ValveKeyValues.h
   src/sources/lutris/LutrisScanner.cpp

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -12,6 +12,7 @@ and runtime logs from RetroArch. It never writes into source launcher directorie
 
 Omakade retains:
 
+- Owned Steam games in the same database
 - Library, source records, favorites, hidden state, and achievements in
   `$XDG_DATA_HOME/omakade/library.sqlite3`
 - User-created links between duplicate installations in the same database
@@ -40,6 +41,12 @@ obtain an app access token, then sends the token and client ID to IGDB.
 Omakade may request missing covers and achievement icons from Steam's public
 HTTPS artwork hosts. Responses are size-limited and the artwork cache is
 bounded by the configured limit.
+
+Omakade requests the account's owned games from Valve's documented
+IPlayerService/GetOwnedGames endpoint when a Steam Web API key is stored and the
+owned-games setting is on. It retains the app ID, title, playtime, and last-played
+time for each owned game in `owned_games` in the local library database. Turning
+the setting off hides those entries; removing the API key stops the requests.
 
 Steam Web API requests occur only after the user stores a key. Omakade refreshes
 stale achievement data when Steam game details open or when the user selects

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Omakade includes:
 - Optional close-after-launch behavior
 - Collections, tags, completion states, and smart organization filters
 - Local Steam achievements plus optional Web API enrichment
+- Owned Steam games alongside installed ones, with delegated installation
 - Optional IGDB critic aggregates and game-length estimates
 - Local, downloaded, and user-selected cover artwork
 - Explicit linking for games installed through multiple sources
@@ -38,6 +39,11 @@ Omakade includes:
 - Keyboard, mouse, and controller navigation
 
 ![Omakade game details showing playtime, IGDB insights, and Steam achievements](docs/assets/game-details.webp)
+
+Owned Steam games need a Steam Web API key and a Steam ID in Settings, and the
+account's Game details privacy set to Public. Entries that are owned but not
+installed are marked **NOT INSTALLED** and offer Install, which hands off to
+Steam. Turn the whole behaviour off with the INSTALLED ONLY toggle in Settings.
 
 Omakade reads launcher data without modifying it. Core discovery, browsing,
 artwork, and launching work offline. Run `omakade --demo` to explore the UI

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -264,6 +264,16 @@ ApplicationWindow {
         }
     }
 
+    function installSelected() {
+        if (DemoMode) {
+            showToast("Demo games cannot be installed")
+        } else if (Launcher.install(selectedInstallation.source, selectedInstallation.appId)) {
+            showToast("Asking Steam to install " + selectedGame.title)
+        } else {
+            showToast(Launcher.lastError)
+        }
+    }
+
     function manageSelected() {
         if (Launcher.manage(selectedInstallation.source, selectedInstallation.appId,
                             selectedInstallation.flatpak || false,
@@ -906,6 +916,7 @@ ApplicationWindow {
                 root.selectedGame = Library.get(root.selectedIndex)
             }
             onPlayRequested: root.playSelected()
+            onInstallRequested: root.installSelected()
             onManageRequested: root.manageSelected()
             onInstallationSelected: installation => root.selectInstallation(installation)
             onLinkRequested: {
@@ -1629,6 +1640,13 @@ ApplicationWindow {
                         text: Preferences.closeAfterLaunch ? "CLOSE AFTER PLAY" : "STAY OPEN"
                         selected: Preferences.closeAfterLaunch
                         onClicked: Preferences.closeAfterLaunch = !Preferences.closeAfterLaunch
+                    }
+                    GlassButton {
+                        Layout.fillWidth: true
+                        compact: true
+                        text: Preferences.steamOwnedGames ? "OWNED STEAM GAMES" : "INSTALLED ONLY"
+                        selected: Preferences.steamOwnedGames
+                        onClicked: Preferences.steamOwnedGames = !Preferences.steamOwnedGames
                     }
                     GlassButton {
                         Layout.fillWidth: true

--- a/qml/components/GameCard.qml
+++ b/qml/components/GameCard.qml
@@ -15,6 +15,7 @@ FocusScope {
     required property color accentEnd
     required property string coverMark
     required property string coverPath
+    property bool installed: true
     property bool current: false
 
     signal activated()
@@ -204,6 +205,28 @@ FocusScope {
                 anchors.centerIn: parent
                 text: root.completionStatus.toUpperCase()
                 color: Theme.brightForeground
+                font.family: Theme.fontFamily
+                font.pixelSize: 8
+                font.weight: Font.Bold
+            }
+        }
+
+        Rectangle {
+            visible: !root.installed
+            height: 25
+            width: notInstalledText.implicitWidth + 18
+            radius: 13
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            anchors.margins: 9
+            color: root.alpha(Theme.darkerBackground, 0.82)
+            border.color: root.alpha(Theme.brightForeground, 0.20)
+
+            Text {
+                id: notInstalledText
+                anchors.centerIn: parent
+                text: "NOT INSTALLED"
+                color: root.alpha(Theme.brightForeground, 0.75)
                 font.family: Theme.fontFamily
                 font.pixelSize: 8
                 font.weight: Font.Bold

--- a/qml/components/LibraryView.qml
+++ b/qml/components/LibraryView.qml
@@ -139,6 +139,7 @@ Item {
             required property color accentEnd
             required property string coverMark
             required property string coverPath
+            required property bool installed
 
             width: grid.cellWidth
             height: grid.cellHeight
@@ -159,6 +160,7 @@ Item {
                 accentEnd: delegateRoot.accentEnd
                 coverMark: delegateRoot.coverMark
                 coverPath: delegateRoot.coverPath
+                installed: delegateRoot.installed
                 current: grid.currentIndex === delegateRoot.index
                 focus: current
 

--- a/qml/screens/GameDetails.qml
+++ b/qml/screens/GameDetails.qml
@@ -18,6 +18,7 @@ Item {
     signal backRequested()
     signal favoriteRequested()
     signal playRequested()
+    signal installRequested()
     signal manageRequested()
     signal hiddenRequested()
     signal connectRequested()
@@ -344,10 +345,11 @@ Item {
                     GlassButton {
                         id: playButton
                         objectName: "playButton"
-                        text: "PLAY"
-                        iconText: "▶"
+                        readonly property bool installed: root.game.installed !== false
+                        text: installed ? "PLAY" : "INSTALL"
+                        iconText: installed ? "▶" : "⭳"
                         primary: true
-                        onClicked: root.playRequested()
+                        onClicked: installed ? root.playRequested() : root.installRequested()
                         Component.onCompleted: forceActiveFocus()
                     }
 

--- a/src/achievements/SteamAccountService.cpp
+++ b/src/achievements/SteamAccountService.cpp
@@ -1,6 +1,7 @@
 #include "achievements/SteamAccountService.h"
 
 #include "app/AppSettings.h"
+#include "sources/steam/SteamOwnedGames.h"
 #include "sources/steam/SteamScanner.h"
 #include "sources/steam/ValveKeyValues.h"
 
@@ -115,6 +116,13 @@ SteamAccountService::SteamAccountService(const QString& databasePath, AppSetting
     if (!discovered.isEmpty()) {
       m_settings->setSteamId(discovered);
     }
+  }
+  if (m_settings != nullptr) {
+    connect(m_settings, &AppSettings::steamOwnedGamesChanged, this, [this] {
+      if (m_settings->steamOwnedGames()) {
+        refreshOwnedGames();
+      }
+    });
   }
   connect(&m_secretWatcher, &QFutureWatcher<SteamSecretResult>::finished, this,
           &SteamAccountService::finishSecretOperation);
@@ -301,11 +309,15 @@ void SteamAccountService::finishSecretOperation() {
     setStatus(m_hasApiKey ? QStringLiteral("connected") : QStringLiteral("local"),
               m_hasApiKey ? QStringLiteral("Steam connection ready")
                           : QStringLiteral("Using Steam's local achievement cache"));
+    if (m_hasApiKey) {
+      QTimer::singleShot(0, this, &SteamAccountService::refreshOwnedGames);
+    }
   } else if (m_secretAction == SecretAction::Store) {
     m_hasApiKey = true;
     emit accountChanged();
     setBusy(false);
     setStatus(QStringLiteral("connected"), QStringLiteral("Steam API key saved securely"));
+    QTimer::singleShot(0, this, &SteamAccountService::refreshOwnedGames);
   } else if (m_secretAction == SecretAction::Remove) {
     m_hasApiKey = false;
     emit accountChanged();
@@ -316,10 +328,138 @@ void SteamAccountService::finishSecretOperation() {
     emit accountChanged();
     setBusy(false);
     setStatus(QStringLiteral("setup"), QStringLiteral("Add a Steam Web API key in settings"));
+  } else if (m_secretAction == SecretAction::LookupForOwned) {
+    startOwnedGamesRequest(std::move(result.secret));
   } else {
     startApiRequests(std::move(result.secret));
   }
   result.secret.fill('\0');
+}
+
+void SteamAccountService::refreshOwnedGames() {
+  if (m_settings != nullptr && !m_settings->steamOwnedGames()) {
+    return;
+  }
+  if (m_busy) {
+    return;
+  }
+  if (steamId().isEmpty()) {
+    setStatus(QStringLiteral("setup"),
+              QStringLiteral("Add your Steam ID in settings to list owned games"));
+    return;
+  }
+  if (!m_hasApiKey) {
+    setStatus(QStringLiteral("setup"),
+              QStringLiteral("Add a Steam Web API key in settings to list owned games"));
+    return;
+  }
+  beginSecretOperation(SecretAction::LookupForOwned);
+}
+
+void SteamAccountService::startOwnedGamesRequest(QByteArray apiKey) {
+  QNetworkRequest request(
+      SteamOwnedGames::requestUrl(SteamAchievementApi::authenticatedHost(), apiKey, steamId()));
+  apiKey.fill('\0');
+  request.setTransferTimeout(15000);
+  request.setHeader(QNetworkRequest::UserAgentHeader,
+                    QStringLiteral("Omakade/%1").arg(QCoreApplication::applicationVersion()));
+  request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                       QNetworkRequest::ManualRedirectPolicy);
+  QNetworkReply* reply = m_network.get(request);
+  m_responseBuffers.insert(reply, {});
+  connect(reply, &QNetworkReply::readyRead, this, [this, reply] {
+    QByteArray& buffer = m_responseBuffers[reply];
+    if (buffer.size() > kMaximumApiResponseBytes) {
+      return;
+    }
+    const qsizetype remaining = kMaximumApiResponseBytes - buffer.size();
+    buffer.append(reply->read(remaining + 1));
+    if (buffer.size() > kMaximumApiResponseBytes) {
+      reply->setProperty("responseTooLarge", true);
+      reply->abort();
+    }
+  });
+  connect(reply, &QNetworkReply::finished, this, [this, reply] { handleOwnedGamesReply(reply); });
+  setStatus(QStringLiteral("refreshing"), QStringLiteral("Refreshing your Steam library"));
+}
+
+void SteamAccountService::handleOwnedGamesReply(QNetworkReply* reply) {
+  const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+  QByteArray contents = m_responseBuffers.take(reply);
+  if (contents.size() <= kMaximumApiResponseBytes) {
+    contents.append(reply->read(kMaximumApiResponseBytes + 1 - contents.size()));
+  }
+  const bool tooLarge =
+      reply->property("responseTooLarge").toBool() || contents.size() > kMaximumApiResponseBytes;
+  const QNetworkReply::NetworkError networkError = reply->error();
+  reply->deleteLater();
+  setBusy(false);
+
+  if (tooLarge) {
+    setStatus(QStringLiteral("connected"),
+              QStringLiteral("Steam sent a larger library than Omakade can read"));
+    return;
+  }
+  if (status == 401 || status == 403) {
+    setStatus(QStringLiteral("setup"), QStringLiteral("Steam rejected the Web API key"));
+    return;
+  }
+  if (networkError != QNetworkReply::NoError || status < 200 || status >= 300) {
+    setStatus(QStringLiteral("connected"),
+              QStringLiteral("Could not reach Steam to refresh your library"));
+    return;
+  }
+
+  const SteamOwnedGamesResult result = SteamOwnedGames::parse(contents);
+  if (!result.valid) {
+    setStatus(QStringLiteral("connected"), result.error);
+    return;
+  }
+  if (!persistOwnedGames(result)) {
+    setStatus(QStringLiteral("connected"), QStringLiteral("Could not store your Steam library"));
+    return;
+  }
+  setStatus(QStringLiteral("connected"),
+            QStringLiteral("Found %1 owned game(s) on Steam").arg(result.games.size()));
+  emit ownedGamesUpdated();
+}
+
+bool SteamAccountService::persistOwnedGames(const SteamOwnedGamesResult& result) {
+  if (!m_database.isOpen() || !m_database.transaction()) {
+    return false;
+  }
+  const qint64 observedAt = QDateTime::currentSecsSinceEpoch();
+  QSqlQuery query(m_database);
+  bool okay = true;
+  for (const SteamOwnedGameRecord& game : result.games) {
+    query.prepare(QStringLiteral(
+        "INSERT INTO games(app_id, title) VALUES(?, ?) ON CONFLICT(app_id) DO UPDATE SET "
+        "title = excluded.title"));
+    query.addBindValue(game.appId);
+    query.addBindValue(game.title);
+    okay = okay && query.exec();
+
+    // Leave cover_path alone so a cached cover survives a refresh.
+    query.prepare(QStringLiteral(
+        "INSERT INTO owned_games(app_id, cover_path, last_played, playtime_minutes, observed_at) "
+        "VALUES(?, NULL, ?, ?, ?) ON CONFLICT(app_id) DO UPDATE SET "
+        "last_played = excluded.last_played, playtime_minutes = excluded.playtime_minutes, "
+        "observed_at = excluded.observed_at"));
+    query.addBindValue(game.appId);
+    query.addBindValue(game.lastPlayed);
+    query.addBindValue(game.playtimeMinutes);
+    query.addBindValue(observedAt);
+    okay = okay && query.exec();
+  }
+  query.prepare(QStringLiteral("DELETE FROM owned_games WHERE observed_at < ?"));
+  query.addBindValue(observedAt);
+  okay = okay && query.exec();
+
+  if (!okay || !m_database.commit()) {
+    m_database.rollback();
+    return false;
+  }
+  return true;
 }
 
 void SteamAccountService::startApiRequests(QByteArray apiKey) {

--- a/src/achievements/SteamAccountService.h
+++ b/src/achievements/SteamAccountService.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "achievements/SteamAchievementApi.h"
+#include "sources/steam/SteamOwnedGames.h"
 
 #include <QFutureWatcher>
 #include <QHash>
@@ -42,15 +43,17 @@ public:
   Q_INVOKABLE void removeApiKey();
   Q_INVOKABLE void refreshAchievements(const QString& appId);
   Q_INVOKABLE void refreshAchievementsIfStale(const QString& appId);
+  Q_INVOKABLE void refreshOwnedGames();
 
 signals:
   void accountChanged();
   void busyChanged();
   void statusChanged();
   void achievementsUpdated(const QString& appId);
+  void ownedGamesUpdated();
 
 private:
-  enum class SecretAction { Detect, Store, Remove, LookupForRefresh };
+  enum class SecretAction { Detect, Store, Remove, LookupForRefresh, LookupForOwned };
   struct ApiRequestState {
     QByteArray player;
     QByteArray schema;
@@ -64,6 +67,9 @@ private:
   void beginSecretOperation(SecretAction action, const QByteArray& value = {});
   void finishSecretOperation();
   void startApiRequests(QByteArray apiKey);
+  void startOwnedGamesRequest(QByteArray apiKey);
+  void handleOwnedGamesReply(QNetworkReply* reply);
+  bool persistOwnedGames(const SteamOwnedGamesResult& result);
   void handleApiReply(QNetworkReply* reply);
   void finishApiRequests();
   bool persistAchievements(const SteamAchievementApiResult& result);

--- a/src/app/AppSettings.cpp
+++ b/src/app/AppSettings.cpp
@@ -127,6 +127,17 @@ void AppSettings::setCloseAfterLaunch(bool value) {
   emit closeAfterLaunchChanged();
 }
 
+bool AppSettings::steamOwnedGames() const { return m_steamOwnedGames; }
+
+void AppSettings::setSteamOwnedGames(bool value) {
+  if (m_steamOwnedGames == value) {
+    return;
+  }
+  m_steamOwnedGames = value;
+  save();
+  emit steamOwnedGamesChanged();
+}
+
 QString AppSettings::defaultPath() {
   return QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) +
          QStringLiteral("/omakade/config.toml");
@@ -171,6 +182,7 @@ void AppSettings::load() {
   m_faugusEnabled = readEnabled(QStringLiteral("faugus_enabled"), true);
   m_retroArchEnabled = readEnabled(QStringLiteral("retroarch_enabled"), true);
   m_closeAfterLaunch = readEnabled(QStringLiteral("close_after_launch"), false);
+  m_steamOwnedGames = readEnabled(QStringLiteral("steam_owned_games"), true);
 }
 
 void AppSettings::save() const {
@@ -182,7 +194,8 @@ void AppSettings::save() const {
   file.write(QStringLiteral("reduced_motion = %1\nartwork_cache_limit_mb = %2\nsteam_id = "
                             "\"%3\"\nigdb_client_id = \"%4\"\nsteam_enabled = %5\n"
                             "lutris_enabled = %6\nheroic_enabled = %7\nfaugus_enabled = %8\n"
-                            "retroarch_enabled = %9\nclose_after_launch = %10\n")
+                            "retroarch_enabled = %9\nclose_after_launch = %10\n"
+                            "steam_owned_games = %11\n")
                  .arg(m_reducedMotion ? QStringLiteral("true") : QStringLiteral("false"))
                  .arg(m_artworkCacheLimitMb)
                  .arg(m_steamId)
@@ -193,6 +206,7 @@ void AppSettings::save() const {
                  .arg(m_faugusEnabled ? QStringLiteral("true") : QStringLiteral("false"))
                  .arg(m_retroArchEnabled ? QStringLiteral("true") : QStringLiteral("false"))
                  .arg(m_closeAfterLaunch ? QStringLiteral("true") : QStringLiteral("false"))
+                 .arg(m_steamOwnedGames ? QStringLiteral("true") : QStringLiteral("false"))
                  .toUtf8());
   file.commit();
 }

--- a/src/app/AppSettings.h
+++ b/src/app/AppSettings.h
@@ -20,6 +20,8 @@ class AppSettings final : public QObject {
       bool retroArchEnabled READ retroArchEnabled WRITE setRetroArchEnabled NOTIFY sourcesChanged)
   Q_PROPERTY(bool closeAfterLaunch READ closeAfterLaunch WRITE setCloseAfterLaunch NOTIFY
                  closeAfterLaunchChanged)
+  Q_PROPERTY(bool steamOwnedGames READ steamOwnedGames WRITE setSteamOwnedGames NOTIFY
+                 steamOwnedGamesChanged)
 
 public:
   explicit AppSettings(const QString& path = {}, QObject* parent = nullptr);
@@ -44,6 +46,8 @@ public:
   void setRetroArchEnabled(bool value);
   [[nodiscard]] bool closeAfterLaunch() const;
   void setCloseAfterLaunch(bool value);
+  [[nodiscard]] bool steamOwnedGames() const;
+  void setSteamOwnedGames(bool value);
 
 signals:
   void reducedMotionChanged();
@@ -52,6 +56,7 @@ signals:
   void igdbClientIdChanged();
   void sourcesChanged();
   void closeAfterLaunchChanged();
+  void steamOwnedGamesChanged();
 
 private:
   [[nodiscard]] static QString defaultPath();
@@ -69,4 +74,5 @@ private:
   bool m_faugusEnabled = true;
   bool m_retroArchEnabled = true;
   bool m_closeAfterLaunch = false;
+  bool m_steamOwnedGames = true;
 };

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -150,6 +150,8 @@ int main(int argc, char* argv[]) {
                      [&achievements](const QString& appId) { achievements.load(appId); });
     QObject::connect(steamAccount.get(), &SteamAccountService::achievementsUpdated, steamLibrary,
                      &SteamGameModel::reloadAchievementSummary);
+    QObject::connect(steamAccount.get(), &SteamAccountService::ownedGamesUpdated, steamLibrary,
+                     &SteamGameModel::reloadOwnedGames);
     gameInsights =
         std::make_unique<GameInsightsService>(steamLibrary->databasePath(), &preferences);
   }

--- a/src/launch/GameLauncher.cpp
+++ b/src/launch/GameLauncher.cpp
@@ -137,6 +137,20 @@ bool GameLauncher::launch(const QString& source, const QString& id, bool flatpak
   return false;
 }
 
+bool GameLauncher::install(const QString& source, const QString& id) {
+  if (source.compare(QStringLiteral("Steam"), Qt::CaseInsensitive) != 0) {
+    setError(QStringLiteral("%1 does not provide installation from Omakade yet.").arg(source));
+    return false;
+  }
+  const QUrl url = SteamLauncher::installUrl(id);
+  if (!url.isValid() || url.isEmpty() || !QDesktopServices::openUrl(url)) {
+    setError(QStringLiteral("Steam could not start the installation."));
+    return false;
+  }
+  setError({});
+  return true;
+}
+
 bool GameLauncher::manage(const QString& source, const QString& id, bool flatpak,
                           const QString& runner) {
   if (source.compare(QStringLiteral("Steam"), Qt::CaseInsensitive) == 0) {

--- a/src/launch/GameLauncher.h
+++ b/src/launch/GameLauncher.h
@@ -26,6 +26,7 @@ public:
   Q_INVOKABLE bool launch(const QString& source, const QString& id, bool flatpak = false,
                           const QString& runner = {}, const QString& installPath = {},
                           const QString& launchTarget = {});
+  Q_INVOKABLE bool install(const QString& source, const QString& id);
   Q_INVOKABLE bool manage(const QString& source, const QString& id, bool flatpak = false,
                           const QString& runner = {});
 

--- a/src/launch/SteamLauncher.cpp
+++ b/src/launch/SteamLauncher.cpp
@@ -23,9 +23,15 @@ QUrl SteamLauncher::manageUrl(const QString& appId) {
                            : QUrl{};
 }
 
+QUrl SteamLauncher::installUrl(const QString& appId) {
+  return validAppId(appId) ? QUrl(QStringLiteral("steam://install/%1").arg(appId)) : QUrl{};
+}
+
 bool SteamLauncher::launch(const QString& appId) { return open(launchUrl(appId)); }
 
 bool SteamLauncher::manage(const QString& appId) { return open(manageUrl(appId)); }
+
+bool SteamLauncher::install(const QString& appId) { return open(installUrl(appId)); }
 
 bool SteamLauncher::open(const QUrl& url) {
   QString error;

--- a/src/launch/SteamLauncher.h
+++ b/src/launch/SteamLauncher.h
@@ -13,9 +13,11 @@ public:
   [[nodiscard]] QString lastError() const;
   [[nodiscard]] static QUrl launchUrl(const QString& appId);
   [[nodiscard]] static QUrl manageUrl(const QString& appId);
+  [[nodiscard]] static QUrl installUrl(const QString& appId);
 
   Q_INVOKABLE bool launch(const QString& appId);
   Q_INVOKABLE bool manage(const QString& appId);
+  Q_INVOKABLE bool install(const QString& appId);
 
 signals:
   void lastErrorChanged();

--- a/src/library/FaugusGameModel.cpp
+++ b/src/library/FaugusGameModel.cpp
@@ -77,7 +77,8 @@ QHash<int, QByteArray> FaugusGameModel::roleNames() const {
           {GameRoles::Source, "source"},
           {GameRoles::Runner, "runner"},
           {GameRoles::Flatpak, "flatpak"},
-          {GameRoles::Hidden, "hidden"}};
+          {GameRoles::Hidden, "hidden"},
+          {GameRoles::Installed, "installed"}};
 }
 
 bool FaugusGameModel::faugusDetected() const { return m_faugusDetected; }
@@ -310,6 +311,8 @@ QVariant FaugusGameModel::valueForRole(const Game& game, int role) const {
     return game.faugus.flatpak;
   case GameRoles::Hidden:
     return game.hidden;
+  case GameRoles::Installed:
+    return true;
   default:
     return {};
   }

--- a/src/library/GameRoles.h
+++ b/src/library/GameRoles.h
@@ -34,5 +34,6 @@ enum Role {
   Tags,
   Collections,
   LaunchTarget,
+  Installed,
 };
 }

--- a/src/library/HeroicGameModel.cpp
+++ b/src/library/HeroicGameModel.cpp
@@ -90,7 +90,8 @@ QHash<int, QByteArray> HeroicGameModel::roleNames() const {
           {GameRoles::Source, "source"},
           {GameRoles::Runner, "runner"},
           {GameRoles::Flatpak, "flatpak"},
-          {GameRoles::Hidden, "hidden"}};
+          {GameRoles::Hidden, "hidden"},
+          {GameRoles::Installed, "installed"}};
 }
 
 bool HeroicGameModel::heroicDetected() const { return m_heroicDetected; }
@@ -327,6 +328,8 @@ QVariant HeroicGameModel::valueForRole(const Game& game, int role) const {
     return game.heroic.flatpak;
   case GameRoles::Hidden:
     return game.hidden;
+  case GameRoles::Installed:
+    return true;
   default:
     return {};
   }

--- a/src/library/LutrisGameModel.cpp
+++ b/src/library/LutrisGameModel.cpp
@@ -77,7 +77,8 @@ QHash<int, QByteArray> LutrisGameModel::roleNames() const {
           {GameRoles::Source, "source"},
           {GameRoles::Runner, "runner"},
           {GameRoles::Flatpak, "flatpak"},
-          {GameRoles::Hidden, "hidden"}};
+          {GameRoles::Hidden, "hidden"},
+          {GameRoles::Installed, "installed"}};
 }
 
 bool LutrisGameModel::lutrisDetected() const { return m_lutrisDetected; }
@@ -325,6 +326,8 @@ QVariant LutrisGameModel::valueForRole(const Game& game, int role) const {
     return game.lutris.flatpak;
   case GameRoles::Hidden:
     return game.hidden;
+  case GameRoles::Installed:
+    return true;
   default:
     return {};
   }

--- a/src/library/MockGameModel.cpp
+++ b/src/library/MockGameModel.cpp
@@ -114,6 +114,7 @@ QHash<int, QByteArray> MockGameModel::roleNames() const {
       {GameRoles::Runner, "runner"},
       {GameRoles::Flatpak, "flatpak"},
       {GameRoles::Hidden, "hidden"},
+      {GameRoles::Installed, "installed"},
   };
 }
 
@@ -189,6 +190,8 @@ QVariant MockGameModel::valueForRole(const Game& game, int role) const {
     return false;
   case GameRoles::Hidden:
     return false;
+  case GameRoles::Installed:
+    return true;
   default:
     return {};
   }

--- a/src/library/RetroArchGameModel.cpp
+++ b/src/library/RetroArchGameModel.cpp
@@ -79,6 +79,7 @@ QHash<int, QByteArray> RetroArchGameModel::roleNames() const {
           {GameRoles::Runner, "runner"},
           {GameRoles::Flatpak, "flatpak"},
           {GameRoles::Hidden, "hidden"},
+          {GameRoles::Installed, "installed"},
           {GameRoles::LaunchTarget, "launchTarget"}};
 }
 
@@ -318,6 +319,8 @@ QVariant RetroArchGameModel::valueForRole(const Game& game, int role) const {
     return record.flatpak;
   case GameRoles::Hidden:
     return game.hidden;
+  case GameRoles::Installed:
+    return true;
   case GameRoles::LaunchTarget:
     return record.corePath;
   default:

--- a/src/library/SteamGameModel.cpp
+++ b/src/library/SteamGameModel.cpp
@@ -74,6 +74,11 @@ SteamGameModel::SteamGameModel(const QString& databasePath, AppSettings* setting
     emit scanningChanged();
   });
 
+  if (m_settings != nullptr) {
+    connect(m_settings, &AppSettings::steamOwnedGamesChanged, this,
+            &SteamGameModel::reloadOwnedGames);
+  }
+
   const QString path = databasePath.isEmpty() ? defaultDatabasePath() : databasePath;
   if (openDatabase(path) && ensureSchema()) {
     loadDatabase();
@@ -127,6 +132,7 @@ QHash<int, QByteArray> SteamGameModel::roleNames() const {
       {GameRoles::Runner, "runner"},
       {GameRoles::Flatpak, "flatpak"},
       {GameRoles::Hidden, "hidden"},
+      {GameRoles::Installed, "installed"},
   };
 }
 
@@ -224,6 +230,15 @@ void SteamGameModel::reloadAchievementSummary(const QString& appId) {
   }
 }
 
+void SteamGameModel::reloadOwnedGames() {
+  if (!m_database.isOpen()) {
+    return;
+  }
+  loadDatabase();
+  requestMissingCovers();
+  emit statusChanged();
+}
+
 void SteamGameModel::refreshFromRoots(const QStringList& roots) {
   if (m_scanning) {
     return;
@@ -248,7 +263,8 @@ QVariant SteamGameModel::valueForRole(const Game& game, int role) const {
   case GameRoles::Subtitle:
     return QStringLiteral("Steam");
   case GameRoles::Description:
-    return QStringLiteral("Installed locally through Steam.");
+    return game.installed ? QStringLiteral("Installed locally through Steam.")
+                          : QStringLiteral("Owned on Steam. Not installed on this machine.");
   case GameRoles::Hours:
     return game.steam.playtimeMinutes / 60;
   case GameRoles::Progress:
@@ -281,8 +297,11 @@ QVariant SteamGameModel::valueForRole(const Game& game, int role) const {
   case GameRoles::LogoPath:
     return localUrl(game.steam.logoPath);
   case GameRoles::InstallPath:
-    return QDir(game.steam.libraryPath + QStringLiteral("/steamapps/common"))
-        .absoluteFilePath(game.steam.installDirectory);
+    return game.installed ? QDir(game.steam.libraryPath + QStringLiteral("/steamapps/common"))
+                                .absoluteFilePath(game.steam.installDirectory)
+                          : QString{};
+  case GameRoles::Installed:
+    return game.installed;
   case GameRoles::Source:
     return QStringLiteral("Steam");
   case GameRoles::Runner:
@@ -326,6 +345,10 @@ bool SteamGameModel::ensureSchema() {
                      "library_path TEXT NOT NULL, manifest_path TEXT NOT NULL, cover_path TEXT, "
                      "hero_path TEXT, logo_path TEXT, last_played INTEGER NOT NULL DEFAULT 0, "
                      "playtime_minutes INTEGER NOT NULL DEFAULT 0, observed_at INTEGER NOT NULL)"),
+      QStringLiteral("CREATE TABLE IF NOT EXISTS owned_games ("
+                     "app_id TEXT PRIMARY KEY REFERENCES games(app_id), cover_path TEXT, "
+                     "last_played INTEGER NOT NULL DEFAULT 0, playtime_minutes INTEGER NOT NULL "
+                     "DEFAULT 0, observed_at INTEGER NOT NULL)"),
       QStringLiteral("CREATE TABLE IF NOT EXISTS source_state ("
                      "source TEXT PRIMARY KEY, last_scan INTEGER, last_error TEXT, paths TEXT NOT "
                      "NULL DEFAULT '')"),
@@ -366,7 +389,7 @@ bool SteamGameModel::ensureSchema() {
     setStatus(QStringLiteral("Could not update source diagnostics"), query.lastError().text());
     return false;
   }
-  if (schemaVersion < 7 && !query.exec(QStringLiteral("PRAGMA user_version = 7"))) {
+  if (schemaVersion < 8 && !query.exec(QStringLiteral("PRAGMA user_version = 8"))) {
     setStatus(QStringLiteral("Could not update the library database version"),
               query.lastError().text());
     return false;
@@ -394,13 +417,21 @@ void SteamGameModel::loadDatabase() {
   QVector<Game> loaded;
   QVector<QPair<QString, QString>> cachedCoverUpdates;
   QSqlQuery query(m_database);
-  if (!query.exec(QStringLiteral(
-          "SELECT g.app_id, g.title, g.favorite, g.hidden, i.install_dir, i.library_path, "
-          "i.manifest_path, i.cover_path, i.hero_path, i.logo_path, i.last_played, "
-          "i.playtime_minutes, COALESCE(a.unlocked, 0), COALESCE(a.total, 0) FROM games g "
-          "JOIN installations i ON i.app_id = g.app_id LEFT JOIN achievement_summary a ON "
-          "a.app_id = g.app_id "
-          "ORDER BY g.title COLLATE NOCASE"))) {
+  const bool includeOwned = m_settings == nullptr || m_settings->steamOwnedGames();
+  query.prepare(QStringLiteral(
+      "SELECT g.app_id, g.title, g.favorite, g.hidden, COALESCE(i.install_dir, ''), "
+      "COALESCE(i.library_path, ''), COALESCE(i.manifest_path, ''), "
+      "COALESCE(i.cover_path, o.cover_path, ''), COALESCE(i.hero_path, ''), "
+      "COALESCE(i.logo_path, ''), COALESCE(i.last_played, o.last_played, 0), "
+      "COALESCE(i.playtime_minutes, o.playtime_minutes, 0), COALESCE(a.unlocked, 0), "
+      "COALESCE(a.total, 0), i.app_id IS NOT NULL FROM games g "
+      "LEFT JOIN installations i ON i.app_id = g.app_id "
+      "LEFT JOIN owned_games o ON o.app_id = g.app_id "
+      "LEFT JOIN achievement_summary a ON a.app_id = g.app_id "
+      "WHERE i.app_id IS NOT NULL OR (? AND o.app_id IS NOT NULL) "
+      "ORDER BY g.title COLLATE NOCASE"));
+  query.addBindValue(includeOwned);
+  if (!query.exec()) {
     setStatus(QStringLiteral("Could not load the game library"), query.lastError().text());
     return;
   }
@@ -429,6 +460,7 @@ void SteamGameModel::loadDatabase() {
       cachedCoverUpdates.append({steam.appId, cachedCover});
     }
     loaded.append({.steam = steam,
+                   .installed = query.value(14).toBool(),
                    .favorite = query.value(2).toBool(),
                    .hidden = query.value(3).toBool(),
                    .achievementsUnlocked = query.value(12).toInt(),
@@ -706,6 +738,10 @@ void SteamGameModel::applyCover(const QString& appId, const QString& path) {
     if (m_database.isOpen()) {
       QSqlQuery query(m_database);
       query.prepare(QStringLiteral("UPDATE installations SET cover_path = ? WHERE app_id = ?"));
+      query.addBindValue(path);
+      query.addBindValue(appId);
+      query.exec();
+      query.prepare(QStringLiteral("UPDATE owned_games SET cover_path = ? WHERE app_id = ?"));
       query.addBindValue(path);
       query.addBindValue(appId);
       query.exec();

--- a/src/library/SteamGameModel.h
+++ b/src/library/SteamGameModel.h
@@ -50,6 +50,7 @@ public:
   Q_INVOKABLE void toggleHidden(int row);
   Q_INVOKABLE void refresh();
   Q_INVOKABLE void reloadAchievementSummary(const QString& appId);
+  Q_INVOKABLE void reloadOwnedGames();
   void refreshFromRoots(const QStringList& roots);
 
 signals:
@@ -59,6 +60,7 @@ signals:
 private:
   struct Game {
     SteamGameRecord steam;
+    bool installed = true;
     bool favorite = false;
     bool hidden = false;
     int achievementsUnlocked = 0;

--- a/src/library/UnifiedGameModel.cpp
+++ b/src/library/UnifiedGameModel.cpp
@@ -213,6 +213,7 @@ QHash<int, QByteArray> UnifiedGameModel::roleNames() const {
   roles.insert(GameRoles::Tags, "tags");
   roles.insert(GameRoles::Collections, "collections");
   roles.insert(GameRoles::LaunchTarget, "launchTarget");
+  roles.insert(GameRoles::Installed, "installed");
   return roles;
 }
 

--- a/src/sources/steam/SteamOwnedGames.cpp
+++ b/src/sources/steam/SteamOwnedGames.cpp
@@ -1,0 +1,78 @@
+#include "sources/steam/SteamOwnedGames.h"
+
+#include "sources/steam/SteamScanner.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QSet>
+#include <QUrlQuery>
+
+#include <algorithm>
+
+QUrl SteamOwnedGames::requestUrl(const QString& host, const QByteArray& apiKey,
+                                 const QString& steamId) {
+  QUrl url;
+  url.setScheme(QStringLiteral("https"));
+  url.setHost(host);
+  url.setPath(QStringLiteral("/IPlayerService/GetOwnedGames/v1/"));
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("key"), QString::fromLatin1(apiKey));
+  query.addQueryItem(QStringLiteral("steamid"), steamId);
+  query.addQueryItem(QStringLiteral("include_appinfo"), QStringLiteral("1"));
+  query.addQueryItem(QStringLiteral("include_played_free_games"), QStringLiteral("1"));
+  url.setQuery(query);
+  return url;
+}
+
+SteamOwnedGamesResult SteamOwnedGames::parse(const QByteArray& payload) {
+  SteamOwnedGamesResult result;
+  QJsonParseError parseError;
+  const QJsonDocument document = QJsonDocument::fromJson(payload, &parseError);
+  if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+    result.error = QStringLiteral("Steam returned an unreadable owned-games response.");
+    return result;
+  }
+  const QJsonValue response = document.object().value(QStringLiteral("response"));
+  if (!response.isObject()) {
+    result.error = QStringLiteral("Steam returned an unreadable owned-games response.");
+    return result;
+  }
+  const QJsonObject object = response.toObject();
+  if (!object.contains(QStringLiteral("games"))) {
+    // Steam answers a private "Game details" profile with an empty response object rather
+    // than an error, so explain the privacy setting instead of reporting an empty library.
+    result.error = QStringLiteral(
+        "Steam returned no owned games. Set Steam privacy for Game details to Public, then "
+        "refresh.");
+    return result;
+  }
+
+  QSet<QString> seen;
+  for (const QJsonValue& value : object.value(QStringLiteral("games")).toArray()) {
+    const QJsonObject game = value.toObject();
+    const qint64 appId = game.value(QStringLiteral("appid")).toInteger();
+    const QString title = game.value(QStringLiteral("name")).toString().trimmed();
+    if (appId <= 0 || title.isEmpty() || SteamScanner::isTool(title)) {
+      continue;
+    }
+    const QString identifier = QString::number(appId);
+    if (seen.contains(identifier)) {
+      continue;
+    }
+    seen.insert(identifier);
+    result.games.append({
+        .appId = identifier,
+        .title = title,
+        .playtimeMinutes = game.value(QStringLiteral("playtime_forever")).toInt(),
+        .lastPlayed = game.value(QStringLiteral("rtime_last_played")).toInteger(),
+    });
+  }
+
+  std::sort(result.games.begin(), result.games.end(), [](const auto& left, const auto& right) {
+    return left.title.localeAwareCompare(right.title) < 0;
+  });
+  result.valid = true;
+  return result;
+}

--- a/src/sources/steam/SteamOwnedGames.h
+++ b/src/sources/steam/SteamOwnedGames.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+#include <QUrl>
+#include <QVector>
+
+struct SteamOwnedGameRecord {
+  QString appId;
+  QString title;
+  int playtimeMinutes = 0;
+  qint64 lastPlayed = 0;
+
+  bool operator==(const SteamOwnedGameRecord&) const = default;
+};
+
+struct SteamOwnedGamesResult {
+  QVector<SteamOwnedGameRecord> games;
+  bool valid = false;
+  QString error;
+};
+
+class SteamOwnedGames final {
+public:
+  [[nodiscard]] static QUrl requestUrl(const QString& host, const QByteArray& apiKey,
+                                       const QString& steamId);
+  [[nodiscard]] static SteamOwnedGamesResult parse(const QByteArray& payload);
+};

--- a/src/sources/steam/SteamScanner.cpp
+++ b/src/sources/steam/SteamScanner.cpp
@@ -33,14 +33,6 @@ QString cleanPath(const QString& path) {
   return QDir::cleanPath(QFileInfo(path).absoluteFilePath());
 }
 
-bool isTool(const QString& name) {
-  const QString normalized = name.trimmed().toLower();
-  return normalized.startsWith(QStringLiteral("proton ")) ||
-         normalized.startsWith(QStringLiteral("steam linux runtime")) ||
-         normalized.startsWith(QStringLiteral("steamworks common redistributables")) ||
-         normalized.startsWith(QStringLiteral("steam runtime"));
-}
-
 QString firstMatchingFile(const QString& directory, const QStringList& filters) {
   const QDir dir(directory);
   for (const QString& filter : filters) {
@@ -287,6 +279,14 @@ void resolveArtwork(SteamGameRecord* game, const QStringList& steamRoots) {
 }
 } // namespace
 
+bool SteamScanner::isTool(const QString& name) {
+  const QString normalized = name.trimmed().toLower();
+  return normalized.startsWith(QStringLiteral("proton ")) ||
+         normalized.startsWith(QStringLiteral("steam linux runtime")) ||
+         normalized.startsWith(QStringLiteral("steamworks common redistributables")) ||
+         normalized.startsWith(QStringLiteral("steam runtime"));
+}
+
 QStringList SteamScanner::discoverSteamRoots() {
   const QString home = QDir::homePath();
   QStringList candidates = {
@@ -343,8 +343,8 @@ SteamScanResult SteamScanner::scan(const QStringList& steamRoots) {
         const QString appId = app->value(QStringLiteral("appid"));
         const QString name = app->value(QStringLiteral("name")).trimmed();
         const int stateFlags = app->value(QStringLiteral("StateFlags")).toInt();
-        if (appId.isEmpty() || name.isEmpty() || (stateFlags & 4) == 0 || isTool(name) ||
-            importedIds.contains(appId)) {
+        if (appId.isEmpty() || name.isEmpty() || (stateFlags & 4) == 0 ||
+            SteamScanner::isTool(name) || importedIds.contains(appId)) {
           continue;
         }
 

--- a/src/sources/steam/SteamScanner.h
+++ b/src/sources/steam/SteamScanner.h
@@ -46,6 +46,7 @@ struct SteamScanResult {
 
 class SteamScanner final {
 public:
+  [[nodiscard]] static bool isTool(const QString& name);
   [[nodiscard]] static QStringList discoverSteamRoots();
   [[nodiscard]] static SteamScanResult scan(const QStringList& steamRoots);
 };

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -20,6 +20,7 @@
 #include "sources/heroic/HeroicScanner.h"
 #include "sources/lutris/LutrisScanner.h"
 #include "sources/retroarch/RetroArchScanner.h"
+#include "sources/steam/SteamOwnedGames.h"
 #include "sources/steam/SteamScanner.h"
 #include "sources/steam/ValveKeyValues.h"
 #include "theme/OmarchyTheme.h"
@@ -220,6 +221,8 @@ private slots:
   void steamAchievementApiParsesPlayerSchemaAndRarity();
   void steamAchievementApiClassifiesFailures();
   void steamLauncherBuildsSafeUrls();
+  void steamOwnedGamesParseHandlesLibraryToolsAndPrivacy();
+  void steamModelListsOwnedGamesWhenEnabled();
   void lutrisScannerImportsOnlyLaunchableGames();
   void lutrisModelIsRepeatableAndPreservesLocalState();
   void malformedLutrisDataDoesNotReplaceCachedGames();
@@ -507,7 +510,7 @@ void CoreTests::steamModelMigratesVersionOneDatabase() {
     QSqlQuery query(verify);
     QVERIFY(query.exec(QStringLiteral("PRAGMA user_version")));
     QVERIFY(query.next());
-    QCOMPARE(query.value(0).toInt(), 7);
+    QCOMPARE(query.value(0).toInt(), 8);
     QVERIFY(query.exec(QStringLiteral(
         "SELECT paths FROM source_state WHERE source = 'steam'")));
     QVERIFY(query.next());
@@ -637,7 +640,102 @@ void CoreTests::steamLauncherBuildsSafeUrls() {
            QUrl(QStringLiteral("steam://rungameid/440")));
   QCOMPARE(SteamLauncher::manageUrl(QStringLiteral("440")),
            QUrl(QStringLiteral("steam://nav/games/details/440")));
+  QCOMPARE(SteamLauncher::installUrl(QStringLiteral("440")),
+           QUrl(QStringLiteral("steam://install/440")));
   QVERIFY(SteamLauncher::launchUrl(QStringLiteral("440;touch /tmp/nope")).isEmpty());
+  QVERIFY(SteamLauncher::installUrl(QStringLiteral("0")).isEmpty());
+}
+
+void CoreTests::steamOwnedGamesParseHandlesLibraryToolsAndPrivacy() {
+  const QByteArray payload = R"({"response":{"game_count":4,"games":[
+    {"appid":620,"name":"Portal 2","playtime_forever":425,"rtime_last_played":1700000000},
+    {"appid":440,"name":"Team Fortress 2","playtime_forever":0,"rtime_last_played":0},
+    {"appid":961940,"name":"Proton 9.0","playtime_forever":0},
+    {"appid":620,"name":"Portal 2","playtime_forever":425}]}})";
+  const SteamOwnedGamesResult result = SteamOwnedGames::parse(payload);
+  QVERIFY(result.valid);
+  // Proton is filtered as a tool and the duplicate app id is dropped.
+  QCOMPARE(result.games.size(), 2);
+  QCOMPARE(result.games.at(0).title, QStringLiteral("Portal 2"));
+  QCOMPARE(result.games.at(0).appId, QStringLiteral("620"));
+  QCOMPARE(result.games.at(0).playtimeMinutes, 425);
+  QCOMPARE(result.games.at(0).lastPlayed, 1700000000);
+  QCOMPARE(result.games.at(1).title, QStringLiteral("Team Fortress 2"));
+
+  // Steam answers a private "Game details" profile with an empty response object.
+  const SteamOwnedGamesResult privateProfile = SteamOwnedGames::parse(R"({"response":{}})");
+  QVERIFY(!privateProfile.valid);
+  QVERIFY(privateProfile.error.contains(QStringLiteral("Public")));
+
+  const SteamOwnedGamesResult broken = SteamOwnedGames::parse(QByteArrayLiteral("not json"));
+  QVERIFY(!broken.valid);
+  QVERIFY(!broken.error.isEmpty());
+
+  const QUrl url = SteamOwnedGames::requestUrl(QStringLiteral("api.steampowered.com"),
+                                               QByteArrayLiteral("KEY"), QStringLiteral("7656119"));
+  QCOMPARE(url.host(), QStringLiteral("api.steampowered.com"));
+  QCOMPARE(url.path(), QStringLiteral("/IPlayerService/GetOwnedGames/v1/"));
+  QVERIFY(url.query().contains(QStringLiteral("include_appinfo=1")));
+  QVERIFY(url.query().contains(QStringLiteral("steamid=7656119")));
+}
+
+void CoreTests::steamModelListsOwnedGamesWhenEnabled() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/Steam");
+  const QString second = directory.path() + QStringLiteral("/Library");
+  const QString database = directory.path() + QStringLiteral("/omakade.sqlite3");
+  const QString config = directory.path() + QStringLiteral("/config.toml");
+  createSteamFixture(root, second);
+
+  AppSettings settings(config);
+  QVERIFY(settings.steamOwnedGames());
+  {
+    SteamGameModel model(database, &settings);
+    model.refreshFromRoots({root});
+    QTRY_VERIFY_WITH_TIMEOUT(!model.scanning(), 3000);
+    QCOMPARE(model.rowCount(), 2);
+  }
+
+  const QString ownedConnection = QStringLiteral("owned-seed");
+  {
+    QSqlDatabase seed = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), ownedConnection);
+    seed.setDatabaseName(database);
+    QVERIFY(seed.open());
+    QSqlQuery query(seed);
+    QVERIFY(query.exec(
+        QStringLiteral("INSERT INTO games(app_id, title) VALUES('620', 'Portal 2')")));
+    QVERIFY(query.exec(QStringLiteral(
+        "INSERT INTO owned_games(app_id, cover_path, last_played, playtime_minutes, observed_at) "
+        "VALUES('620', NULL, 1700000000, 425, 1700000000)")));
+    seed.close();
+  }
+  QSqlDatabase::removeDatabase(ownedConnection);
+
+  SteamGameModel withOwned(database, &settings);
+  QCOMPARE(withOwned.rowCount(), 3);
+  int ownedRow = -1;
+  for (int row = 0; row < withOwned.rowCount(); ++row) {
+    if (withOwned.get(row).value(QStringLiteral("appId")).toString() == QStringLiteral("620")) {
+      ownedRow = row;
+    }
+  }
+  QVERIFY(ownedRow >= 0);
+  const QVariantMap owned = withOwned.get(ownedRow);
+  QVERIFY(!owned.value(QStringLiteral("installed")).toBool());
+  QCOMPARE(owned.value(QStringLiteral("hours")).toInt(), 7);
+  QVERIFY(owned.value(QStringLiteral("installPath")).toString().isEmpty());
+
+  // Installed games keep the role set, so only the owned entry is marked uninstalled.
+  for (int row = 0; row < withOwned.rowCount(); ++row) {
+    if (row != ownedRow) {
+      QVERIFY(withOwned.get(row).value(QStringLiteral("installed")).toBool());
+    }
+  }
+
+  settings.setSteamOwnedGames(false);
+  SteamGameModel installedOnly(database, &settings);
+  QCOMPARE(installedOnly.rowCount(), 2);
 }
 
 void CoreTests::lutrisScannerImportsOnlyLaunchableGames() {


### PR DESCRIPTION
## What this adds

Omakade only lists games that have an `appmanifest_*.acf` on disk. On an account with a
large Steam library that means the grid shows the handful of games installed locally and
nothing else — see #12, where only 22 of ~2000 games appear.

This adds owned-game discovery through Valve's documented
`IPlayerService/GetOwnedGames` endpoint.

## How it fits the existing design

PLAN.md says owned games "can be added through documented APIs, but must not replace local
installed-game discovery", so this is strictly additive:

- Owned entries land in a new `owned_games` table and join the library as rows that have
  **no** `installations` row. Installed-game discovery remains the source of truth for
  anything on disk, and still works with no key and no network.
- It reuses the Steam Web API key already stored in Secret Service and the Steam ID
  already in settings — no new credentials, no new storage location.
- The request mirrors the existing achievement calls: same host helper, same 4 MB response
  cap, same transfer timeout, same User-Agent, manual redirect policy.
- Owned-but-not-installed games are marked `NOT INSTALLED` on the card and offer `INSTALL`
  in the details pane, which hands off to `steam://install/<appid>`. Omakade still never
  installs anything itself.
- `cover_path` is left alone across refreshes so cached artwork survives.
- A private *Game details* profile answers with an empty `response` object rather than an
  error, so that case reports the privacy setting to fix instead of an empty library.

## Default

The setting ships **on** (`steam_owned_games = true`), with an `INSTALLED ONLY` toggle in
Settings to turn it off. If you would rather it be opt-in, flipping the default is a
one-line change in `AppSettings` — happy to do that if you prefer.

## Tests

`ctest --preset dev` — 4/4 suites pass, 53 core assertions. New coverage:

- `steamOwnedGamesParseHandlesLibraryToolsAndPrivacy` — parsing, tool filtering, duplicate
  app IDs, the private-profile response, malformed JSON, and request URL construction.
- `steamModelListsOwnedGamesWhenEnabled` — owned rows appear alongside installed ones,
  carry `installed == false`, expose no install path, and disappear when the setting is off.
- `steamLauncherBuildsSafeUrls` extended for `installUrl`, including the invalid-app-ID case.

The schema version moves 7 → 8; `steamModelMigratesVersionOneDatabase` is updated to match.

## Note

Not rebased on #17 — these touch the same file but different concerns, and #17 should land
on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Import owned Steam games into the library using Steam Web API credentials.
  - Show owned games that are not installed with a **NOT INSTALLED** badge.
  - Install Steam games directly through Steam using the **INSTALL** action.
  - Toggle between **INSTALLED ONLY** and **OWNED STEAM GAMES** views.
  - Refresh owned-game information after account or setting changes.

- **Documentation**
  - Added setup, privacy, and feature details for Steam owned-game integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->