### PR TITLE
steam: import non-Steam shortcuts from shortcuts.vdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Steam
+
+- Imported non-Steam shortcuts from `shortcuts.vdf`, including Wine/Proton
+  games added to Steam, and launched them with the 64-bit shortcut ID Steam
+  expects.
+
 ## 1.3.0
 
 ### Steam

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ into one quiet, cover-focused home that follows the active Omarchy theme.
 Omakade includes:
 
 - Native and Flatpak Steam, Lutris, Heroic, Faugus, and RetroArch discovery,
-  including games sideloaded into Heroic
+  including Steam non-Steam shortcuts and games sideloaded into Heroic
 - One-click details and delegated launching through the owning platform
 - Omarchy palette, font, transparency, and live theme updates
 - Search, favorites, hidden games, sorting, and source filters

--- a/src/launch/SteamLauncher.cpp
+++ b/src/launch/SteamLauncher.cpp
@@ -8,6 +8,23 @@ bool validAppId(const QString& appId) {
   static const QRegularExpression digits(QStringLiteral("^[1-9][0-9]*$"));
   return digits.match(appId).hasMatch();
 }
+
+QString launchTargetId(const QString& appId) {
+  if (!validAppId(appId)) {
+    return {};
+  }
+  bool numeric = false;
+  const quint64 id = appId.toULongLong(&numeric);
+  if (!numeric || id == 0) {
+    return {};
+  }
+  // Non-Steam shortcuts store a 32-bit ID with the high bit set. Steam launches
+  // them with the 64-bit Big Picture ID: (appid << 32) | 0x02000000.
+  if (id <= 0xFFFFFFFFull && (id & 0x80000000ull) != 0) {
+    return QString::number((id << 32) | 0x02000000ull);
+  }
+  return appId;
+}
 } // namespace
 
 SteamLauncher::SteamLauncher(QObject* parent) : QObject(parent) {}
@@ -15,7 +32,8 @@ SteamLauncher::SteamLauncher(QObject* parent) : QObject(parent) {}
 QString SteamLauncher::lastError() const { return m_lastError; }
 
 QUrl SteamLauncher::launchUrl(const QString& appId) {
-  return validAppId(appId) ? QUrl(QStringLiteral("steam://rungameid/%1").arg(appId)) : QUrl{};
+  const QString target = launchTargetId(appId);
+  return target.isEmpty() ? QUrl{} : QUrl(QStringLiteral("steam://rungameid/%1").arg(target));
 }
 
 QUrl SteamLauncher::manageUrl(const QString& appId) {

--- a/src/library/SteamGameModel.cpp
+++ b/src/library/SteamGameModel.cpp
@@ -684,9 +684,16 @@ void SteamGameModel::rebuildWatchPaths(const SteamScanResult& result) {
     for (const QString& user : userdata.entryList(QDir::Dirs | QDir::NoDotAndDotDot)) {
       const QString userConfig = userdata.absoluteFilePath(user + QStringLiteral("/config"));
       const QString localConfig = userConfig + QStringLiteral("/localconfig.vdf");
+      const QString shortcuts = userConfig + QStringLiteral("/shortcuts.vdf");
       const QString grid = userConfig + QStringLiteral("/grid");
       if (QFileInfo::exists(localConfig)) {
         files.append(localConfig);
+      }
+      if (QFileInfo::exists(shortcuts)) {
+        files.append(shortcuts);
+      }
+      if (QFileInfo(userConfig).isDir()) {
+        directories.append(userConfig);
       }
       if (QFileInfo(grid).isDir()) {
         directories.append(grid);
@@ -726,8 +733,13 @@ void SteamGameModel::requestCoverForGame(const Game& game) {
     return;
   }
   bool numeric = false;
-  game.steam.appId.toULongLong(&numeric);
+  const quint64 appId = game.steam.appId.toULongLong(&numeric);
   if (!numeric) {
+    return;
+  }
+  // Non-Steam shortcuts have no Steam store capsule. Grid art or the shortcut
+  // icon is already resolved during the local scan.
+  if (appId <= 0xFFFFFFFFull && (appId & 0x80000000ull) != 0) {
     return;
   }
   const QString cached = coverCachePath(game.steam.appId);

--- a/src/sources/steam/SteamScanner.cpp
+++ b/src/sources/steam/SteamScanner.cpp
@@ -201,6 +201,84 @@ QHash<QString, AchievementCache> readAchievementCaches(const QStringList& roots)
   return result;
 }
 
+void resolveArtwork(SteamGameRecord* game, const QStringList& steamRoots);
+
+QString unquotePath(const QString& value) {
+  const QString trimmed = value.trimmed();
+  if (trimmed.size() >= 2 && trimmed.front() == QLatin1Char('"') &&
+      trimmed.back() == QLatin1Char('"')) {
+    return trimmed.mid(1, trimmed.size() - 2);
+  }
+  return trimmed;
+}
+
+void importNonSteamShortcuts(const QStringList& steamRoots, const QHash<QString, Activity>& activity,
+                             QSet<QString>* importedIds, SteamScanResult* result) {
+  for (const QString& root : steamRoots) {
+    QDir userdata(root + QStringLiteral("/userdata"));
+    for (const QString& user : userdata.entryList(QDir::Dirs | QDir::NoDotAndDotDot)) {
+      const QString shortcutsPath =
+          userdata.absoluteFilePath(user + QStringLiteral("/config/shortcuts.vdf"));
+      if (!QFileInfo::exists(shortcutsPath)) {
+        continue;
+      }
+      ValveKeyValues parsed;
+      QString error;
+      if (!ValveKeyValuesParser::parseBinaryFile(shortcutsPath, &parsed, &error)) {
+        result->warnings.append(
+            QStringLiteral("Could not read %1: %2").arg(shortcutsPath, error));
+        continue;
+      }
+      const ValveKeyValues* shortcuts = parsed.object(QStringLiteral("shortcuts"));
+      if (shortcuts == nullptr) {
+        continue;
+      }
+      for (auto iterator = shortcuts->objects.cbegin(); iterator != shortcuts->objects.cend();
+           ++iterator) {
+        const ValveKeyValues& entry = iterator.value();
+        const QString appId = entry.value(QStringLiteral("appid"));
+        const QString name = entry.value(QStringLiteral("AppName")).trimmed();
+        bool numeric = false;
+        appId.toULongLong(&numeric);
+        if (!numeric || appId == QStringLiteral("0") || name.isEmpty() ||
+            SteamScanner::isToolTitle(name) || importedIds->contains(appId)) {
+          continue;
+        }
+
+        const QString exe = unquotePath(entry.value(QStringLiteral("Exe")));
+        QString startDir = unquotePath(entry.value(QStringLiteral("StartDir")));
+        if (startDir.isEmpty() && !exe.isEmpty()) {
+          startDir = QFileInfo(exe).absolutePath();
+        }
+        const QString icon = unquotePath(entry.value(QStringLiteral("icon")));
+        const Activity gameActivity = activity.value(appId);
+        SteamGameRecord game{
+            .appId = appId,
+            .title = name,
+            .installDirectory = startDir,
+            .libraryPath = cleanPath(root),
+            .manifestPath = shortcutsPath,
+            .coverPath = {},
+            .heroPath = {},
+            .logoPath = {},
+            .lastPlayed = qMax(gameActivity.lastPlayed, entry.value(QStringLiteral("LastPlayTime"))
+                                                            .toLongLong()),
+            .playtimeMinutes = gameActivity.playtimeMinutes,
+            .achievementsUnlocked = 0,
+            .achievementsTotal = 0,
+            .achievements = {},
+        };
+        resolveArtwork(&game, steamRoots);
+        if (game.coverPath.isEmpty() && !icon.isEmpty() && QFileInfo::exists(icon)) {
+          game.coverPath = icon;
+        }
+        result->games.append(game);
+        importedIds->insert(appId);
+      }
+    }
+  }
+}
+
 QStringList libraryPaths(const QString& steamRoot, QStringList* warnings, bool* incomplete) {
   QStringList paths{steamRoot};
   QString libraryFile = steamRoot + QStringLiteral("/config/libraryfolders.vdf");
@@ -372,6 +450,8 @@ SteamScanResult SteamScanner::scan(const QStringList& steamRoots) {
       }
     }
   }
+
+  importNonSteamShortcuts(steamRoots, activity, &importedIds, &result);
 
   result.libraryPaths.removeDuplicates();
 

--- a/src/sources/steam/SteamScanner.cpp
+++ b/src/sources/steam/SteamScanner.cpp
@@ -227,6 +227,7 @@ void importNonSteamShortcuts(const QStringList& steamRoots, const QHash<QString,
       if (!ValveKeyValuesParser::parseBinaryFile(shortcutsPath, &parsed, &error)) {
         result->warnings.append(
             QStringLiteral("Could not read %1: %2").arg(shortcutsPath, error));
+        result->unreadableManifests.append(shortcutsPath);
         continue;
       }
       const ValveKeyValues* shortcuts = parsed.object(QStringLiteral("shortcuts"));

--- a/src/sources/steam/ValveKeyValues.cpp
+++ b/src/sources/steam/ValveKeyValues.cpp
@@ -303,6 +303,11 @@ bool ValveKeyValuesParser::parseBinary(const QByteArray& contents, ValveKeyValue
       static_cast<unsigned char>(contents.at(position)) == 0x08) {
     ++position;
   }
+  if (success && position != contents.size()) {
+    localError = QStringLiteral("Unexpected trailing data");
+    *result = {};
+    success = false;
+  }
   if (error != nullptr) {
     *error = localError;
   }
@@ -318,11 +323,12 @@ bool ValveKeyValuesParser::parseBinaryFile(const QString& path, ValveKeyValues* 
     }
     return false;
   }
-  if (file.size() > kMaximumFileBytes) {
+  const QByteArray contents = file.read(kMaximumFileBytes + 1);
+  if (contents.size() > kMaximumFileBytes) {
     if (error != nullptr) {
       *error = QStringLiteral("File is too large");
     }
     return false;
   }
-  return parseBinary(file.readAll(), result, error);
+  return parseBinary(contents, result, error);
 }

--- a/src/sources/steam/ValveKeyValues.cpp
+++ b/src/sources/steam/ValveKeyValues.cpp
@@ -1,6 +1,7 @@
 #include "sources/steam/ValveKeyValues.h"
 
 #include <QFile>
+#include <QtEndian>
 
 #include <cctype>
 
@@ -185,4 +186,143 @@ bool ValveKeyValuesParser::parseFile(const QString& path, ValveKeyValues* result
     return false;
   }
   return parse(file.readAll(), result, error);
+}
+
+namespace {
+bool readCString(const QByteArray& input, qsizetype* position, QString* result, QString* error) {
+  const qsizetype start = *position;
+  while (*position < input.size()) {
+    if (input.at(*position) == '\0') {
+      *result = QString::fromUtf8(input.constData() + start, *position - start);
+      ++(*position);
+      return true;
+    }
+    ++(*position);
+  }
+  *error = QStringLiteral("Unterminated binary string");
+  return false;
+}
+
+bool parseBinaryObject(const QByteArray& input, qsizetype* position, ValveKeyValues* result,
+                       int depth, QString* error) {
+  if (depth > kMaximumNestingDepth) {
+    *error = QStringLiteral("Object nesting is too deep");
+    return false;
+  }
+  while (true) {
+    if (*position >= input.size()) {
+      *error = QStringLiteral("Object is missing a closing marker");
+      return false;
+    }
+    const auto type = static_cast<unsigned char>(input.at((*position)++));
+    if (type == 0x08) {
+      return true;
+    }
+    QString key;
+    if (!readCString(input, position, &key, error)) {
+      return false;
+    }
+    if (type == 0x00) {
+      ValveKeyValues child;
+      if (!parseBinaryObject(input, position, &child, depth + 1, error)) {
+        return false;
+      }
+      result->objects.insert(key, child);
+      continue;
+    }
+    if (type == 0x01) {
+      QString value;
+      if (!readCString(input, position, &value, error)) {
+        return false;
+      }
+      result->values.insert(key, value);
+      continue;
+    }
+    if (type == 0x02) {
+      if (*position + 4 > input.size()) {
+        *error = QStringLiteral("Truncated 32-bit value");
+        return false;
+      }
+      const auto value =
+          qFromLittleEndian<quint32>(input.constData() + *position);
+      *position += 4;
+      result->values.insert(key, QString::number(value));
+      continue;
+    }
+    if (type == 0x07) {
+      if (*position + 8 > input.size()) {
+        *error = QStringLiteral("Truncated 64-bit value");
+        return false;
+      }
+      const auto value =
+          qFromLittleEndian<quint64>(input.constData() + *position);
+      *position += 8;
+      result->values.insert(key, QString::number(value));
+      continue;
+    }
+    *error = QStringLiteral("Unsupported binary type %1").arg(type);
+    return false;
+  }
+}
+} // namespace
+
+bool ValveKeyValuesParser::parseBinary(const QByteArray& contents, ValveKeyValues* result,
+                                       QString* error) {
+  if (result == nullptr) {
+    return false;
+  }
+  *result = {};
+  if (contents.size() > kMaximumFileBytes) {
+    if (error != nullptr) {
+      *error = QStringLiteral("File is too large");
+    }
+    return false;
+  }
+  if (contents.isEmpty()) {
+    return true;
+  }
+
+  QString localError;
+  qsizetype position = 0;
+  bool success = false;
+  if (static_cast<unsigned char>(contents.at(0)) == 0x00) {
+    ++position;
+    QString rootKey;
+    success = readCString(contents, &position, &rootKey, &localError);
+    if (success) {
+      ValveKeyValues child;
+      success = parseBinaryObject(contents, &position, &child, 1, &localError);
+      if (success) {
+        result->objects.insert(rootKey, child);
+      }
+    }
+  } else {
+    success = parseBinaryObject(contents, &position, result, 0, &localError);
+  }
+  if (success && position < contents.size() &&
+      static_cast<unsigned char>(contents.at(position)) == 0x08) {
+    ++position;
+  }
+  if (error != nullptr) {
+    *error = localError;
+  }
+  return success;
+}
+
+bool ValveKeyValuesParser::parseBinaryFile(const QString& path, ValveKeyValues* result,
+                                           QString* error) {
+  QFile file(path);
+  if (!file.open(QIODevice::ReadOnly)) {
+    if (error != nullptr) {
+      *error = file.errorString();
+    }
+    return false;
+  }
+  if (file.size() > kMaximumFileBytes) {
+    if (error != nullptr) {
+      *error = QStringLiteral("File is too large");
+    }
+    return false;
+  }
+  return parseBinary(file.readAll(), result, error);
 }

--- a/src/sources/steam/ValveKeyValues.h
+++ b/src/sources/steam/ValveKeyValues.h
@@ -17,4 +17,8 @@ public:
                                   QString* error = nullptr);
   [[nodiscard]] static bool parseFile(const QString& path, ValveKeyValues* result,
                                       QString* error = nullptr);
+  [[nodiscard]] static bool parseBinary(const QByteArray& contents, ValveKeyValues* result,
+                                        QString* error = nullptr);
+  [[nodiscard]] static bool parseBinaryFile(const QString& path, ValveKeyValues* result,
+                                            QString* error = nullptr);
 };

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -579,6 +579,10 @@ void CoreTests::valveKeyValuesRejectsMalformedInput() {
   QString error;
   QVERIFY(!ValveKeyValuesParser::parse("\"Root\" { \"name\" \"unfinished\"", &values, &error));
   QVERIFY(!error.isEmpty());
+
+  const QByteArray trailing = sampleShortcutsVdf("/icon.png") + QByteArray(1, 0x01);
+  QVERIFY(!ValveKeyValuesParser::parseBinary(trailing, &values, &error));
+  QCOMPARE(error, QStringLiteral("Unexpected trailing data"));
 }
 
 void CoreTests::valveKeyValuesRejectsExcessiveNesting() {
@@ -657,6 +661,14 @@ void CoreTests::steamScannerImportsNonSteamShortcuts() {
   QCOMPARE(shortcut->lastPlayed, 1700000001);
   QVERIFY(shortcut->coverPath.endsWith(QStringLiteral("3236138358p.png")));
   QVERIFY(result.warnings.isEmpty());
+  QVERIFY(result.unreadableManifests.isEmpty());
+
+  writeFile(root + QStringLiteral("/userdata/42/config/shortcuts.vdf"), "not a binary vdf");
+  const SteamScanResult unreadable = SteamScanner::scan({root});
+  QCOMPARE(unreadable.games.size(), 2);
+  QCOMPARE(unreadable.unreadableManifests.size(), 1);
+  QVERIFY(unreadable.unreadableManifests.constFirst().endsWith(QStringLiteral("shortcuts.vdf")));
+  QVERIFY(unreadable.warnings.join(QLatin1Char('\n')).contains(QStringLiteral("shortcuts.vdf")));
 }
 
 void CoreTests::steamScannerRejectsLandscapeCoverFallbackAndImportsAchievements() {

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -39,12 +39,65 @@
 
 #include <SDL3/SDL.h>
 
+#include <algorithm>
+
 namespace {
 void writeFile(const QString& path, const QByteArray& contents) {
   QDir().mkpath(QFileInfo(path).absolutePath());
   QFile file(path);
   QVERIFY2(file.open(QIODevice::WriteOnly | QIODevice::Truncate), qPrintable(file.errorString()));
   QCOMPARE(file.write(contents), contents.size());
+}
+
+QByteArray binaryCString(const QByteArray& value) {
+  QByteArray out = value;
+  out.append('\0');
+  return out;
+}
+
+QByteArray binaryKey(char type, const QByteArray& key) {
+  QByteArray out;
+  out.append(type);
+  out.append(binaryCString(key));
+  return out;
+}
+
+QByteArray binaryStringField(const QByteArray& key, const QByteArray& value) {
+  return binaryKey(0x01, key) + binaryCString(value);
+}
+
+QByteArray binaryIntField(const QByteArray& key, quint32 value) {
+  QByteArray out = binaryKey(0x02, key);
+  out.append(char(value & 0xff));
+  out.append(char((value >> 8) & 0xff));
+  out.append(char((value >> 16) & 0xff));
+  out.append(char((value >> 24) & 0xff));
+  return out;
+}
+
+QByteArray sampleShortcutsVdf(const QByteArray& iconPath) {
+  QByteArray shortcut = binaryKey(0x00, "0");
+  shortcut += binaryIntField("appid", 3236138358u);
+  shortcut += binaryStringField("AppName", "Soulframe");
+  shortcut += binaryStringField("Exe", "/games/Soulframe/Launcher.exe");
+  shortcut += binaryStringField("StartDir", "/games/Soulframe");
+  shortcut += binaryStringField("icon", iconPath);
+  shortcut += binaryIntField("LastPlayTime", 1700000001);
+  shortcut += binaryKey(0x00, "tags");
+  shortcut += char(0x08);
+  shortcut += char(0x08);
+
+  QByteArray skipped = binaryKey(0x00, "1");
+  skipped += binaryIntField("appid", 1);
+  skipped += binaryStringField("AppName", "");
+  skipped += char(0x08);
+
+  QByteArray shortcuts = binaryKey(0x00, "shortcuts");
+  shortcuts += shortcut;
+  shortcuts += skipped;
+  shortcuts += char(0x08);
+  shortcuts += char(0x08);
+  return shortcuts;
 }
 
 QByteArray sampleTheme(const QByteArray& accent = "#7aa2f7") {
@@ -233,6 +286,7 @@ private slots:
   void valveKeyValuesRejectsMalformedInput();
   void valveKeyValuesRejectsExcessiveNesting();
   void steamScannerImportsLibrariesAndCustomArtwork();
+  void steamScannerImportsNonSteamShortcuts();
   void steamScannerRejectsLandscapeCoverFallbackAndImportsAchievements();
   void steamScannerSurvivesMissingLibrariesAndBrokenManifests();
   void steamModelPersistsFavoritesAndHiddenState();
@@ -564,6 +618,44 @@ void CoreTests::steamScannerImportsLibrariesAndCustomArtwork() {
   QCOMPARE(result.games.at(0).playtimeMinutes, 125);
   QVERIFY(result.games.at(0).coverPath.endsWith(QStringLiteral("10p.png")));
   QCOMPARE(result.games.at(1).appId, QStringLiteral("20"));
+  QVERIFY(result.warnings.isEmpty());
+}
+
+void CoreTests::steamScannerImportsNonSteamShortcuts() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/Steam");
+  const QString second = directory.path() + QStringLiteral("/Second Library");
+  createSteamFixture(root, second);
+
+  const QString icon = directory.path() + QStringLiteral("/soulframe-icon.png");
+  writeFile(icon, "icon");
+  writeFile(root + QStringLiteral("/userdata/42/config/shortcuts.vdf"),
+            sampleShortcutsVdf(icon.toUtf8()));
+  writeFile(root + QStringLiteral("/userdata/42/config/grid/3236138358p.png"), "shortcut cover");
+  writeFile(root + QStringLiteral("/userdata/42/config/localconfig.vdf"),
+            "\"UserLocalConfigStore\" { \"Software\" { \"Valve\" { \"Steam\" { \"apps\" { "
+            "\"10\" { \"LastPlayed\" \"1700000000\" \"Playtime\" \"125\" } "
+            "\"3236138358\" { \"LastPlayed\" \"1690000000\" \"Playtime\" \"954\" } } } } } }\n");
+
+  ValveKeyValues parsed;
+  QVERIFY(ValveKeyValuesParser::parseBinaryFile(
+      root + QStringLiteral("/userdata/42/config/shortcuts.vdf"), &parsed));
+  QCOMPARE(parsed.object(QStringLiteral("shortcuts"))->object(QStringLiteral("0"))
+               ->value(QStringLiteral("AppName")),
+           QStringLiteral("Soulframe"));
+
+  const SteamScanResult result = SteamScanner::scan({root});
+  QCOMPARE(result.games.size(), 3);
+  const auto shortcut = std::find_if(result.games.cbegin(), result.games.cend(), [](const auto& game) {
+    return game.appId == QStringLiteral("3236138358");
+  });
+  QVERIFY(shortcut != result.games.cend());
+  QCOMPARE(shortcut->title, QStringLiteral("Soulframe"));
+  QCOMPARE(shortcut->installDirectory, QStringLiteral("/games/Soulframe"));
+  QCOMPARE(shortcut->playtimeMinutes, 954);
+  QCOMPARE(shortcut->lastPlayed, 1700000001);
+  QVERIFY(shortcut->coverPath.endsWith(QStringLiteral("3236138358p.png")));
   QVERIFY(result.warnings.isEmpty());
 }
 
@@ -1050,6 +1142,10 @@ void CoreTests::steamLauncherBuildsSafeUrls() {
            QUrl(QStringLiteral("steam://nav/games/details/440")));
   QCOMPARE(SteamLauncher::installUrl(QStringLiteral("440")),
            QUrl(QStringLiteral("steam://install/440")));
+  QCOMPARE(SteamLauncher::launchUrl(QStringLiteral("3236138358")),
+           QUrl(QStringLiteral("steam://rungameid/13899108412974694400")));
+  QCOMPARE(SteamLauncher::launchUrl(QStringLiteral("13899108412974694400")),
+           QUrl(QStringLiteral("steam://rungameid/13899108412974694400")));
   QVERIFY(SteamLauncher::launchUrl(QStringLiteral("440;touch /tmp/nope")).isEmpty());
   QVERIFY(SteamLauncher::installUrl(QStringLiteral("440;touch /tmp/nope")).isEmpty());
 }


### PR DESCRIPTION
## Summary

Omakade only listed Steam games that have an `appmanifest_*.acf`. Titles added with Steam's **Add a Non-Steam Game** (typical for Wine/Proton Windows games) live in `userdata/<id>/config/shortcuts.vdf` and never appeared.

## What this does

- Parses binary `shortcuts.vdf` through a new `ValveKeyValuesParser::parseBinary` path
- Imports named shortcuts into the Steam library
- Reuses Steam grid artwork (`{appid}p.*`, `_hero`, `_logo`) and falls back to the shortcut icon
- Reuses `localconfig.vdf` playtime keyed by the 32-bit shortcut appid
- Launches with Steam's 64-bit shortcut ID: `(appid << 32) | 0x02000000`
- Watches `shortcuts.vdf` for rescans
- Skips Steam store capsule downloads for shortcut IDs (the high bit is set)

Omakade still only reads Steam files. It does not write shortcuts, prefixes, or Proton settings.

## Tests

`ctest --preset dev` — 8/8 targets pass, including:

- `steamScannerImportsNonSteamShortcuts`
- `steamLauncherBuildsSafeUrls` now covers the 64-bit shortcut launch URL

Manually tested on Omarchy 4 with native Steam: three Proton non-Steam shortcuts appeared with grid art and playtime, and Play handed off to Steam.

## Test plan

- [x] `ctest --preset dev`
- [ ] Maintainer: add a non-Steam shortcut in Steam, rescan, confirm it appears and Play launches through Steam

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering non-Steam shortcuts configured in Steam, including Wine/Proton games.
  * Imported shortcuts now include playtime, last-played information, and available artwork.
  * Non-Steam shortcuts can be launched correctly through Steam.

* **Bug Fixes**
  * Improved handling of Steam shortcut identifiers for reliable launching.
  * Steam shortcut scanning now continues safely when shortcut data is unreadable.

* **Documentation**
  * Updated the changelog and README to document Steam non-Steam shortcut support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->