### PR TITLE
Add Battle.net as a library source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Battle.net
+
+- Added Battle.net as a library source. Omakade finds the Windows Battle.net
+  client in Wine, Proton, and Bottles prefixes, imports installed games from
+  `product.db`, and launches them through Battle.net.
+- Downloads missing Battle.net covers and banners from Lutris's public artwork
+  hosts, including Heroes of the Storm.
+
 ## 1.3.1
 
 - Left the library, database, and cover requests alone when a Steam rescan finds the same

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ add_library(omakade_core STATIC
   src/library/LibraryFilterModel.cpp
   src/library/LibraryFilterModel.h
   src/library/GameRoles.h
+  src/library/BattleNetGameModel.cpp
+  src/library/BattleNetGameModel.h
   src/library/FaugusGameModel.cpp
   src/library/FaugusGameModel.h
   src/library/HeroicGameModel.cpp
@@ -68,6 +70,8 @@ add_library(omakade_core STATIC
   src/sources/heroic/HeroicScanner.h
   src/sources/faugus/FaugusScanner.cpp
   src/sources/faugus/FaugusScanner.h
+  src/sources/battlenet/BattleNetScanner.cpp
+  src/sources/battlenet/BattleNetScanner.h
   src/theme/OmarchyTheme.cpp
   src/theme/OmarchyTheme.h
 )

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,13 +1,13 @@
 # Omakade product and delivery plan
 
 Implementation status: M0 through M5 are complete. Steam, Lutris, Heroic,
-Faugus, and RetroArch import, launch delegation, source filters, organization,
+Faugus, RetroArch, and Battle.net import, launch delegation, source filters, organization,
 settings, release checks, and explicit linking are implemented.
 
 ## Product statement
 
 Omakade is a beautiful, local-first game library built for Omarchy. It brings
-installed games from Steam, Lutris, Heroic, Faugus, and RetroArch into one coherent place.
+installed games from Steam, Lutris, Heroic, Faugus, RetroArch, and Battle.net into one coherent place.
 It owns discovery, presentation, search, achievements, organization, and the
 launch action. Existing platforms continue to own authentication, installation,
 updates, compatibility tools, cloud saves, DRM, and overlays.
@@ -416,6 +416,14 @@ must not replace local installed-game discovery.
   and runtime logs without crawling arbitrary ROM folders.
 - Do not become an emulator manager in the first major release.
 - RetroAchievements is a separate optional connection.
+
+### Battle.net
+
+- Discover Wine, Proton, and Bottles prefixes that contain Battle.net's Agent
+  `product.db`. Do not crawl arbitrary home folders.
+- Import installed products only, skipping the Battle.net agent and app.
+- Launch through the Battle.net client in the same prefix. Keep authentication,
+  installation, updates, and DRM in Battle.net.
 
 ## Omarchy operating-system integration
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -8,8 +8,9 @@ system, or required online service.
 Omakade reads Steam library manifests, artwork caches, playtime, recent-play
 state, and achievement caches. It also reads installed-game manifests and
 cached artwork from Lutris and Heroic, Heroic's sideloaded game list and play
-timestamps, plus configured playlists, thumbnails, and runtime logs from
-RetroArch. It never writes into source launcher directories.
+timestamps, configured playlists, thumbnails, and runtime logs from RetroArch,
+and Battle.net Agent product databases plus last-played stamps inside Wine,
+Proton, and Bottles prefixes. It never writes into source launcher directories.
 
 Omakade retains:
 
@@ -41,7 +42,8 @@ obtain an app access token, then sends the token and client ID to IGDB.
 ## Network requests
 
 Omakade may request missing covers and achievement icons from Steam's public
-HTTPS artwork hosts. Responses are size-limited and the artwork cache is
+HTTPS artwork hosts, and missing Battle.net covers and banners from Lutris's
+public game-art URLs. Responses are size-limited and the artwork cache is
 bounded by the configured limit.
 
 Steam Web API requests occur only after the user stores a key. Omakade refreshes

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [Watch the 18-second demo](https://tsouth89.github.io/omakade/assets/omakade-demo.mp4)
 
 Omakade is a fast, local-first game library built for Omarchy. It brings
-installed Steam, Lutris, Heroic, Faugus, RetroArch, Epic, GOG, and Amazon games
+installed Steam, Lutris, Heroic, Faugus, RetroArch, Battle.net, Epic, GOG, and Amazon games
 into one quiet, cover-focused home that follows the active Omarchy theme.
 
 [Project homepage](https://tsouth89.github.io/omakade/) ·
@@ -24,7 +24,8 @@ into one quiet, cover-focused home that follows the active Omarchy theme.
 Omakade includes:
 
 - Native and Flatpak Steam, Lutris, Heroic, Faugus, and RetroArch discovery,
-  including games sideloaded into Heroic
+  including games sideloaded into Heroic, plus Battle.net games from Wine,
+  Proton, and Bottles prefixes
 - One-click details and delegated launching through the owning platform
 - Omarchy palette, font, transparency, and live theme updates
 - Search, favorites, hidden games, sorting, and source filters
@@ -100,6 +101,10 @@ RetroArch games come from its configured playlists. Omakade uses local
 RetroArch thumbnails and runtime logs, then launches each game with its assigned
 core. Entries without a core association remain visible and explain how to fix
 launching after you press Play.
+
+Battle.net games come from the Battle.net Agent database inside a Wine, Proton,
+or Bottles prefix. Omakade launches each title through that prefix's Battle.net
+client. Wine, umu-launcher, or Bottles must be installed to play.
 
 ## Build
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,7 +4,8 @@ Please include these details with a bug report:
 
 - Omakade version
 - Omarchy version and active theme
-- Native or Flatpak installation for Steam, Lutris, Heroic, Faugus, or RetroArch
+- Native or Flatpak installation for Steam, Lutris, Heroic, Faugus, RetroArch,
+  or Battle.net (and whether Battle.net runs under Wine, Proton, or Bottles)
 - The source shown for the affected game
 - Steps that reproduce the problem
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -38,8 +38,9 @@ CI. Additional real-user reports expand compatibility coverage after v1.
 ## Contract-tested sources
 
 Lutris native and Flatpak discovery, Heroic native and Flatpak discovery,
-Faugus and RetroArch native and Flatpak discovery, and Epic, GOG, and Amazon
-manifests are covered by repeatable local fixtures. These
+Faugus and RetroArch native and Flatpak discovery, Epic, GOG, and Amazon
+manifests, and Battle.net product.db discovery across Wine, Proton, and Bottles
+prefixes are covered by repeatable local fixtures. These
 paths still need reports from users with those launchers installed before the
 stable release gate can close.
 
@@ -50,6 +51,7 @@ stable release gate can close.
 - Native and Flatpak Heroic libraries from real users
 - A configured native or Flatpak Faugus library from a real user
 - A configured native or Flatpak RetroArch library from a real user
+- A Battle.net library from a real Wine, Proton, or Bottles prefix
 - Steam Flatpak from a real user
 - Light, scaled, ultrawide, and blur-disabled checks on real displays
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
       <section class="hero wrap">
         <div class="eyebrow"><span></span> Built for Omarchy</div>
         <h1>Your games,<br><em>beautifully together.</em></h1>
-        <p class="lede">A fast, local-first home for Steam, Lutris, Heroic, Faugus, RetroArch, Epic, GOG, and Amazon games. Theme-native, controller-ready, and quiet by design.</p>
+        <p class="lede">A fast, local-first home for Steam, Lutris, Heroic, Faugus, RetroArch, Battle.net, Epic, GOG, and Amazon games. Theme-native, controller-ready, and quiet by design.</p>
         <div class="actions">
           <a class="button primary" href="https://github.com/tsouth89/omakade/releases/latest">Get Omakade</a>
           <a class="button secondary" href="https://github.com/tsouth89/omakade#build">Build from source</a>
@@ -86,7 +86,7 @@
           <h2>Bring the launchers.<br>Lose the clutter.</h2>
         </div>
         <div class="source-list">
-          <span>STEAM</span><span>LUTRIS</span><span>HEROIC</span><span>FAUGUS</span><span>RETROARCH</span><span>EPIC</span><span>GOG</span><span>AMAZON</span>
+          <span>STEAM</span><span>LUTRIS</span><span>HEROIC</span><span>FAUGUS</span><span>RETROARCH</span><span>BATTLE.NET</span><span>EPIC</span><span>GOG</span><span>AMAZON</span>
         </div>
       </section>
 

--- a/packaging/io.github.tsouth89.Omakade.metainfo.xml
+++ b/packaging/io.github.tsouth89.Omakade.metainfo.xml
@@ -11,7 +11,7 @@
   <description>
     <p>
       Omakade is a local-first game library for Omarchy. It discovers installed
-      Steam, Lutris, Heroic, Faugus, and RetroArch games, uses local artwork,
+      Steam, Lutris, Heroic, Faugus, RetroArch, and Battle.net games, uses local artwork,
       follows the active Omarchy theme, and delegates launching back to the owning platform.
     </p>
   </description>

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -163,6 +163,7 @@ ApplicationWindow {
         if (HeroicLibrary && Preferences.heroicEnabled) HeroicLibrary.refresh()
         if (FaugusLibrary && Preferences.faugusEnabled) FaugusLibrary.refresh()
         if (RetroArchLibrary && Preferences.retroArchEnabled) RetroArchLibrary.refresh()
+        if (BattleNetLibrary && Preferences.battleNetEnabled) BattleNetLibrary.refresh()
     }
 
     function focusAboveGrid() {
@@ -375,7 +376,8 @@ ApplicationWindow {
     function manageSelected() {
         if (Launcher.manage(selectedInstallation.source, selectedInstallation.appId,
                             selectedInstallation.flatpak || false,
-                            selectedInstallation.runner || "")) {
+                            selectedInstallation.runner || "",
+                            selectedInstallation.launchTarget || "")) {
             showToast("Opening " + selectedInstallation.source)
         } else {
             showToast(Launcher.lastError)
@@ -873,6 +875,18 @@ ApplicationWindow {
                         }
                     }
                     GlassButton {
+                        id: battleNetSourceButton
+                        objectName: "battleNetSourceButton"
+                        text: "BATTLE.NET"
+                        compact: true
+                        visible: Preferences.battleNetEnabled
+                        selected: Library.sourceFilter === "Battle.net"
+                        onClicked: {
+                            Library.sourceFilter = "Battle.net"
+                            libraryView.currentIndex = Library.rowCount() > 0 ? 0 : -1
+                        }
+                    }
+                    GlassButton {
                         id: lutrisSourceButton
                         objectName: "lutrisSourceButton"
                         text: "LUTRIS"
@@ -1117,6 +1131,8 @@ ApplicationWindow {
                             ? "Faugus was not found"
                             : Library.sourceFilter === "RetroArch" && RetroArchLibrary && !RetroArchLibrary.retroArchDetected
                             ? "RetroArch was not found"
+                            : Library.sourceFilter === "Battle.net" && BattleNetLibrary && !BattleNetLibrary.battleNetDetected
+                            ? "Battle.net was not found"
                             : Library.sourceFilter === "Lutris" && LutrisLibrary && !LutrisLibrary.lutrisDetected
                             ? "Lutris was not found"
                             : Library.sourceFilter === "Steam" && SteamLibrary && !SteamLibrary.steamDetected
@@ -1137,14 +1153,18 @@ ApplicationWindow {
                               ? HeroicLibrary.errorText
                               : Library.sourceFilter === "Lutris" && LutrisLibrary && LutrisLibrary.errorText.length > 0
                               ? LutrisLibrary.errorText
+                              : Library.sourceFilter === "Battle.net" && BattleNetLibrary && BattleNetLibrary.errorText.length > 0
+                              ? BattleNetLibrary.errorText
                               : SteamLibrary && SteamLibrary.errorText.length > 0
                                 ? SteamLibrary.errorText
-                                : "Install a game in Steam, Lutris, Heroic, Faugus, or RetroArch, then rescan your library."
+                                : "Install a game in Steam, Lutris, Heroic, Faugus, RetroArch, or Battle.net, then rescan your library."
                 onGameActivated: index => root.openGame(index)
                 onFavoriteToggled: index => Library.toggleFavorite(index)
                 onCoverRequested: function(source, appId) {
                     if (source === "Steam" && SteamLibrary) {
                         SteamLibrary.requestCover(appId)
+                    } else if (source === "Battle.net" && BattleNetLibrary) {
+                        BattleNetLibrary.requestCover(appId)
                     }
                 }
                 onRefreshRequested: {
@@ -1521,6 +1541,11 @@ ApplicationWindow {
                           error: SteamLibrary ? SteamLibrary.errorText : "",
                           paths: SteamLibrary ? SteamLibrary.detectedPaths : [],
                           lastScan: SteamLibrary ? SteamLibrary.lastScan : 0 },
+                        { name: "BATTLE.NET", enabled: Preferences.battleNetEnabled,
+                          status: BattleNetLibrary ? BattleNetLibrary.statusText : "Unavailable",
+                          error: BattleNetLibrary ? BattleNetLibrary.errorText : "",
+                          paths: BattleNetLibrary ? BattleNetLibrary.detectedPaths : [],
+                          lastScan: BattleNetLibrary ? BattleNetLibrary.lastScan : 0 },
                         { name: "LUTRIS", enabled: Preferences.lutrisEnabled,
                           status: LutrisLibrary ? LutrisLibrary.statusText : "Unavailable",
                           error: LutrisLibrary ? LutrisLibrary.errorText : "",
@@ -1566,6 +1591,10 @@ ApplicationWindow {
                                         Preferences.steamEnabled = !Preferences.steamEnabled
                                         nowEnabled = Preferences.steamEnabled
                                         if (Preferences.steamEnabled) SteamLibrary.refresh()
+                                    } else if (modelData.name === "BATTLE.NET") {
+                                        Preferences.battleNetEnabled = !Preferences.battleNetEnabled
+                                        nowEnabled = Preferences.battleNetEnabled
+                                        if (Preferences.battleNetEnabled) BattleNetLibrary.refresh()
                                     } else if (modelData.name === "LUTRIS") {
                                         Preferences.lutrisEnabled = !Preferences.lutrisEnabled
                                         nowEnabled = Preferences.lutrisEnabled
@@ -1594,6 +1623,7 @@ ApplicationWindow {
                                 enabled: modelData.enabled
                                 onClicked: {
                                     if (modelData.name === "STEAM") SteamLibrary.refresh()
+                                    else if (modelData.name === "BATTLE.NET") BattleNetLibrary.refresh()
                                     else if (modelData.name === "LUTRIS") LutrisLibrary.refresh()
                                     else if (modelData.name === "HEROIC") HeroicLibrary.refresh()
                                     else if (modelData.name === "FAUGUS") FaugusLibrary.refresh()

--- a/qml/screens/GameDetails.qml
+++ b/qml/screens/GameDetails.qml
@@ -378,6 +378,7 @@ Item {
                                  || root.selectedInstallation.source === "Heroic"
                                  || root.selectedInstallation.source === "Faugus"
                                  || root.selectedInstallation.source === "RetroArch"
+                                 || root.selectedInstallation.source === "Battle.net"
                         text: "MANAGE IN " + (root.selectedInstallation.source || "LAUNCHER").toUpperCase()
                         onClicked: root.manageRequested()
                     }

--- a/src/app/AppSettings.cpp
+++ b/src/app/AppSettings.cpp
@@ -116,6 +116,17 @@ void AppSettings::setRetroArchEnabled(bool value) {
   emit sourcesChanged();
 }
 
+bool AppSettings::battleNetEnabled() const { return m_battleNetEnabled; }
+
+void AppSettings::setBattleNetEnabled(bool value) {
+  if (m_battleNetEnabled == value) {
+    return;
+  }
+  m_battleNetEnabled = value;
+  save();
+  emit sourcesChanged();
+}
+
 bool AppSettings::closeAfterLaunch() const { return m_closeAfterLaunch; }
 
 void AppSettings::setCloseAfterLaunch(bool value) {
@@ -171,6 +182,7 @@ void AppSettings::load() {
   m_heroicEnabled = readEnabled(QStringLiteral("heroic_enabled"), true);
   m_faugusEnabled = readEnabled(QStringLiteral("faugus_enabled"), true);
   m_retroArchEnabled = readEnabled(QStringLiteral("retroarch_enabled"), true);
+  m_battleNetEnabled = readEnabled(QStringLiteral("battlenet_enabled"), true);
   m_closeAfterLaunch = readEnabled(QStringLiteral("close_after_launch"), false);
 }
 
@@ -183,7 +195,8 @@ void AppSettings::save() const {
   file.write(QStringLiteral("reduced_motion = %1\nartwork_cache_limit_mb = %2\nsteam_id = "
                             "\"%3\"\nigdb_client_id = \"%4\"\nsteam_enabled = %5\n"
                             "lutris_enabled = %6\nheroic_enabled = %7\nfaugus_enabled = %8\n"
-                            "retroarch_enabled = %9\nclose_after_launch = %10\n")
+                            "retroarch_enabled = %9\nbattlenet_enabled = %10\n"
+                            "close_after_launch = %11\n")
                  .arg(m_reducedMotion ? QStringLiteral("true") : QStringLiteral("false"))
                  .arg(m_artworkCacheLimitMb)
                  .arg(m_steamId)
@@ -193,6 +206,7 @@ void AppSettings::save() const {
                  .arg(m_heroicEnabled ? QStringLiteral("true") : QStringLiteral("false"))
                  .arg(m_faugusEnabled ? QStringLiteral("true") : QStringLiteral("false"))
                  .arg(m_retroArchEnabled ? QStringLiteral("true") : QStringLiteral("false"))
+                 .arg(m_battleNetEnabled ? QStringLiteral("true") : QStringLiteral("false"))
                  .arg(m_closeAfterLaunch ? QStringLiteral("true") : QStringLiteral("false"))
                  .toUtf8());
   file.commit();

--- a/src/app/AppSettings.h
+++ b/src/app/AppSettings.h
@@ -18,6 +18,8 @@ class AppSettings final : public QObject {
   Q_PROPERTY(bool faugusEnabled READ faugusEnabled WRITE setFaugusEnabled NOTIFY sourcesChanged)
   Q_PROPERTY(
       bool retroArchEnabled READ retroArchEnabled WRITE setRetroArchEnabled NOTIFY sourcesChanged)
+  Q_PROPERTY(
+      bool battleNetEnabled READ battleNetEnabled WRITE setBattleNetEnabled NOTIFY sourcesChanged)
   Q_PROPERTY(bool closeAfterLaunch READ closeAfterLaunch WRITE setCloseAfterLaunch NOTIFY
                  closeAfterLaunchChanged)
 
@@ -42,6 +44,8 @@ public:
   void setFaugusEnabled(bool value);
   [[nodiscard]] bool retroArchEnabled() const;
   void setRetroArchEnabled(bool value);
+  [[nodiscard]] bool battleNetEnabled() const;
+  void setBattleNetEnabled(bool value);
   [[nodiscard]] bool closeAfterLaunch() const;
   void setCloseAfterLaunch(bool value);
 
@@ -68,5 +72,6 @@ private:
   bool m_heroicEnabled = true;
   bool m_faugusEnabled = true;
   bool m_retroArchEnabled = true;
+  bool m_battleNetEnabled = true;
   bool m_closeAfterLaunch = false;
 };

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -4,6 +4,7 @@
 #include "app/SingleInstance.h"
 #include "input/ControllerInput.h"
 #include "launch/GameLauncher.h"
+#include "library/BattleNetGameModel.h"
 #include "library/FaugusGameModel.h"
 #include "library/HeroicGameModel.h"
 #include "library/LibraryFilterModel.h"
@@ -109,11 +110,13 @@ int main(int argc, char* argv[]) {
   std::unique_ptr<HeroicGameModel> heroicGames;
   std::unique_ptr<FaugusGameModel> faugusGames;
   std::unique_ptr<RetroArchGameModel> retroArchGames;
+  std::unique_ptr<BattleNetGameModel> battleNetGames;
   SteamGameModel* steamLibrary = nullptr;
   LutrisGameModel* lutrisLibrary = nullptr;
   HeroicGameModel* heroicLibrary = nullptr;
   FaugusGameModel* faugusLibrary = nullptr;
   RetroArchGameModel* retroArchLibrary = nullptr;
+  BattleNetGameModel* battleNetLibrary = nullptr;
   QString libraryDatabasePath;
   if (demoMode || stressMode || navigationTest) {
     games =
@@ -131,6 +134,9 @@ int main(int argc, char* argv[]) {
     faugusLibrary = faugusGames.get();
     retroArchGames = std::make_unique<RetroArchGameModel>(steamLibrary->databasePath());
     retroArchLibrary = retroArchGames.get();
+    battleNetGames =
+        std::make_unique<BattleNetGameModel>(steamLibrary->databasePath(), &preferences);
+    battleNetLibrary = battleNetGames.get();
   }
   UnifiedGameModel unifiedGames(libraryDatabasePath);
   unifiedGames.addSourceModel(games.get());
@@ -146,12 +152,16 @@ int main(int argc, char* argv[]) {
   if (retroArchGames != nullptr) {
     unifiedGames.addSourceModel(retroArchGames.get());
   }
+  if (battleNetGames != nullptr) {
+    unifiedGames.addSourceModel(battleNetGames.get());
+  }
   const auto applySourcePreferences = [&] {
     unifiedGames.setSourceEnabled(QStringLiteral("Steam"), preferences.steamEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("Lutris"), preferences.lutrisEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("Heroic"), preferences.heroicEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("Faugus"), preferences.faugusEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("RetroArch"), preferences.retroArchEnabled());
+    unifiedGames.setSourceEnabled(QStringLiteral("Battle.net"), preferences.battleNetEnabled());
   };
   applySourcePreferences();
   QObject::connect(&preferences, &AppSettings::sourcesChanged, &unifiedGames,
@@ -258,6 +268,7 @@ int main(int argc, char* argv[]) {
   engine.rootContext()->setContextProperty(QStringLiteral("HeroicLibrary"), heroicLibrary);
   engine.rootContext()->setContextProperty(QStringLiteral("FaugusLibrary"), faugusLibrary);
   engine.rootContext()->setContextProperty(QStringLiteral("RetroArchLibrary"), retroArchLibrary);
+  engine.rootContext()->setContextProperty(QStringLiteral("BattleNetLibrary"), battleNetLibrary);
   engine.rootContext()->setContextProperty(QStringLiteral("Launcher"), &launcher);
   engine.rootContext()->setContextProperty(QStringLiteral("Preferences"), &preferences);
   engine.rootContext()->setContextProperty(QStringLiteral("Controller"), &controller);
@@ -391,7 +402,7 @@ int main(int argc, char* argv[]) {
                   fail(QStringLiteral("Controller Left did not reach source filters when tiled"));
                   return;
                 }
-                for (int step = 0; step < 5; ++step) {
+                for (int step = 0; step < 6; ++step) {
                   controller.focusDirectionRequested(Qt::Key_Left);
                 }
                 controller.focusDirectionRequested(Qt::Key_Up);
@@ -425,7 +436,7 @@ int main(int argc, char* argv[]) {
                 fail(QStringLiteral("Controller Down did not reach source filters"));
                 return;
               }
-              for (int step = 0; step < 5; ++step) {
+              for (int step = 0; step < 6; ++step) {
                 controller.focusDirectionRequested(Qt::Key_Left);
               }
               if (!allSources->hasActiveFocus()) {
@@ -809,6 +820,9 @@ int main(int argc, char* argv[]) {
   }
   if (retroArchLibrary != nullptr && preferences.retroArchEnabled()) {
     QTimer::singleShot(600, retroArchLibrary, &RetroArchGameModel::refresh);
+  }
+  if (battleNetLibrary != nullptr && preferences.battleNetEnabled()) {
+    QTimer::singleShot(750, battleNetLibrary, &BattleNetGameModel::refresh);
   }
 
   if (smokeTest && !renderMode) {

--- a/src/launch/GameLauncher.cpp
+++ b/src/launch/GameLauncher.cpp
@@ -2,10 +2,14 @@
 
 #include "launch/SteamLauncher.h"
 #include "sources/FlatpakInstall.h"
+#include "sources/battlenet/BattleNetScanner.h"
 
 #include <QDesktopServices>
+#include <QDir>
+#include <QFile>
 #include <QFileInfo>
 #include <QProcess>
+#include <QProcessEnvironment>
 #include <QRegularExpression>
 #include <QStandardPaths>
 #include <QUrlQuery>
@@ -36,6 +40,53 @@ bool installedTargetExists(const QString& path) {
   }
   const qsizetype archiveSeparator = path.indexOf(QLatin1Char('#'));
   return archiveSeparator > 0 && QFileInfo::exists(path.left(archiveSeparator));
+}
+
+bool validBattleNetId(const QString& id) {
+  static const QRegularExpression product(
+      QStringLiteral("^[A-Za-z][A-Za-z0-9._-]{0,63}(@[a-f0-9]{8})?$"));
+  return product.match(id).hasMatch();
+}
+
+bool validBattleNetPrefix(const QString& prefix) {
+  const QString cleaned = QDir::cleanPath(prefix);
+  return cleaned.startsWith(QLatin1Char('/')) && !cleaned.contains(QStringLiteral("/../")) &&
+         !cleaned.contains(QChar::Null);
+}
+
+QString battleNetExecutable(const QString& prefix) {
+  const QStringList candidates = {
+      prefix + QStringLiteral("/drive_c/Program Files (x86)/Battle.net/Battle.net.exe"),
+      prefix + QStringLiteral("/drive_c/Program Files/Battle.net/Battle.net.exe"),
+      prefix + QStringLiteral("/drive_c/Program Files (x86)/Battle.net/Battle.net Launcher.exe"),
+      prefix + QStringLiteral("/drive_c/Program Files/Battle.net/Battle.net Launcher.exe")};
+  for (const QString& candidate : candidates) {
+    if (QFileInfo(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return candidates.constFirst();
+}
+
+QString wineExecutable() {
+  const QString wine = QStandardPaths::findExecutable(QStringLiteral("wine"));
+  return wine.isEmpty() ? QStandardPaths::findExecutable(QStringLiteral("wine64")) : wine;
+}
+
+QString bottlesBottleName(const QString& prefix) {
+  QFile file(prefix + QStringLiteral("/bottle.yml"));
+  if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    static const QRegularExpression name(
+        QStringLiteral("(?m)^Name:\\s*[\"']?([^\"'\\n]+?)[\"']?\\s*$"));
+    const QRegularExpressionMatch match = name.match(QString::fromUtf8(file.readAll()));
+    if (match.hasMatch()) {
+      const QString value = match.captured(1).trimmed();
+      if (!value.isEmpty()) {
+        return value;
+      }
+    }
+  }
+  return QFileInfo(prefix).fileName();
 }
 } // namespace
 
@@ -99,6 +150,34 @@ LaunchCommand GameLauncher::retroArchCommand(const QString& contentPath, const Q
                                  {QStringLiteral("-L"), corePath, contentPath}};
 }
 
+LaunchCommand GameLauncher::battleNetCommand(const QString& id, const QString& prefix,
+                                             const QString& runner, bool flatpak) {
+  if (!validBattleNetId(id) || !validBattleNetPrefix(prefix)) {
+    return {};
+  }
+  const QString launchCode = BattleNetScanner::launchCodeForProduct(id);
+  const QString exe = battleNetExecutable(prefix);
+  const QString execArg = QStringLiteral("--exec=launch %1").arg(launchCode);
+  if (runner == QStringLiteral("bottles")) {
+    const QString bottle = bottlesBottleName(prefix);
+    if (bottle.isEmpty()) {
+      return {};
+    }
+    return flatpak ? LaunchCommand{QStringLiteral("flatpak"),
+                                   {QStringLiteral("run"), QStringLiteral("--command=bottles-cli"),
+                                    QStringLiteral("com.usebottles.bottles"), QStringLiteral("run"),
+                                    QStringLiteral("-b"), bottle, QStringLiteral("-e"), exe,
+                                    QStringLiteral("--"), execArg}}
+                   : LaunchCommand{QStringLiteral("bottles-cli"),
+                                   {QStringLiteral("run"), QStringLiteral("-b"), bottle,
+                                    QStringLiteral("-e"), exe, QStringLiteral("--"), execArg}};
+  }
+  if (runner == QStringLiteral("proton")) {
+    return {QStringLiteral("umu-run"), {exe, execArg}};
+  }
+  return {QStringLiteral("wine"), {exe, execArg}};
+}
+
 bool GameLauncher::launch(const QString& source, const QString& id, bool flatpak,
                           const QString& runner, const QString& installPath,
                           const QString& launchTarget) {
@@ -134,12 +213,15 @@ bool GameLauncher::launch(const QString& source, const QString& id, bool flatpak
   if (source.compare(QStringLiteral("RetroArch"), Qt::CaseInsensitive) == 0) {
     return launchRetroArch(installPath, launchTarget, flatpak, false);
   }
+  if (source.compare(QStringLiteral("Battle.net"), Qt::CaseInsensitive) == 0) {
+    return launchBattleNet(id, launchTarget, runner, flatpak, false);
+  }
   setError(QStringLiteral("%1 games cannot be launched yet.").arg(source));
   return false;
 }
 
 bool GameLauncher::manage(const QString& source, const QString& id, bool flatpak,
-                          const QString& runner) {
+                          const QString& runner, const QString& launchTarget) {
   if (source.compare(QStringLiteral("Steam"), Qt::CaseInsensitive) == 0) {
     const QUrl url = SteamLauncher::manageUrl(id);
     if (!url.isValid() || url.isEmpty() || !QDesktopServices::openUrl(url)) {
@@ -160,6 +242,9 @@ bool GameLauncher::manage(const QString& source, const QString& id, bool flatpak
   }
   if (source.compare(QStringLiteral("RetroArch"), Qt::CaseInsensitive) == 0) {
     return launchRetroArch({}, {}, flatpak, true);
+  }
+  if (source.compare(QStringLiteral("Battle.net"), Qt::CaseInsensitive) == 0) {
+    return launchBattleNet(id, launchTarget, runner, flatpak, true);
   }
   setError(QStringLiteral("%1 does not provide game management yet.").arg(source));
   return false;
@@ -323,6 +408,77 @@ bool GameLauncher::launchRetroArch(const QString& contentPath, const QString& co
   }
   if (!QProcess::startDetached(command.program, command.arguments)) {
     setError(QStringLiteral("RetroArch could not be started. Open RetroArch and try again."));
+    return false;
+  }
+  setError({});
+  return true;
+}
+
+bool GameLauncher::launchBattleNet(const QString& id, const QString& prefix, const QString& runner,
+                                   bool flatpak, bool manageOnly) {
+  LaunchCommand command = battleNetCommand(id, prefix, runner, flatpak);
+  if (!command.isValid()) {
+    setError(QStringLiteral("This game has an invalid Battle.net target."));
+    return false;
+  }
+  const QString exe = battleNetExecutable(prefix);
+  if (!QFileInfo(exe).isFile()) {
+    setError(QStringLiteral(
+        "Battle.net is not installed in this Wine prefix. Install it, then rescan."));
+    return false;
+  }
+  const QString execArg =
+      QStringLiteral("--exec=launch %1").arg(BattleNetScanner::launchCodeForProduct(id));
+  const bool bottlesAvailable =
+      runner == QStringLiteral("bottles") &&
+      !QStandardPaths::findExecutable(command.program).isEmpty();
+  const bool protonAvailable = runner == QStringLiteral("proton") &&
+                               !QStandardPaths::findExecutable(QStringLiteral("umu-run")).isEmpty();
+  if (bottlesAvailable && flatpak) {
+    const QString error =
+        flatpakError(QStringLiteral("com.usebottles.bottles"), QStringLiteral("Bottles"));
+    if (!error.isEmpty()) {
+      setError(error);
+      return false;
+    }
+  }
+  if (!bottlesAvailable && !protonAvailable) {
+    const QString wine = wineExecutable();
+    if (wine.isEmpty()) {
+      if (runner == QStringLiteral("proton")) {
+        setError(QStringLiteral(
+            "umu-launcher is not installed. Install it or Wine to launch Battle.net games."));
+      } else if (runner == QStringLiteral("bottles")) {
+        setError(flatpak ? QStringLiteral("The Bottles Flatpak is not installed.")
+                         : QStringLiteral("Bottles is not installed."));
+      } else {
+        setError(QStringLiteral("Wine is not installed."));
+      }
+      return false;
+    }
+    command = {wine, manageOnly ? QStringList{exe} : QStringList{exe, execArg}};
+  } else if (manageOnly && !command.arguments.isEmpty() &&
+             command.arguments.constLast().startsWith(QStringLiteral("--exec="))) {
+    command.arguments.removeLast();
+    if (!command.arguments.isEmpty() && command.arguments.constLast() == QStringLiteral("--")) {
+      command.arguments.removeLast();
+    }
+  }
+
+  QProcess process;
+  process.setProgram(command.program);
+  process.setArguments(command.arguments);
+  process.setWorkingDirectory(QFileInfo(exe).absolutePath());
+  QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+  environment.insert(QStringLiteral("WINEPREFIX"), QDir::cleanPath(prefix));
+  if (protonAvailable) {
+    environment.insert(QStringLiteral("GAMEID"), QStringLiteral("0"));
+    environment.insert(QStringLiteral("STEAM_COMPAT_DATA_PATH"),
+                       QFileInfo(prefix + QStringLiteral("/..")).absoluteFilePath());
+  }
+  process.setProcessEnvironment(environment);
+  if (!process.startDetached()) {
+    setError(QStringLiteral("Battle.net could not be started. Open Battle.net and try again."));
     return false;
   }
   setError({});

--- a/src/launch/GameLauncher.h
+++ b/src/launch/GameLauncher.h
@@ -23,11 +23,13 @@ public:
   [[nodiscard]] static LaunchCommand faugusCommand(const QString& id, bool flatpak);
   [[nodiscard]] static LaunchCommand retroArchCommand(const QString& contentPath,
                                                       const QString& corePath, bool flatpak);
+  [[nodiscard]] static LaunchCommand battleNetCommand(const QString& id, const QString& prefix,
+                                                      const QString& runner, bool flatpak);
   Q_INVOKABLE bool launch(const QString& source, const QString& id, bool flatpak = false,
                           const QString& runner = {}, const QString& installPath = {},
                           const QString& launchTarget = {});
   Q_INVOKABLE bool manage(const QString& source, const QString& id, bool flatpak = false,
-                          const QString& runner = {});
+                          const QString& runner = {}, const QString& launchTarget = {});
   Q_INVOKABLE bool install(const QString& source, const QString& id);
 
 signals:
@@ -39,6 +41,8 @@ private:
   bool launchFaugus(const QString& id, bool flatpak, bool manageOnly);
   bool launchRetroArch(const QString& contentPath, const QString& corePath, bool flatpak,
                        bool manageOnly);
+  bool launchBattleNet(const QString& id, const QString& prefix, const QString& runner,
+                       bool flatpak, bool manageOnly);
   [[nodiscard]] QString flatpakError(const QString& appId, const QString& launcherName) const;
   void setError(const QString& error);
   QString m_lastError;

--- a/src/library/BattleNetGameModel.cpp
+++ b/src/library/BattleNetGameModel.cpp
@@ -1,0 +1,626 @@
+#include "library/BattleNetGameModel.h"
+
+#include "app/AppSettings.h"
+#include "library/GameRoles.h"
+
+#include <QCryptographicHash>
+#include <QDateTime>
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileInfo>
+#include <QImage>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QRegularExpression>
+#include <QSaveFile>
+#include <QSet>
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QStandardPaths>
+#include <QTimer>
+#include <QUrl>
+#include <QtConcurrent>
+
+#include <algorithm>
+
+namespace {
+QColor colorFor(const QString& key, int offset) {
+  const QByteArray hash = QCryptographicHash::hash(key.toUtf8(), QCryptographicHash::Sha256);
+  return QColor::fromHsl((static_cast<unsigned char>(hash.at(offset)) * 359) / 255, 115,
+                         offset == 0 ? 105 : 72);
+}
+
+QString localUrl(const QString& path) {
+  return path.isEmpty() ? QString{} : QUrl::fromLocalFile(path).toString();
+}
+
+QString runnerLabel(const QString& runner) {
+  if (runner == QStringLiteral("proton")) {
+    return QStringLiteral("Proton");
+  }
+  if (runner == QStringLiteral("bottles")) {
+    return QStringLiteral("Bottles");
+  }
+  return QStringLiteral("Wine");
+}
+
+constexpr qint64 kMaximumCoverBytes = 8 * 1024 * 1024;
+constexpr int kMaximumConcurrentCoverDownloads = 4;
+
+QString coverCacheRoot() {
+  return QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) +
+         QStringLiteral("/omakade/covers/battlenet");
+}
+
+bool safeProductId(const QString& productId) {
+  static const QRegularExpression valid(QStringLiteral("^[A-Za-z][A-Za-z0-9._-]{0,63}$"));
+  return valid.match(productId).hasMatch();
+}
+
+QString cachedArtwork(const QString& productId, bool hero) {
+  if (!safeProductId(productId)) {
+    return {};
+  }
+  const QString base =
+      coverCacheRoot() + QLatin1Char('/') + productId + (hero ? QStringLiteral("-hero") : QString{});
+  for (const QString& extension : {QStringLiteral(".webp"), QStringLiteral(".jpg"),
+                                   QStringLiteral(".jpeg"), QStringLiteral(".png")}) {
+    const QString path = base + extension;
+    if (QFileInfo::exists(path)) {
+      return path;
+    }
+  }
+  return {};
+}
+
+QString artworkExtension(const QByteArray& contents, const QString& contentType) {
+  if (contentType.contains(QStringLiteral("webp")) || contents.startsWith("RIFF")) {
+    return QStringLiteral(".webp");
+  }
+  if (contentType.contains(QStringLiteral("png")) || contents.startsWith("\x89PNG")) {
+    return QStringLiteral(".png");
+  }
+  return QStringLiteral(".jpg");
+}
+} // namespace
+
+BattleNetGameModel::BattleNetGameModel(const QString& omakadeDatabasePath, AppSettings* settings,
+                                       QObject* parent)
+    : QAbstractListModel(parent),
+      m_connectionName(
+          QStringLiteral("omakade-battlenet-%1").arg(reinterpret_cast<quintptr>(this))),
+      m_settings(settings) {
+  connect(&m_scanWatcher, &QFutureWatcher<BattleNetScanResult>::finished, this,
+          [this] { applyScan(m_scanWatcher.result()); });
+  if (openDatabase(omakadeDatabasePath) && ensureSchema()) {
+    loadDatabase();
+    loadSourceState();
+    QTimer::singleShot(400, this, [this] { requestMissingCovers(); });
+  }
+}
+
+BattleNetGameModel::~BattleNetGameModel() {
+  if (m_scanWatcher.isRunning()) {
+    m_scanWatcher.waitForFinished();
+  }
+  const auto replies = m_coverBuffers.keys();
+  for (QNetworkReply* reply : replies) {
+    reply->disconnect(this);
+    reply->abort();
+    reply->deleteLater();
+  }
+  m_coverBuffers.clear();
+  m_database.close();
+  m_database = {};
+  QSqlDatabase::removeDatabase(m_connectionName);
+}
+
+int BattleNetGameModel::rowCount(const QModelIndex& parent) const {
+  return parent.isValid() ? 0 : static_cast<int>(m_games.size());
+}
+
+QVariant BattleNetGameModel::data(const QModelIndex& index, int role) const {
+  if (!index.isValid() || index.row() < 0 || index.row() >= m_games.size()) {
+    return {};
+  }
+  return valueForRole(m_games.at(index.row()), role);
+}
+
+QHash<int, QByteArray> BattleNetGameModel::roleNames() const {
+  return {{GameRoles::Title, "title"},
+          {GameRoles::Subtitle, "subtitle"},
+          {GameRoles::Description, "description"},
+          {GameRoles::Hours, "hours"},
+          {GameRoles::Progress, "progress"},
+          {GameRoles::AchievementsUnlocked, "achievementsUnlocked"},
+          {GameRoles::AchievementsTotal, "achievementsTotal"},
+          {GameRoles::Favorite, "favorite"},
+          {GameRoles::Recent, "recent"},
+          {GameRoles::LastPlayed, "lastPlayed"},
+          {GameRoles::AccentStart, "accentStart"},
+          {GameRoles::AccentEnd, "accentEnd"},
+          {GameRoles::CoverMark, "coverMark"},
+          {GameRoles::Year, "year"},
+          {GameRoles::AppId, "appId"},
+          {GameRoles::CoverPath, "coverPath"},
+          {GameRoles::HeroPath, "heroPath"},
+          {GameRoles::LogoPath, "logoPath"},
+          {GameRoles::InstallPath, "installPath"},
+          {GameRoles::Source, "source"},
+          {GameRoles::Runner, "runner"},
+          {GameRoles::Flatpak, "flatpak"},
+          {GameRoles::Hidden, "hidden"},
+          {GameRoles::LaunchTarget, "launchTarget"},
+          {GameRoles::Installed, "installed"}};
+}
+
+bool BattleNetGameModel::battleNetDetected() const { return m_battleNetDetected; }
+QString BattleNetGameModel::statusText() const { return m_statusText; }
+QString BattleNetGameModel::errorText() const { return m_errorText; }
+QStringList BattleNetGameModel::detectedPaths() const { return m_detectedPaths; }
+qint64 BattleNetGameModel::lastScan() const { return m_lastScan; }
+
+void BattleNetGameModel::toggleFavorite(int row) {
+  if (row < 0 || row >= m_games.size() || !m_database.isOpen()) {
+    return;
+  }
+  Game& game = m_games[row];
+  game.favorite = !game.favorite;
+  QSqlQuery query(m_database);
+  query.prepare(QStringLiteral("UPDATE battlenet_games SET favorite = ? WHERE game_id = ?"));
+  query.addBindValue(game.favorite);
+  query.addBindValue(game.battlenet.gameId);
+  if (!query.exec()) {
+    game.favorite = !game.favorite;
+    setStatus(m_statusText, query.lastError().text());
+    return;
+  }
+  emit dataChanged(index(row), index(row), {GameRoles::Favorite});
+}
+
+void BattleNetGameModel::toggleHidden(int row) {
+  if (row < 0 || row >= m_games.size() || !m_database.isOpen()) {
+    return;
+  }
+  Game& game = m_games[row];
+  game.hidden = !game.hidden;
+  QSqlQuery query(m_database);
+  query.prepare(QStringLiteral("UPDATE battlenet_games SET hidden = ? WHERE game_id = ?"));
+  query.addBindValue(game.hidden);
+  query.addBindValue(game.battlenet.gameId);
+  if (!query.exec()) {
+    game.hidden = !game.hidden;
+    setStatus(m_statusText, query.lastError().text());
+    return;
+  }
+  emit dataChanged(index(row), index(row), {GameRoles::Hidden});
+}
+
+void BattleNetGameModel::requestCover(const QString& appId) {
+  for (const Game& game : m_games) {
+    if (game.battlenet.gameId == appId) {
+      requestCoverForGame(game);
+      startNextCoverDownloads();
+      return;
+    }
+  }
+}
+
+void BattleNetGameModel::refresh() {
+  if (m_scanWatcher.isRunning()) {
+    return;
+  }
+  setStatus(QStringLiteral("Scanning Battle.net library"));
+  m_scanWatcher.setFuture(QtConcurrent::run(
+      [] { return BattleNetScanner::scan(BattleNetScanner::discoverPrefixes()); }));
+}
+
+void BattleNetGameModel::refreshFromPrefixes(const QStringList& prefixes) {
+  applyScan(BattleNetScanner::scan(prefixes));
+}
+
+bool BattleNetGameModel::openDatabase(const QString& path) {
+  if (path != QStringLiteral(":memory:")) {
+    QDir().mkpath(QFileInfo(path).absolutePath());
+  }
+  m_database = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), m_connectionName);
+  m_database.setDatabaseName(path);
+  if (!m_database.open()) {
+    setStatus(QStringLiteral("Battle.net cache unavailable"), m_database.lastError().text());
+    return false;
+  }
+  return true;
+}
+
+bool BattleNetGameModel::ensureSchema() {
+  QSqlQuery query(m_database);
+  if (!query.exec(QStringLiteral(
+          "CREATE TABLE IF NOT EXISTS battlenet_games (game_id TEXT PRIMARY KEY, product_id TEXT "
+          "NOT NULL, name TEXT NOT NULL, launch_code TEXT, install_path TEXT, wine_prefix TEXT, "
+          "runner TEXT, cover_path TEXT, hero_path TEXT, last_played INTEGER NOT NULL DEFAULT 0, "
+          "flatpak INTEGER NOT NULL DEFAULT 0, favorite INTEGER NOT NULL DEFAULT 0, hidden INTEGER "
+          "NOT NULL DEFAULT 0, observed_at INTEGER NOT NULL)"))) {
+    return false;
+  }
+  QSet<QString> columns;
+  if (query.exec(QStringLiteral("PRAGMA table_info(battlenet_games)"))) {
+    while (query.next()) {
+      columns.insert(query.value(1).toString());
+    }
+  }
+  if (!columns.contains(QStringLiteral("game_id"))) {
+    if (!query.exec(QStringLiteral("ALTER TABLE battlenet_games RENAME TO battlenet_games_legacy")) ||
+        !query.exec(QStringLiteral(
+            "CREATE TABLE battlenet_games (game_id TEXT PRIMARY KEY, product_id TEXT NOT NULL, "
+            "name TEXT NOT NULL, launch_code TEXT, install_path TEXT, wine_prefix TEXT, runner "
+            "TEXT, cover_path TEXT, hero_path TEXT, last_played INTEGER NOT NULL DEFAULT 0, "
+            "flatpak INTEGER NOT NULL DEFAULT 0, favorite INTEGER NOT NULL DEFAULT 0, hidden "
+            "INTEGER NOT NULL DEFAULT 0, observed_at INTEGER NOT NULL)"))) {
+      return false;
+    }
+    QSqlQuery legacy(m_database);
+    if (!legacy.exec(QStringLiteral(
+            "SELECT product_id, name, launch_code, install_path, wine_prefix, runner, cover_path, "
+            "hero_path, last_played, flatpak, favorite, hidden, observed_at FROM "
+            "battlenet_games_legacy"))) {
+      return false;
+    }
+    QSqlQuery insert(m_database);
+    insert.prepare(QStringLiteral(
+        "INSERT INTO battlenet_games(game_id, product_id, name, launch_code, install_path, "
+        "wine_prefix, runner, cover_path, hero_path, last_played, flatpak, favorite, hidden, "
+        "observed_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"));
+    while (legacy.next()) {
+      const QString productId = legacy.value(0).toString();
+      const QString prefix = legacy.value(4).toString();
+      insert.bindValue(0, prefix.isEmpty() ? productId
+                                           : BattleNetScanner::gameIdFor(productId, prefix));
+      for (int column = 0; column < 13; ++column) {
+        insert.bindValue(column + 1, legacy.value(column));
+      }
+      if (!insert.exec()) {
+        return false;
+      }
+    }
+    if (!query.exec(QStringLiteral("DROP TABLE battlenet_games_legacy"))) {
+      return false;
+    }
+  }
+  if (!query.exec(QStringLiteral(
+          "CREATE TABLE IF NOT EXISTS source_state (source TEXT PRIMARY KEY, last_scan INTEGER, "
+          "last_error TEXT, paths TEXT NOT NULL DEFAULT '')"))) {
+    return false;
+  }
+  return true;
+}
+
+void BattleNetGameModel::loadDatabase() {
+  QVector<Game> loaded;
+  QSqlQuery query(m_database);
+  if (!query.exec(QStringLiteral(
+          "SELECT game_id, product_id, name, launch_code, install_path, wine_prefix, runner, "
+          "cover_path, hero_path, last_played, flatpak, favorite, hidden FROM battlenet_games "
+          "WHERE observed_at > 0 ORDER BY name COLLATE NOCASE"))) {
+    setStatus(QStringLiteral("Could not load cached Battle.net games"), query.lastError().text());
+    return;
+  }
+  while (query.next()) {
+    BattleNetGameRecord record{.gameId = query.value(0).toString(),
+                               .productId = query.value(1).toString(),
+                               .title = query.value(2).toString(),
+                               .launchCode = query.value(3).toString(),
+                               .installPath = query.value(4).toString(),
+                               .winePrefix = query.value(5).toString(),
+                               .runner = query.value(6).toString(),
+                               .coverPath = query.value(7).toString(),
+                               .heroPath = query.value(8).toString(),
+                               .lastPlayed = query.value(9).toLongLong(),
+                               .flatpak = query.value(10).toBool()};
+    loaded.append({.battlenet = record,
+                   .favorite = query.value(11).toBool(),
+                   .hidden = query.value(12).toBool(),
+                   .accentStart = colorFor(record.gameId, 0),
+                   .accentEnd = colorFor(record.gameId, 1)});
+  }
+  beginResetModel();
+  m_games = loaded;
+  endResetModel();
+}
+
+void BattleNetGameModel::loadSourceState() {
+  QSqlQuery query(m_database);
+  query.prepare(QStringLiteral(
+      "SELECT last_scan, last_error, paths FROM source_state WHERE source = 'battlenet'"));
+  if (!query.exec() || !query.next()) {
+    return;
+  }
+  m_lastScan = query.value(0).toLongLong();
+  m_errorText = query.value(1).toString();
+  m_detectedPaths = query.value(2).toString().split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+  m_battleNetDetected = !m_detectedPaths.isEmpty();
+  if (m_lastScan > 0) {
+    m_statusText = QStringLiteral("Loaded cached Battle.net library");
+  }
+}
+
+void BattleNetGameModel::applyScan(const BattleNetScanResult& result) {
+  m_battleNetDetected = !result.prefixes.isEmpty();
+  if (result.incomplete || (result.prefixes.isEmpty() && !m_games.isEmpty())) {
+    setStatus(QStringLiteral("Battle.net scan interrupted; kept the cached library"),
+              result.warnings.join(QLatin1Char('\n')));
+    return;
+  }
+  m_coverQueue.clear();
+  m_pendingCovers.clear();
+  if (!m_database.transaction()) {
+    setStatus(QStringLiteral("Could not update Battle.net games"), m_database.lastError().text());
+    return;
+  }
+  QSqlQuery query(m_database);
+  bool okay = query.exec(QStringLiteral("UPDATE battlenet_games SET observed_at = 0"));
+  for (const BattleNetGameRecord& game : result.games) {
+    query.prepare(QStringLiteral(
+        "INSERT INTO battlenet_games(game_id, product_id, name, launch_code, install_path, "
+        "wine_prefix, runner, cover_path, hero_path, last_played, flatpak, observed_at) VALUES(?, "
+        "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s', 'now')) ON CONFLICT(game_id) DO UPDATE SET "
+        "product_id = excluded.product_id, name = excluded.name, launch_code = excluded.launch_code, "
+        "install_path = excluded.install_path, wine_prefix = excluded.wine_prefix, runner = "
+        "excluded.runner, cover_path = CASE WHEN excluded.cover_path IS NULL OR "
+        "excluded.cover_path = '' THEN battlenet_games.cover_path ELSE excluded.cover_path END, "
+        "hero_path = CASE WHEN excluded.hero_path IS NULL OR excluded.hero_path = '' THEN "
+        "battlenet_games.hero_path ELSE excluded.hero_path END, last_played = excluded.last_played, "
+        "flatpak = excluded.flatpak, observed_at = excluded.observed_at"));
+    query.addBindValue(game.gameId);
+    query.addBindValue(game.productId);
+    query.addBindValue(game.title);
+    query.addBindValue(game.launchCode);
+    query.addBindValue(game.installPath);
+    query.addBindValue(game.winePrefix);
+    query.addBindValue(game.runner);
+    query.addBindValue(game.coverPath);
+    query.addBindValue(game.heroPath);
+    query.addBindValue(game.lastPlayed);
+    query.addBindValue(game.flatpak);
+    okay = okay && query.exec();
+  }
+  query.prepare(QStringLiteral(
+      "INSERT INTO source_state(source, last_scan, last_error, paths) VALUES('battlenet', "
+      "strftime('%s', 'now'), ?, ?) ON CONFLICT(source) DO UPDATE SET last_scan = "
+      "excluded.last_scan, last_error = excluded.last_error, paths = excluded.paths"));
+  query.addBindValue(result.warnings.join(QLatin1Char('\n')));
+  query.addBindValue(result.prefixes.isEmpty() ? QStringLiteral("")
+                                               : result.prefixes.join(QLatin1Char('\n')));
+  okay = okay && query.exec();
+  if (!okay || !m_database.commit()) {
+    m_database.rollback();
+    setStatus(QStringLiteral("Could not update Battle.net games"), query.lastError().text());
+    return;
+  }
+  loadDatabase();
+  m_detectedPaths = result.prefixes;
+  m_lastScan = QDateTime::currentSecsSinceEpoch();
+  m_failedCovers.clear();
+  requestMissingCovers();
+  setStatus(m_battleNetDetected
+                ? QStringLiteral("Imported %1 Battle.net game(s)").arg(result.games.size())
+                : QStringLiteral("Battle.net was not found"),
+            result.warnings.join(QLatin1Char('\n')));
+}
+
+QVariant BattleNetGameModel::valueForRole(const Game& game, int role) const {
+  switch (role) {
+  case GameRoles::Title:
+    return game.battlenet.title;
+  case GameRoles::Subtitle:
+    return QStringLiteral("Battle.net · %1").arg(runnerLabel(game.battlenet.runner));
+  case GameRoles::Description:
+    return QStringLiteral("Installed locally through Battle.net.");
+  case GameRoles::Hours:
+  case GameRoles::Progress:
+  case GameRoles::AchievementsUnlocked:
+  case GameRoles::AchievementsTotal:
+  case GameRoles::Year:
+    return 0;
+  case GameRoles::Favorite:
+    return game.favorite;
+  case GameRoles::Recent:
+    return game.battlenet.lastPlayed > 0;
+  case GameRoles::LastPlayed:
+    return game.battlenet.lastPlayed;
+  case GameRoles::AccentStart:
+    return game.accentStart;
+  case GameRoles::AccentEnd:
+    return game.accentEnd;
+  case GameRoles::CoverMark:
+    return game.battlenet.title.left(1).toUpper();
+  case GameRoles::AppId:
+    return game.battlenet.gameId;
+  case GameRoles::CoverPath:
+    return localUrl(game.battlenet.coverPath);
+  case GameRoles::HeroPath:
+    return localUrl(game.battlenet.heroPath);
+  case GameRoles::LogoPath:
+    return QString{};
+  case GameRoles::InstallPath:
+    return game.battlenet.installPath;
+  case GameRoles::Source:
+    return QStringLiteral("Battle.net");
+  case GameRoles::Runner:
+    return game.battlenet.runner;
+  case GameRoles::Flatpak:
+    return game.battlenet.flatpak;
+  case GameRoles::Hidden:
+    return game.hidden;
+  case GameRoles::LaunchTarget:
+    return game.battlenet.winePrefix;
+  case GameRoles::Installed:
+    return true;
+  default:
+    return {};
+  }
+}
+
+void BattleNetGameModel::setStatus(const QString& status, const QString& error) {
+  m_statusText = status;
+  m_errorText = error;
+  emit statusChanged();
+}
+
+void BattleNetGameModel::requestMissingCovers() {
+  for (const Game& game : m_games) {
+    requestCoverForGame(game);
+  }
+  startNextCoverDownloads();
+}
+
+void BattleNetGameModel::requestCoverForGame(const Game& game) {
+  const auto queueIfMissing = [this, &game](bool hero) {
+    const QString current = hero ? game.battlenet.heroPath : game.battlenet.coverPath;
+    const QString key = game.battlenet.gameId + (hero ? QStringLiteral("-hero") : QString{});
+    if ((!current.isEmpty() && QFileInfo::exists(current)) || m_pendingCovers.contains(key) ||
+        m_failedCovers.contains(key)) {
+      return;
+    }
+    const QUrl url = hero ? BattleNetScanner::heroUrl(game.battlenet.productId)
+                          : BattleNetScanner::coverUrl(game.battlenet.productId);
+    if (!url.isValid() || url.isEmpty()) {
+      return;
+    }
+    const QString cached = cachedArtwork(game.battlenet.productId, hero);
+    if (!cached.isEmpty()) {
+      applyArtwork(game.battlenet.gameId, cached, hero);
+      return;
+    }
+    m_pendingCovers.insert(key);
+    m_coverQueue.enqueue({game.battlenet.gameId, game.battlenet.productId, hero});
+  };
+  queueIfMissing(false);
+  queueIfMissing(true);
+}
+
+void BattleNetGameModel::startNextCoverDownloads() {
+  while (m_activeCoverDownloads < kMaximumConcurrentCoverDownloads && !m_coverQueue.isEmpty()) {
+    const CoverRequest request = m_coverQueue.dequeue();
+    downloadArtwork(request.gameId, request.productId, request.hero);
+  }
+}
+
+void BattleNetGameModel::downloadArtwork(const QString& gameId, const QString& productId, bool hero) {
+  if (!safeProductId(productId)) {
+    const QString key = gameId + (hero ? QStringLiteral("-hero") : QString{});
+    m_pendingCovers.remove(key);
+    m_failedCovers.insert(key);
+    startNextCoverDownloads();
+    return;
+  }
+  const QUrl url = hero ? BattleNetScanner::heroUrl(productId) : BattleNetScanner::coverUrl(productId);
+  QNetworkRequest request(url);
+  request.setTransferTimeout(12000);
+  request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                       QNetworkRequest::NoLessSafeRedirectPolicy);
+  QNetworkReply* reply = m_network.get(request);
+  ++m_activeCoverDownloads;
+  m_coverBuffers.insert(reply, {});
+  connect(reply, &QNetworkReply::readyRead, this, [this, reply] {
+    QByteArray& buffer = m_coverBuffers[reply];
+    const qsizetype remaining = kMaximumCoverBytes - buffer.size();
+    buffer.append(reply->read(remaining + 1));
+    if (buffer.size() > kMaximumCoverBytes) {
+      reply->setProperty("tooLarge", true);
+      reply->abort();
+    }
+  });
+  connect(reply, &QNetworkReply::finished, this, [this, reply, gameId, productId, hero] {
+    QByteArray contents = m_coverBuffers.take(reply);
+    if (contents.size() <= kMaximumCoverBytes) {
+      contents.append(reply->read(kMaximumCoverBytes + 1 - contents.size()));
+    }
+    const bool tooLarge =
+        reply->property("tooLarge").toBool() || contents.size() > kMaximumCoverBytes;
+    const QString contentType =
+        QString::fromLatin1(reply->header(QNetworkRequest::ContentTypeHeader).toByteArray());
+    const bool valid = reply->error() == QNetworkReply::NoError && !contents.isEmpty() &&
+                       !tooLarge && !QImage::fromData(contents).isNull();
+    bool saved = false;
+    if (valid) {
+      const QString path = coverCacheRoot() + QLatin1Char('/') + productId +
+                           (hero ? QStringLiteral("-hero") : QString{}) +
+                           artworkExtension(contents, contentType);
+      QDir().mkpath(QFileInfo(path).absolutePath());
+      QSaveFile file(path);
+      saved = file.open(QIODevice::WriteOnly) && file.write(contents) == contents.size() &&
+              file.commit();
+      if (saved) {
+        applyArtwork(gameId, path, hero);
+      }
+    }
+    reply->deleteLater();
+    --m_activeCoverDownloads;
+    const QString key = gameId + (hero ? QStringLiteral("-hero") : QString{});
+    m_pendingCovers.remove(key);
+    if (!saved) {
+      m_failedCovers.insert(key);
+    }
+    startNextCoverDownloads();
+    if (m_activeCoverDownloads == 0 && m_coverQueue.isEmpty()) {
+      pruneCoverCache();
+    }
+  });
+}
+
+void BattleNetGameModel::applyArtwork(const QString& gameId, const QString& path, bool hero) {
+  for (int row = 0; row < m_games.size(); ++row) {
+    if (m_games.at(row).battlenet.gameId != gameId) {
+      continue;
+    }
+    QString& current =
+        hero ? m_games[row].battlenet.heroPath : m_games[row].battlenet.coverPath;
+    if (!current.isEmpty() && QFileInfo::exists(current) &&
+        !current.startsWith(coverCacheRoot())) {
+      return;
+    }
+    current = path;
+    if (m_database.isOpen()) {
+      QSqlQuery query(m_database);
+      query.prepare(hero ? QStringLiteral("UPDATE battlenet_games SET hero_path = ? WHERE game_id = ?")
+                         : QStringLiteral(
+                               "UPDATE battlenet_games SET cover_path = ? WHERE game_id = ?"));
+      query.addBindValue(path);
+      query.addBindValue(gameId);
+      query.exec();
+    }
+    emit dataChanged(index(row), index(row),
+                     {hero ? GameRoles::HeroPath : GameRoles::CoverPath});
+    return;
+  }
+}
+
+void BattleNetGameModel::pruneCoverCache() {
+  const int limitMb = m_settings == nullptr ? 1024 : m_settings->artworkCacheLimitMb();
+  const qint64 limit = static_cast<qint64>(limitMb) * 1024 * 1024;
+  struct CachedFile {
+    QString path;
+    QDateTime modified;
+    qint64 size = 0;
+  };
+  QVector<CachedFile> files;
+  qint64 total = 0;
+  QDirIterator iterator(coverCacheRoot(), QDir::Files);
+  while (iterator.hasNext()) {
+    const QFileInfo info(iterator.next());
+    files.append({info.absoluteFilePath(), info.lastModified(), info.size()});
+    total += info.size();
+  }
+  std::sort(files.begin(), files.end(), [](const CachedFile& left, const CachedFile& right) {
+    return left.modified < right.modified;
+  });
+  for (const CachedFile& file : files) {
+    if (total <= limit) {
+      break;
+    }
+    if (QFile::remove(file.path)) {
+      total -= file.size;
+    }
+  }
+}

--- a/src/library/BattleNetGameModel.h
+++ b/src/library/BattleNetGameModel.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "sources/battlenet/BattleNetScanner.h"
+
+#include <QAbstractListModel>
+#include <QColor>
+#include <QFutureWatcher>
+#include <QHash>
+#include <QNetworkAccessManager>
+#include <QQueue>
+#include <QSet>
+#include <QSqlDatabase>
+
+class AppSettings;
+class QNetworkReply;
+
+class BattleNetGameModel final : public QAbstractListModel {
+  Q_OBJECT
+  Q_PROPERTY(bool battleNetDetected READ battleNetDetected NOTIFY statusChanged)
+  Q_PROPERTY(QString statusText READ statusText NOTIFY statusChanged)
+  Q_PROPERTY(QString errorText READ errorText NOTIFY statusChanged)
+  Q_PROPERTY(QStringList detectedPaths READ detectedPaths NOTIFY statusChanged)
+  Q_PROPERTY(qint64 lastScan READ lastScan NOTIFY statusChanged)
+
+public:
+  explicit BattleNetGameModel(const QString& omakadeDatabasePath, AppSettings* settings = nullptr,
+                              QObject* parent = nullptr);
+  ~BattleNetGameModel() override;
+
+  [[nodiscard]] int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+  [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
+  [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
+  [[nodiscard]] bool battleNetDetected() const;
+  [[nodiscard]] QString statusText() const;
+  [[nodiscard]] QString errorText() const;
+  [[nodiscard]] QStringList detectedPaths() const;
+  [[nodiscard]] qint64 lastScan() const;
+
+  Q_INVOKABLE void toggleFavorite(int row);
+  Q_INVOKABLE void toggleHidden(int row);
+  Q_INVOKABLE void requestCover(const QString& appId);
+  Q_INVOKABLE void refresh();
+  void refreshFromPrefixes(const QStringList& prefixes);
+
+signals:
+  void statusChanged();
+
+private:
+  struct Game {
+    BattleNetGameRecord battlenet;
+    bool favorite = false;
+    bool hidden = false;
+    QColor accentStart;
+    QColor accentEnd;
+  };
+
+  struct CoverRequest {
+    QString gameId;
+    QString productId;
+    bool hero = false;
+  };
+
+  bool openDatabase(const QString& path);
+  bool ensureSchema();
+  void loadDatabase();
+  void loadSourceState();
+  void applyScan(const BattleNetScanResult& result);
+  [[nodiscard]] QVariant valueForRole(const Game& game, int role) const;
+  void setStatus(const QString& status, const QString& error = {});
+  void requestMissingCovers();
+  void requestCoverForGame(const Game& game);
+  void startNextCoverDownloads();
+  void downloadArtwork(const QString& gameId, const QString& productId, bool hero);
+  void applyArtwork(const QString& gameId, const QString& path, bool hero);
+  void pruneCoverCache();
+
+  QVector<Game> m_games;
+  QSqlDatabase m_database;
+  QString m_connectionName;
+  QFutureWatcher<BattleNetScanResult> m_scanWatcher;
+  bool m_battleNetDetected = false;
+  QString m_statusText;
+  QString m_errorText;
+  QStringList m_detectedPaths;
+  qint64 m_lastScan = 0;
+  AppSettings* m_settings = nullptr;
+  QNetworkAccessManager m_network;
+  QHash<QNetworkReply*, QByteArray> m_coverBuffers;
+  QQueue<CoverRequest> m_coverQueue;
+  QSet<QString> m_pendingCovers;
+  QSet<QString> m_failedCovers;
+  int m_activeCoverDownloads = 0;
+};

--- a/src/sources/battlenet/BattleNetScanner.cpp
+++ b/src/sources/battlenet/BattleNetScanner.cpp
@@ -1,0 +1,638 @@
+#include "sources/battlenet/BattleNetScanner.h"
+
+#include "sources/steam/SteamScanner.h"
+#include "sources/steam/ValveKeyValues.h"
+
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QHash>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSet>
+#include <QStandardPaths>
+
+namespace {
+constexpr qint64 kMaximumProductDbBytes = 16 * 1024 * 1024;
+constexpr qint64 kMaximumConfigBytes = 4 * 1024 * 1024;
+const QString kProductDbRelative =
+    QStringLiteral("/drive_c/ProgramData/Battle.net/Agent/product.db");
+
+struct ProductCatalogEntry {
+  const char* productCode;
+  const char* title;
+  const char* launchCode;
+  const char* slug;
+};
+
+constexpr ProductCatalogEntry kCatalog[] = {
+    {"s1", "StarCraft Remastered", "S1", "starcraft-remastered"},
+    {"s2", "StarCraft II", "S2", "starcraft-ii"},
+    {"sca", "StarCraft Anthology", "Starcraft", "starcraft"},
+    {"wow", "World of Warcraft", "WoW", "world-of-warcraft"},
+    {"wow_classic", "World of Warcraft Classic", "WoW_wow_classic", "world-of-warcraft-classic"},
+    {"wow_classic_era", "World of Warcraft Classic Era", "WoW_wow_classic_era",
+     "world-of-warcraft-classic"},
+    {"wow_classic_ptr", "World of Warcraft Classic PTR", "WoW_wow_classic",
+     "world-of-warcraft-classic"},
+    {"wow_classic_era_ptr", "World of Warcraft Classic Era PTR", "WoW_wow_classic_era",
+     "world-of-warcraft-classic"},
+    {"wow_beta", "World of Warcraft Beta", "WoW", "world-of-warcraft"},
+    {"pro", "Overwatch 2", "Pro", "overwatch-2"},
+    {"prometheus", "Overwatch 2", "Pro", "overwatch-2"},
+    {"prometheus_dev", "Overwatch 2 PTR", "Pro", "overwatch-2"},
+    {"w1", "Warcraft: Orcs & Humans", "W1", "warcraft-orcs-humans"},
+    {"w1r", "Warcraft I: Remastered", "W1R", "warcraft-i-remastered"},
+    {"w2bn", "Warcraft II: Battle.net Edition", "W2BN", "warcraft-ii-battle-net-edition"},
+    {"w2r", "Warcraft II: Remastered", "W2R", "warcraft-ii-remastered"},
+    {"w3", "Warcraft III: Reforged", "W3", "warcraft-iii-reforged"},
+    {"w3ROC", "Warcraft III: Reign of Chaos", "Warcraft III", "warcraft-iii-reign-of-chaos"},
+    {"w3tft", "Warcraft III: The Frozen Throne", "Warcraft III", "warcraft-iii-the-frozen-throne"},
+    {"wild", "Warcraft III: Reforged", "W3", "warcraft-iii-reforged"},
+    {"gryphon", "Warcraft Rumble", "GRY", "warcraft-rumble"},
+    {"hsb", "Hearthstone", "WTCG", "hearthstone"},
+    {"wtcg", "Hearthstone", "WTCG", "hearthstone"},
+    {"hero", "Heroes of the Storm", "Hero", "heroes-of-the-storm"},
+    {"d2", "Diablo II", "Diablo II", "diablo-ii"},
+    {"d2LOD", "Diablo II: Lord of Destruction", "Diablo II", "diablo-ii-lord-of-destruction"},
+    {"osi", "Diablo II: Resurrected", "OSI", "diablo-2-ressurected"}, // Lutris slug spelling
+    {"d3", "Diablo III", "D3", "diablo-iii"},
+    {"d3cn", "Diablo III", "D3CN", "diablo-iii"},
+    {"fenris", "Diablo IV", "Fen", "diablo-iv"},
+    {"fenris_beta", "Diablo IV Beta", "Fen", "diablo-iv"},
+    {"fenris_ptr", "Diablo IV PTR", "Fen", "diablo-iv"},
+    {"anbs", "Diablo Immortal", "ANBS", "diablo-immortal"},
+    {"viper", "Call of Duty: Black Ops 4", "VIPR", "call-of-duty-black-ops-4"},
+    {"vipr", "Call of Duty: Black Ops 4", "VIPR", "call-of-duty-black-ops-4"},
+    {"odin", "Call of Duty: Modern Warfare", "ODIN", "call-of-duty-modern-warfare"},
+    {"lazarus", "Call of Duty: MW2 Campaign Remastered", "LAZR",
+     "call-of-duty-modern-warfare-2-campaign-remastered"},
+    {"lazr", "Call of Duty: MW2 Campaign Remastered", "LAZR",
+     "call-of-duty-modern-warfare-2-campaign-remastered"},
+    {"zeus", "Call of Duty: Black Ops Cold War", "ZEUS", "call-of-duty-black-ops-cold-war"},
+    {"auks", "Call of Duty: Modern Warfare II", "AUKS", "call-of-duty-modern-warfare-ii"},
+    {"codhq", "Call of Duty HQ", "CODHQ", "call-of-duty-hq"},
+    {"fore", "Call of Duty: Vanguard", "FORE", "call-of-duty-vanguard"},
+    {"rtro", "Blizzard Arcade Collection", "RTRO", "blizzard-arcade-collection"},
+    {"wlby", "Crash Bandicoot 4: It's About Time", "WLBY", "crash-bandicoot-4-its-about-time"},
+};
+
+QString cleanPath(const QString& path) {
+  return QDir::cleanPath(QFileInfo(path).absoluteFilePath());
+}
+
+bool readVarint(const QByteArray& data, int* offset, quint64* value) {
+  quint64 result = 0;
+  int shift = 0;
+  while (*offset < data.size() && shift <= 63) {
+    const auto byte = static_cast<unsigned char>(data.at((*offset)++));
+    result |= static_cast<quint64>(byte & 0x7F) << shift;
+    if ((byte & 0x80) == 0) {
+      *value = result;
+      return true;
+    }
+    shift += 7;
+  }
+  return false;
+}
+
+bool readLengthDelimited(const QByteArray& data, int* offset, QByteArray* value) {
+  quint64 length = 0;
+  if (!readVarint(data, offset, &length) || length > static_cast<quint64>(data.size() - *offset)) {
+    return false;
+  }
+  *value = data.mid(*offset, static_cast<int>(length));
+  *offset += static_cast<int>(length);
+  return true;
+}
+
+bool skipField(const QByteArray& data, int* offset, int wireType) {
+  switch (wireType) {
+  case 0: {
+    quint64 unused = 0;
+    return readVarint(data, offset, &unused);
+  }
+  case 1:
+    if (*offset + 8 > data.size()) {
+      return false;
+    }
+    *offset += 8;
+    return true;
+  case 2: {
+    QByteArray unused;
+    return readLengthDelimited(data, offset, &unused);
+  }
+  case 5:
+    if (*offset + 4 > data.size()) {
+      return false;
+    }
+    *offset += 4;
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool nextField(const QByteArray& data, int* offset, int* field, int* wireType) {
+  quint64 key = 0;
+  if (!readVarint(data, offset, &key) || key > 0xFFFFFFFULL) {
+    return false;
+  }
+  *field = static_cast<int>(key >> 3);
+  *wireType = static_cast<int>(key & 7);
+  return *field > 0;
+}
+
+bool readStringField(const QByteArray& data, int* offset, QString* value) {
+  QByteArray bytes;
+  if (!readLengthDelimited(data, offset, &bytes)) {
+    return false;
+  }
+  *value = QString::fromUtf8(bytes);
+  return true;
+}
+
+void writeVarint(QByteArray* out, quint64 value) {
+  while (value >= 0x80) {
+    out->append(static_cast<char>((value & 0x7F) | 0x80));
+    value >>= 7;
+  }
+  out->append(static_cast<char>(value));
+}
+
+void writeKey(QByteArray* out, int field, int wireType) {
+  writeVarint(out, (static_cast<quint64>(field) << 3) | static_cast<quint64>(wireType));
+}
+
+void writeString(QByteArray* out, int field, const QString& value) {
+  const QByteArray utf8 = value.toUtf8();
+  writeKey(out, field, 2);
+  writeVarint(out, static_cast<quint64>(utf8.size()));
+  out->append(utf8);
+}
+
+void writeBool(QByteArray* out, int field, bool value) {
+  writeKey(out, field, 0);
+  writeVarint(out, value ? 1 : 0);
+}
+
+void writeMessage(QByteArray* out, int field, const QByteArray& message) {
+  writeKey(out, field, 2);
+  writeVarint(out, static_cast<quint64>(message.size()));
+  out->append(message);
+}
+
+bool parseBaseProductState(const QByteArray& data, bool* installed, bool* playable) {
+  int offset = 0;
+  while (offset < data.size()) {
+    int field = 0;
+    int wireType = 0;
+    if (!nextField(data, &offset, &field, &wireType)) {
+      return false;
+    }
+    if (wireType == 0 && (field == 1 || field == 2)) {
+      quint64 value = 0;
+      if (!readVarint(data, &offset, &value)) {
+        return false;
+      }
+      if (field == 1) {
+        *installed = value != 0;
+      } else {
+        *playable = value != 0;
+      }
+    } else if (!skipField(data, &offset, wireType)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool parseCachedProductState(const QByteArray& data, bool* installed, bool* playable) {
+  int offset = 0;
+  while (offset < data.size()) {
+    int field = 0;
+    int wireType = 0;
+    if (!nextField(data, &offset, &field, &wireType)) {
+      return false;
+    }
+    if (field == 1 && wireType == 2) {
+      QByteArray nested;
+      if (!readLengthDelimited(data, &offset, &nested) ||
+          !parseBaseProductState(nested, installed, playable)) {
+        return false;
+      }
+    } else if (!skipField(data, &offset, wireType)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool parseUserSettings(const QByteArray& data, QString* installPath) {
+  int offset = 0;
+  while (offset < data.size()) {
+    int field = 0;
+    int wireType = 0;
+    if (!nextField(data, &offset, &field, &wireType)) {
+      return false;
+    }
+    if (field == 1 && wireType == 2) {
+      if (!readStringField(data, &offset, installPath)) {
+        return false;
+      }
+    } else if (!skipField(data, &offset, wireType)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool parseProductInstall(const QByteArray& data, BattleNetProductInstall* install) {
+  int offset = 0;
+  while (offset < data.size()) {
+    int field = 0;
+    int wireType = 0;
+    if (!nextField(data, &offset, &field, &wireType)) {
+      return false;
+    }
+    if (wireType == 2 && field == 1) {
+      if (!readStringField(data, &offset, &install->uid)) {
+        return false;
+      }
+    } else if (wireType == 2 && field == 2) {
+      if (!readStringField(data, &offset, &install->productCode)) {
+        return false;
+      }
+    } else if (wireType == 2 && field == 3) {
+      QByteArray nested;
+      if (!readLengthDelimited(data, &offset, &nested) ||
+          !parseUserSettings(nested, &install->installPath)) {
+        return false;
+      }
+    } else if (wireType == 2 && field == 4) {
+      QByteArray nested;
+      if (!readLengthDelimited(data, &offset, &nested) ||
+          !parseCachedProductState(nested, &install->installed, &install->playable)) {
+        return false;
+      }
+    } else if (!skipField(data, &offset, wireType)) {
+      return false;
+    }
+  }
+  return !install->productCode.isEmpty() || !install->uid.isEmpty();
+}
+
+const ProductCatalogEntry* catalogEntry(const QString& productCode) {
+  for (const ProductCatalogEntry& entry : kCatalog) {
+    if (productCode.compare(QLatin1String(entry.productCode), Qt::CaseInsensitive) == 0) {
+      return &entry;
+    }
+  }
+  return nullptr;
+}
+
+QString unixPathFromWindows(const QString& prefix, const QString& windowsPath) {
+  QString path = windowsPath.trimmed();
+  path.replace(QLatin1Char('\\'), QLatin1Char('/'));
+  if (path.size() < 3 || path.at(1) != QLatin1Char(':')) {
+    return {};
+  }
+  const QChar drive = path.at(0).toLower();
+  if (drive < QLatin1Char('a') || drive > QLatin1Char('z')) {
+    return {};
+  }
+  const QString rest = path.mid(2);
+  const QString dosDevice = prefix + QStringLiteral("/dosdevices/") + drive + QLatin1Char(':');
+  if (QFileInfo::exists(dosDevice)) {
+    return QDir::cleanPath(QFileInfo(dosDevice).canonicalFilePath() + rest);
+  }
+  if (drive == QLatin1Char('c')) {
+    return QDir::cleanPath(prefix + QStringLiteral("/drive_c") + rest);
+  }
+  return {};
+}
+
+QString firstArtwork(const QString& directory, const QStringList& names) {
+  if (directory.isEmpty()) {
+    return {};
+  }
+  for (const QString& name : names) {
+    const QString candidate = directory + QLatin1Char('/') + name;
+    if (QFileInfo(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return {};
+}
+
+qint64 unixFromBattleNetTimestamp(qint64 value) {
+  if (value <= 0) {
+    return 0;
+  }
+  // Windows FILETIME (100-ns ticks since 1601).
+  if (value > 10'000'000'000'000'000LL) {
+    const qint64 unix = (value / 10'000'000LL) - 11'644'473'600LL;
+    return unix > 0 ? unix : 0;
+  }
+  // Milliseconds.
+  if (value > 10'000'000'000LL) {
+    return value / 1000;
+  }
+  return value;
+}
+
+QHash<QString, qint64> readLastPlayed(const QString& prefix) {
+  QHash<QString, qint64> played;
+  const QDir users(prefix + QStringLiteral("/drive_c/users"));
+  const QStringList accounts = users.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+  for (const QString& account : accounts) {
+    const QString path = users.absoluteFilePath(
+        account + QStringLiteral("/AppData/Roaming/Battle.net/Battle.net.config"));
+    QFile file(path);
+    if (!file.exists() || !file.open(QIODevice::ReadOnly) || file.size() > kMaximumConfigBytes) {
+      continue;
+    }
+    const QJsonObject games =
+        QJsonDocument::fromJson(file.readAll()).object().value(QStringLiteral("Games")).toObject();
+    for (auto iterator = games.begin(); iterator != games.end(); ++iterator) {
+      const qint64 stamp = unixFromBattleNetTimestamp(
+          iterator.value().toObject().value(QStringLiteral("LastPlayed")).toVariant().toLongLong());
+      if (stamp > 0) {
+        played[iterator.key().toLower()] = qMax(played.value(iterator.key().toLower()), stamp);
+      }
+    }
+  }
+  return played;
+}
+
+QString detectRunner(const QString& prefix) {
+  if (QFileInfo(prefix + QStringLiteral("/bottle.yml")).isFile()) {
+    return QStringLiteral("bottles");
+  }
+  const QFileInfo info(prefix);
+  if (info.fileName() == QStringLiteral("pfx") &&
+      QFileInfo(info.dir().absoluteFilePath(QStringLiteral("version"))).isFile()) {
+    return QStringLiteral("proton");
+  }
+  return QStringLiteral("wine");
+}
+
+bool detectFlatpak(const QString& prefix) {
+  return prefix.contains(QStringLiteral("/.var/app/com.usebottles.bottles/")) ||
+         prefix.contains(QStringLiteral("/.var/app/com.valvesoftware.Steam/"));
+}
+
+void appendPrefixIfPresent(const QString& prefix, QStringList* prefixes) {
+  const QString cleaned = cleanPath(prefix);
+  if (cleaned.isEmpty() || prefixes->contains(cleaned)) {
+    return;
+  }
+  if (QFileInfo(cleaned + kProductDbRelative).isFile()) {
+    prefixes->append(cleaned);
+  }
+}
+
+void appendChildPrefixes(const QString& parent, QStringList* prefixes) {
+  QDir directory(parent);
+  if (!directory.exists()) {
+    return;
+  }
+  const QStringList children = directory.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+  for (const QString& child : children) {
+    appendPrefixIfPresent(directory.absoluteFilePath(child), prefixes);
+  }
+}
+
+QStringList steamLibraryRoots() {
+  QStringList libraries;
+  for (const QString& steamRoot : SteamScanner::discoverSteamRoots()) {
+    libraries.append(steamRoot);
+    QString libraryFile = steamRoot + QStringLiteral("/config/libraryfolders.vdf");
+    if (!QFileInfo::exists(libraryFile)) {
+      libraryFile = steamRoot + QStringLiteral("/steamapps/libraryfolders.vdf");
+    }
+    ValveKeyValues root;
+    if (!ValveKeyValuesParser::parseFile(libraryFile, &root)) {
+      continue;
+    }
+    const ValveKeyValues* folders = root.object(QStringLiteral("libraryfolders"));
+    if (folders == nullptr) {
+      folders = &root;
+    }
+    for (auto iterator = folders->values.cbegin(); iterator != folders->values.cend(); ++iterator) {
+      bool numeric = false;
+      iterator.key().toInt(&numeric);
+      if (numeric && !iterator.value().isEmpty()) {
+        libraries.append(cleanPath(iterator.value()));
+      }
+    }
+    for (auto iterator = folders->objects.cbegin(); iterator != folders->objects.cend();
+         ++iterator) {
+      bool numeric = false;
+      iterator.key().toInt(&numeric);
+      const QString path = iterator.value().value(QStringLiteral("path"));
+      if (numeric && !path.isEmpty()) {
+        libraries.append(cleanPath(path));
+      }
+    }
+  }
+  libraries.removeDuplicates();
+  return libraries;
+}
+} // namespace
+
+QString BattleNetScanner::titleForProduct(const QString& productCode) {
+  if (const ProductCatalogEntry* entry = catalogEntry(productCodeFromId(productCode))) {
+    return QString::fromUtf8(entry->title);
+  }
+  QString title = productCode.trimmed();
+  title.replace(QLatin1Char('_'), QLatin1Char(' '));
+  if (!title.isEmpty()) {
+    title[0] = title[0].toUpper();
+  }
+  return title;
+}
+
+QString BattleNetScanner::productCodeFromId(const QString& id) {
+  const QString trimmed = id.trimmed();
+  const qsizetype separator = trimmed.indexOf(QLatin1Char('@'));
+  return separator < 0 ? trimmed : trimmed.left(separator);
+}
+
+QString BattleNetScanner::gameIdFor(const QString& productCode, const QString& prefix) {
+  const QString product = productCodeFromId(productCode);
+  const QByteArray digest =
+      QCryptographicHash::hash(cleanPath(prefix).toUtf8(), QCryptographicHash::Sha256).toHex();
+  return product + QLatin1Char('@') + QString::fromLatin1(digest.left(8));
+}
+
+QString BattleNetScanner::launchCodeForProduct(const QString& productCode) {
+  const QString product = productCodeFromId(productCode);
+  if (const ProductCatalogEntry* entry = catalogEntry(product)) {
+    return QString::fromUtf8(entry->launchCode);
+  }
+  return product;
+}
+
+QString BattleNetScanner::slugForProduct(const QString& productCode) {
+  if (const ProductCatalogEntry* entry = catalogEntry(productCodeFromId(productCode));
+      entry != nullptr && entry->slug != nullptr && entry->slug[0] != '\0') {
+    return QString::fromUtf8(entry->slug);
+  }
+  return {};
+}
+
+QUrl BattleNetScanner::coverUrl(const QString& productCode) {
+  const QString slug = slugForProduct(productCode);
+  return slug.isEmpty()
+             ? QUrl{}
+             : QUrl(QStringLiteral("https://lutris.net/games/cover/%1.jpg").arg(slug));
+}
+
+QUrl BattleNetScanner::heroUrl(const QString& productCode) {
+  const QString slug = slugForProduct(productCode);
+  return slug.isEmpty()
+             ? QUrl{}
+             : QUrl(QStringLiteral("https://lutris.net/games/banner/%1.jpg").arg(slug));
+}
+
+bool BattleNetScanner::isToolProduct(const QString& productCode) {
+  return productCode.compare(QStringLiteral("agent"), Qt::CaseInsensitive) == 0 ||
+         productCode.compare(QStringLiteral("bna"), Qt::CaseInsensitive) == 0;
+}
+
+QByteArray BattleNetScanner::encodeProductDb(const QVector<BattleNetProductInstall>& installs) {
+  QByteArray database;
+  for (const BattleNetProductInstall& install : installs) {
+    QByteArray settings;
+    writeString(&settings, 1, install.installPath);
+    QByteArray state;
+    writeBool(&state, 1, install.installed);
+    writeBool(&state, 2, install.playable);
+    QByteArray cached;
+    writeMessage(&cached, 1, state);
+    QByteArray product;
+    writeString(&product, 1, install.uid.isEmpty() ? install.productCode : install.uid);
+    writeString(&product, 2, install.productCode);
+    writeMessage(&product, 3, settings);
+    writeMessage(&product, 4, cached);
+    writeMessage(&database, 1, product);
+  }
+  return database;
+}
+
+QVector<BattleNetProductInstall> BattleNetScanner::decodeProductDb(const QByteArray& data,
+                                                                   bool* ok) {
+  QVector<BattleNetProductInstall> installs;
+  int offset = 0;
+  bool valid = true;
+  while (valid && offset < data.size()) {
+    int field = 0;
+    int wireType = 0;
+    if (!nextField(data, &offset, &field, &wireType)) {
+      valid = false;
+      break;
+    }
+    if (field == 1 && wireType == 2) {
+      QByteArray nested;
+      BattleNetProductInstall install;
+      if (!readLengthDelimited(data, &offset, &nested) || !parseProductInstall(nested, &install)) {
+        valid = false;
+        break;
+      }
+      installs.append(install);
+    } else if (!skipField(data, &offset, wireType)) {
+      valid = false;
+      break;
+    }
+  }
+  if (ok != nullptr) {
+    *ok = valid;
+  }
+  return valid ? installs : QVector<BattleNetProductInstall>{};
+}
+
+QStringList BattleNetScanner::discoverPrefixes() {
+  const QString home = QDir::homePath();
+  const QString data = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+  QStringList prefixes;
+  appendPrefixIfPresent(home + QStringLiteral("/.wine"), &prefixes);
+  appendChildPrefixes(data + QStringLiteral("/wineprefixes"), &prefixes);
+  appendChildPrefixes(home + QStringLiteral("/.local/share/wineprefixes"), &prefixes);
+  appendChildPrefixes(data + QStringLiteral("/bottles/bottles"), &prefixes);
+  appendChildPrefixes(
+      home + QStringLiteral("/.var/app/com.usebottles.bottles/data/bottles/bottles"), &prefixes);
+  appendChildPrefixes(home + QStringLiteral("/Games"), &prefixes);
+  for (const QString& library : steamLibraryRoots()) {
+    QDir compat(library + QStringLiteral("/steamapps/compatdata"));
+    const QStringList apps = compat.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    for (const QString& app : apps) {
+      appendPrefixIfPresent(compat.absoluteFilePath(app + QStringLiteral("/pfx")), &prefixes);
+    }
+  }
+  prefixes.removeDuplicates();
+  return prefixes;
+}
+
+BattleNetScanResult BattleNetScanner::scan(const QStringList& prefixes) {
+  BattleNetScanResult result;
+  QSet<QString> imported;
+  for (const QString& prefix : prefixes) {
+    const QString productDbPath = prefix + kProductDbRelative;
+    if (!QFileInfo(productDbPath).isFile()) {
+      continue;
+    }
+    result.prefixes.append(cleanPath(prefix));
+    QFile file(productDbPath);
+    if (!file.open(QIODevice::ReadOnly) || file.size() > kMaximumProductDbBytes) {
+      result.incomplete = true;
+      result.warnings.append(QStringLiteral("Could not read %1").arg(productDbPath));
+      continue;
+    }
+    bool ok = false;
+    const QVector<BattleNetProductInstall> installs = decodeProductDb(file.readAll(), &ok);
+    if (!ok) {
+      result.incomplete = true;
+      result.warnings.append(QStringLiteral("Could not parse %1").arg(productDbPath));
+      continue;
+    }
+    const QHash<QString, qint64> lastPlayed = readLastPlayed(prefix);
+    const QString runner = detectRunner(prefix);
+    const bool flatpak = detectFlatpak(prefix);
+    for (const BattleNetProductInstall& install : installs) {
+      const QString productId = install.productCode.trimmed();
+      const QString gameId = gameIdFor(productId, prefix);
+      if (productId.isEmpty() || isToolProduct(productId) || imported.contains(gameId) ||
+          !(install.installed || install.playable)) {
+        continue;
+      }
+      const QString installPath = unixPathFromWindows(prefix, install.installPath);
+      if (installPath.isEmpty()) {
+        continue;
+      }
+      const QString title = titleForProduct(productId);
+      result.games.append(
+          {.gameId = gameId,
+           .productId = productId,
+           .title = title,
+           .launchCode = launchCodeForProduct(productId),
+           .installPath = installPath,
+           .winePrefix = cleanPath(prefix),
+           .runner = runner,
+           .coverPath = firstArtwork(
+               installPath, {QStringLiteral("cover.png"), QStringLiteral("cover.jpg"),
+                             QStringLiteral("cover.webp"), QStringLiteral("cover.jpeg"),
+                             QStringLiteral("library_600x900.jpg"),
+                             QStringLiteral("library_600x900.png")}),
+           .heroPath = firstArtwork(
+               installPath, {QStringLiteral("library_hero.png"), QStringLiteral("library_hero.jpg"),
+                             QStringLiteral("header.jpg"), QStringLiteral("header.png")}),
+           .lastPlayed = qMax(lastPlayed.value(productId.toLower()),
+                              lastPlayed.value(launchCodeForProduct(productId).toLower())),
+           .flatpak = flatpak});
+      imported.insert(gameId);
+    }
+  }
+  return result;
+}

--- a/src/sources/battlenet/BattleNetScanner.h
+++ b/src/sources/battlenet/BattleNetScanner.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <QUrl>
+#include <QVector>
+
+struct BattleNetGameRecord {
+  QString gameId;
+  QString productId;
+  QString title;
+  QString launchCode;
+  QString installPath;
+  QString winePrefix;
+  QString runner;
+  QString coverPath;
+  QString heroPath;
+  qint64 lastPlayed = 0;
+  bool flatpak = false;
+};
+
+struct BattleNetProductInstall {
+  QString uid;
+  QString productCode;
+  QString installPath;
+  bool installed = false;
+  bool playable = false;
+};
+
+struct BattleNetScanResult {
+  QVector<BattleNetGameRecord> games;
+  QStringList prefixes;
+  QStringList warnings;
+  bool incomplete = false;
+};
+
+class BattleNetScanner final {
+public:
+  [[nodiscard]] static QStringList discoverPrefixes();
+  [[nodiscard]] static BattleNetScanResult scan(const QStringList& prefixes);
+  [[nodiscard]] static QString titleForProduct(const QString& productCode);
+  [[nodiscard]] static QString launchCodeForProduct(const QString& productCode);
+  [[nodiscard]] static QString productCodeFromId(const QString& id);
+  [[nodiscard]] static QString gameIdFor(const QString& productCode, const QString& prefix);
+  [[nodiscard]] static QString slugForProduct(const QString& productCode);
+  [[nodiscard]] static QUrl coverUrl(const QString& productCode);
+  [[nodiscard]] static QUrl heroUrl(const QString& productCode);
+  [[nodiscard]] static bool isToolProduct(const QString& productCode);
+  [[nodiscard]] static QByteArray encodeProductDb(const QVector<BattleNetProductInstall>& installs);
+  [[nodiscard]] static QVector<BattleNetProductInstall> decodeProductDb(const QByteArray& data,
+                                                                        bool* ok = nullptr);
+};

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -5,6 +5,7 @@
 #include "input/ControllerInput.h"
 #include "launch/GameLauncher.h"
 #include "launch/SteamLauncher.h"
+#include "library/BattleNetGameModel.h"
 #include "library/FaugusGameModel.h"
 #include "library/GameRoles.h"
 #include "library/HeroicGameModel.h"
@@ -17,6 +18,7 @@
 #include "library/UnifiedGameModel.h"
 #include "metadata/GameInsightsService.h"
 #include "metadata/IgdbApi.h"
+#include "sources/battlenet/BattleNetScanner.h"
 #include "sources/faugus/FaugusScanner.h"
 #include "sources/heroic/HeroicScanner.h"
 #include "sources/lutris/LutrisScanner.h"
@@ -45,6 +47,19 @@ void writeFile(const QString& path, const QByteArray& contents) {
   QFile file(path);
   QVERIFY2(file.open(QIODevice::WriteOnly | QIODevice::Truncate), qPrintable(file.errorString()));
   QCOMPARE(file.write(contents), contents.size());
+}
+
+auto redirectCacheHome(const QString& path) {
+  const bool wasSet = qEnvironmentVariableIsSet("XDG_CACHE_HOME");
+  const QByteArray previous = qgetenv("XDG_CACHE_HOME");
+  qputenv("XDG_CACHE_HOME", path.toUtf8());
+  return qScopeGuard([wasSet, previous] {
+    if (wasSet) {
+      qputenv("XDG_CACHE_HOME", previous);
+    } else {
+      qunsetenv("XDG_CACHE_HOME");
+    }
+  });
 }
 
 QByteArray sampleTheme(const QByteArray& accent = "#7aa2f7") {
@@ -179,6 +194,32 @@ void createFaugusFixture(const QString& root) {
   writeFile(root + QStringLiteral("/icons/linux-tool.png"), "icon");
 }
 
+void createBattleNetFixture(const QString& prefix) {
+  writeFile(prefix + QStringLiteral("/drive_c/Program Files (x86)/Battle.net/Battle.net.exe"),
+            "mz");
+  writeFile(prefix + QStringLiteral("/drive_c/Program Files (x86)/World of Warcraft/cover.png"),
+            "cover");
+  writeFile(prefix + QStringLiteral("/drive_c/Program Files (x86)/Overwatch/library_hero.jpg"),
+            "hero");
+  writeFile(prefix + QStringLiteral("/drive_c/Program Files (x86)/Custom/game.exe"), "exe");
+  writeFile(prefix + QStringLiteral("/drive_c/Program Files (x86)/Custom/icon.ico"), "icon");
+  writeFile(prefix + QStringLiteral("/drive_c/users/steamuser/AppData/Roaming/Battle.net/"
+                                    "Battle.net.config"),
+            R"({"Games":{"wow":{"LastPlayed":1700000000},"Pro":{"LastPlayed":1700001000}}})");
+  writeFile(prefix + QStringLiteral("/drive_c/ProgramData/Battle.net/Agent/product.db"),
+            BattleNetScanner::encodeProductDb(
+                {{QStringLiteral("agent"), QStringLiteral("agent"),
+                  QStringLiteral("C:\\ProgramData\\Battle.net\\Agent"), true, true},
+                 {QStringLiteral("wow"), QStringLiteral("wow"),
+                  QStringLiteral("C:\\Program Files (x86)\\World of Warcraft"), true, true},
+                 {QStringLiteral("pro"), QStringLiteral("pro"),
+                  QStringLiteral("C:\\Program Files (x86)\\Overwatch"), true, true},
+                 {QStringLiteral("d3"), QStringLiteral("d3"),
+                  QStringLiteral("C:\\Program Files (x86)\\Diablo III"), false, false},
+                 {QStringLiteral("custom_mod"), QStringLiteral("custom_mod"),
+                  QStringLiteral("C:\\Program Files (x86)\\Custom"), true, true}}));
+}
+
 void createRetroArchFixture(const QString& root) {
   const QString content = root + QStringLiteral("/roms/Sonic & Tails.bin");
   const QString unassigned = root + QStringLiteral("/roms/Unassigned.nes");
@@ -271,6 +312,13 @@ private slots:
   void retroArchModelIsRepeatableAndPreservesLocalState();
   void malformedRetroArchDataDoesNotReplaceCachedGames();
   void retroArchLauncherBuildsSafeCommands();
+  void battleNetScannerImportsInstalledGamesAndArtwork();
+  void battleNetScannerDiscoversKnownPrefixes();
+  void battleNetScannerKeepsInstallsFromSeparatePrefixes();
+  void battleNetModelIsRepeatableAndPreservesLocalState();
+  void malformedBattleNetDataDoesNotReplaceCachedGames();
+  void oversizedBattleNetDatabaseDoesNotReplaceCachedGames();
+  void battleNetLauncherBuildsSafeCommands();
   void launcherReportsInvalidAndStaleTargets();
   void igdbApiBuildsSafeQueriesAndParsesInsights();
   void igdbInsightsLoadFromOfflineCache();
@@ -1635,23 +1683,40 @@ void CoreTests::launcherRefreshesRunAsynchronously() {
   const QString configHome = directory.path() + QStringLiteral("/config");
   qputenv("XDG_DATA_HOME", dataHome.toUtf8());
   qputenv("XDG_CONFIG_HOME", configHome.toUtf8());
+  const auto restoreCacheHome = redirectCacheHome(directory.path() + QStringLiteral("/cache"));
+  Q_UNUSED(restoreCacheHome);
   createLutrisFixture(dataHome + QStringLiteral("/lutris"));
   createHeroicFixture(configHome + QStringLiteral("/heroic"));
   createFaugusFixture(dataHome + QStringLiteral("/faugus-launcher"));
+  createBattleNetFixture(directory.path() + QStringLiteral("/home/.wine"));
+  const bool homeWasSet = qEnvironmentVariableIsSet("HOME");
+  const QByteArray previousHome = qgetenv("HOME");
+  qputenv("HOME", QByteArray(directory.path().toUtf8() + "/home"));
+  const auto restoreHome = qScopeGuard([&] {
+    if (homeWasSet) {
+      qputenv("HOME", previousHome);
+    } else {
+      qunsetenv("HOME");
+    }
+  });
 
   const QString database = directory.path() + QStringLiteral("/omakade.sqlite3");
   LutrisGameModel lutris(database);
   HeroicGameModel heroic(database);
   FaugusGameModel faugus(database);
+  BattleNetGameModel battlenet(database);
   lutris.refresh();
   heroic.refresh();
   faugus.refresh();
+  battlenet.refresh();
   QCOMPARE(lutris.statusText(), QStringLiteral("Scanning Lutris library"));
   QCOMPARE(heroic.statusText(), QStringLiteral("Scanning Heroic library"));
   QCOMPARE(faugus.statusText(), QStringLiteral("Scanning Faugus library"));
+  QCOMPARE(battlenet.statusText(), QStringLiteral("Scanning Battle.net library"));
   QTRY_COMPARE_WITH_TIMEOUT(lutris.rowCount(), 1, 3000);
   QTRY_COMPARE_WITH_TIMEOUT(heroic.rowCount(), 4, 3000);
   QTRY_COMPARE_WITH_TIMEOUT(faugus.rowCount(), 3, 3000);
+  QTRY_COMPARE_WITH_TIMEOUT(battlenet.rowCount(), 3, 3000);
 }
 
 void CoreTests::absentLaunchersPersistEmptySourcePaths() {
@@ -1683,6 +1748,11 @@ void CoreTests::absentLaunchersPersistEmptySourcePaths() {
     model.refreshFromRoots({});
     QVERIFY(model.errorText().isEmpty());
   }
+  {
+    BattleNetGameModel model(database);
+    model.refreshFromPrefixes({});
+    QVERIFY(model.errorText().isEmpty());
+  }
 
   const QString connection = QStringLiteral("empty-source-paths-") + QUuid::createUuid().toString();
   {
@@ -1692,9 +1762,10 @@ void CoreTests::absentLaunchersPersistEmptySourcePaths() {
     QSqlQuery query(stored);
     QVERIFY(query.exec(QStringLiteral(
         "SELECT COUNT(*) FROM source_state WHERE source IN "
-        "('lutris', 'heroic', 'faugus', 'retroarch') AND paths = '' AND paths IS NOT NULL")));
+        "('lutris', 'heroic', 'faugus', 'retroarch', 'battlenet') AND paths = '' AND paths IS NOT "
+        "NULL")));
     QVERIFY(query.next());
-    QCOMPARE(query.value(0).toInt(), 4);
+    QCOMPARE(query.value(0).toInt(), 5);
   }
   QSqlDatabase::removeDatabase(connection);
 }
@@ -1856,6 +1927,233 @@ void CoreTests::retroArchLauncherBuildsSafeCommands() {
   QVERIFY(!launcher.lastError().startsWith(QStringLiteral("The installed files are missing.")));
 }
 
+void CoreTests::battleNetScannerImportsInstalledGamesAndArtwork() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString prefix = directory.path() + QStringLiteral("/wine");
+  createBattleNetFixture(prefix);
+
+  const BattleNetScanResult result = BattleNetScanner::scan({prefix});
+  QVERIFY(!result.incomplete);
+  QCOMPARE(result.prefixes, QStringList({QDir::cleanPath(prefix)}));
+  QCOMPARE(result.games.size(), 3);
+  QCOMPARE(result.games.at(0).productId, QStringLiteral("wow"));
+  QCOMPARE(result.games.at(0).title, QStringLiteral("World of Warcraft"));
+  QCOMPARE(result.games.at(0).launchCode, QStringLiteral("WoW"));
+  QCOMPARE(result.games.at(0).runner, QStringLiteral("wine"));
+  QCOMPARE(result.games.at(0).lastPlayed, 1700000000);
+  QVERIFY(result.games.at(0).coverPath.endsWith(QStringLiteral("cover.png")));
+  QCOMPARE(result.games.at(1).productId, QStringLiteral("pro"));
+  QCOMPARE(result.games.at(1).title, QStringLiteral("Overwatch 2"));
+  QCOMPARE(result.games.at(1).lastPlayed, 1700001000);
+  QVERIFY(result.games.at(1).heroPath.endsWith(QStringLiteral("library_hero.jpg")));
+  QCOMPARE(result.games.at(2).productId, QStringLiteral("custom_mod"));
+  QCOMPARE(result.games.at(2).title, QStringLiteral("Custom mod"));
+  QVERIFY(result.games.at(2).coverPath.isEmpty());
+  QVERIFY(result.games.at(0).gameId.contains(QStringLiteral("wow@")));
+  QVERIFY(result.games.at(0).gameId != result.games.at(0).productId);
+  QVERIFY(BattleNetScanner::isToolProduct(QStringLiteral("agent")));
+  QVERIFY(BattleNetScanner::isToolProduct(QStringLiteral("bna")));
+  QVERIFY(!BattleNetScanner::isToolProduct(QStringLiteral("wow")));
+  QCOMPARE(BattleNetScanner::slugForProduct(QStringLiteral("hero")),
+           QStringLiteral("heroes-of-the-storm"));
+  QCOMPARE(BattleNetScanner::coverUrl(QStringLiteral("hero")).toString(),
+           QStringLiteral("https://lutris.net/games/cover/heroes-of-the-storm.jpg"));
+  QCOMPARE(BattleNetScanner::heroUrl(QStringLiteral("hero")).toString(),
+           QStringLiteral("https://lutris.net/games/banner/heroes-of-the-storm.jpg"));
+  QVERIFY(BattleNetScanner::coverUrl(QStringLiteral("custom_mod")).isEmpty());
+
+  bool ok = false;
+  const QVector<BattleNetProductInstall> decoded = BattleNetScanner::decodeProductDb(
+      BattleNetScanner::encodeProductDb({{QStringLiteral("wow"), QStringLiteral("wow"),
+                                          QStringLiteral("C:\\Games\\WoW"), true, true}}),
+      &ok);
+  QVERIFY(ok);
+  QCOMPARE(decoded.size(), 1);
+  QCOMPARE(decoded.at(0).productCode, QStringLiteral("wow"));
+  QCOMPARE(decoded.at(0).installPath, QStringLiteral("C:\\Games\\WoW"));
+  QVERIFY(decoded.at(0).installed);
+}
+
+void CoreTests::battleNetScannerDiscoversKnownPrefixes() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const bool homeWasSet = qEnvironmentVariableIsSet("HOME");
+  const bool dataHomeWasSet = qEnvironmentVariableIsSet("XDG_DATA_HOME");
+  const QByteArray previousHome = qgetenv("HOME");
+  const QByteArray previousDataHome = qgetenv("XDG_DATA_HOME");
+  const auto restoreEnvironment = qScopeGuard([&] {
+    if (homeWasSet) {
+      qputenv("HOME", previousHome);
+    } else {
+      qunsetenv("HOME");
+    }
+    if (dataHomeWasSet) {
+      qputenv("XDG_DATA_HOME", previousDataHome);
+    } else {
+      qunsetenv("XDG_DATA_HOME");
+    }
+  });
+  const QString home = directory.path() + QStringLiteral("/home");
+  const QString data = directory.path() + QStringLiteral("/data");
+  qputenv("HOME", home.toUtf8());
+  qputenv("XDG_DATA_HOME", data.toUtf8());
+
+  createBattleNetFixture(home + QStringLiteral("/.wine"));
+  createBattleNetFixture(data + QStringLiteral("/wineprefixes/bnet"));
+  createBattleNetFixture(data + QStringLiteral("/bottles/bottles/Wow"));
+  writeFile(data + QStringLiteral("/bottles/bottles/Wow/bottle.yml"), "Name: Wow\n");
+  createBattleNetFixture(home + QStringLiteral("/Games/battlenet"));
+  const QString steamRoot = home + QStringLiteral("/.local/share/Steam");
+  createBattleNetFixture(steamRoot + QStringLiteral("/steamapps/compatdata/4242/pfx"));
+  writeFile(steamRoot + QStringLiteral("/steamapps/compatdata/4242/version"), "9.0\n");
+  writeFile(steamRoot + QStringLiteral("/steamapps/libraryfolders.vdf"),
+            "\"libraryfolders\"\n{\n\"0\" { \"path\" \"" + steamRoot.toUtf8() + "\" }\n}\n");
+
+  const QStringList prefixes = BattleNetScanner::discoverPrefixes();
+  QVERIFY(prefixes.contains(QDir::cleanPath(home + QStringLiteral("/.wine"))));
+  QVERIFY(prefixes.contains(QDir::cleanPath(data + QStringLiteral("/wineprefixes/bnet"))));
+  QVERIFY(prefixes.contains(QDir::cleanPath(data + QStringLiteral("/bottles/bottles/Wow"))));
+  QVERIFY(prefixes.contains(QDir::cleanPath(home + QStringLiteral("/Games/battlenet"))));
+  QVERIFY(prefixes.contains(
+      QDir::cleanPath(steamRoot + QStringLiteral("/steamapps/compatdata/4242/pfx"))));
+
+  const BattleNetScanResult bottles =
+      BattleNetScanner::scan({data + QStringLiteral("/bottles/bottles/Wow")});
+  QCOMPARE(bottles.games.at(0).runner, QStringLiteral("bottles"));
+  const BattleNetScanResult proton =
+      BattleNetScanner::scan({steamRoot + QStringLiteral("/steamapps/compatdata/4242/pfx")});
+  QCOMPARE(proton.games.at(0).runner, QStringLiteral("proton"));
+}
+
+void CoreTests::battleNetScannerKeepsInstallsFromSeparatePrefixes() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString first = directory.path() + QStringLiteral("/wine");
+  const QString second = directory.path() + QStringLiteral("/proton/pfx");
+  createBattleNetFixture(first);
+  createBattleNetFixture(second);
+  writeFile(directory.path() + QStringLiteral("/proton/version"), "9.0\n");
+
+  const BattleNetScanResult result = BattleNetScanner::scan({first, second});
+  QVERIFY(!result.incomplete);
+  QCOMPARE(result.games.size(), 6);
+  QStringList wowIds;
+  for (const BattleNetGameRecord& game : result.games) {
+    if (game.productId == QStringLiteral("wow")) {
+      wowIds.append(game.gameId);
+    }
+  }
+  QCOMPARE(wowIds.size(), 2);
+  QVERIFY(wowIds.at(0) != wowIds.at(1));
+  QCOMPARE(BattleNetScanner::productCodeFromId(wowIds.at(0)), QStringLiteral("wow"));
+}
+
+void CoreTests::battleNetModelIsRepeatableAndPreservesLocalState() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const auto restoreCacheHome = redirectCacheHome(directory.path() + QStringLiteral("/cache"));
+  Q_UNUSED(restoreCacheHome);
+  const QString prefix = directory.path() + QStringLiteral("/wine");
+  const QString database = directory.path() + QStringLiteral("/omakade.sqlite3");
+  createBattleNetFixture(prefix);
+
+  BattleNetGameModel model(database);
+  model.refreshFromPrefixes({prefix});
+  QCOMPARE(model.rowCount(), 3);
+  QCOMPARE(model.detectedPaths(), QStringList({QDir::cleanPath(prefix)}));
+  QVERIFY(model.lastScan() > 0);
+  QCOMPARE(model.data(model.index(0), GameRoles::Source).toString(),
+           QStringLiteral("Battle.net"));
+  QCOMPARE(model.data(model.index(0), GameRoles::Runner).toString(), QStringLiteral("wine"));
+  QCOMPARE(model.data(model.index(0), GameRoles::LaunchTarget).toString(),
+           QDir::cleanPath(prefix));
+  model.toggleFavorite(0);
+  model.toggleHidden(0);
+  model.refreshFromPrefixes({prefix});
+  QCOMPARE(model.rowCount(), 3);
+  QVERIFY(model.data(model.index(0), GameRoles::Favorite).toBool());
+  QVERIFY(model.data(model.index(0), GameRoles::Hidden).toBool());
+
+  BattleNetGameModel reloaded(database);
+  QCOMPARE(reloaded.detectedPaths(), QStringList({QDir::cleanPath(prefix)}));
+  QCOMPARE(reloaded.lastScan(), model.lastScan());
+  QVERIFY(reloaded.data(reloaded.index(0), GameRoles::Favorite).toBool());
+}
+
+void CoreTests::malformedBattleNetDataDoesNotReplaceCachedGames() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const auto restoreCacheHome = redirectCacheHome(directory.path() + QStringLiteral("/cache"));
+  Q_UNUSED(restoreCacheHome);
+  const QString prefix = directory.path() + QStringLiteral("/wine");
+  createBattleNetFixture(prefix);
+  BattleNetGameModel model(directory.path() + QStringLiteral("/omakade.sqlite3"));
+  model.refreshFromPrefixes({prefix});
+  QCOMPARE(model.rowCount(), 3);
+  writeFile(prefix + QStringLiteral("/drive_c/ProgramData/Battle.net/Agent/product.db"),
+            "not protobuf");
+  model.refreshFromPrefixes({prefix});
+  QCOMPARE(model.rowCount(), 3);
+  QVERIFY(model.statusText().startsWith(QStringLiteral("Battle.net scan interrupted")));
+}
+
+void CoreTests::oversizedBattleNetDatabaseDoesNotReplaceCachedGames() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const auto restoreCacheHome = redirectCacheHome(directory.path() + QStringLiteral("/cache"));
+  Q_UNUSED(restoreCacheHome);
+  const QString prefix = directory.path() + QStringLiteral("/wine");
+  createBattleNetFixture(prefix);
+  BattleNetGameModel model(directory.path() + QStringLiteral("/omakade.sqlite3"));
+  model.refreshFromPrefixes({prefix});
+  QCOMPARE(model.rowCount(), 3);
+  QFile productDb(prefix + QStringLiteral("/drive_c/ProgramData/Battle.net/Agent/product.db"));
+  QVERIFY(productDb.resize(16LL * 1024 * 1024 + 1));
+  model.refreshFromPrefixes({prefix});
+  QCOMPARE(model.rowCount(), 3);
+  QVERIFY(model.statusText().startsWith(QStringLiteral("Battle.net scan interrupted")));
+}
+
+void CoreTests::battleNetLauncherBuildsSafeCommands() {
+  const QString prefix = QStringLiteral("/tmp/omakade-bnet");
+  const LaunchCommand wine =
+      GameLauncher::battleNetCommand(QStringLiteral("wow"), prefix, QStringLiteral("wine"), false);
+  QCOMPARE(wine.program, QStringLiteral("wine"));
+  QCOMPARE(wine.arguments.constLast(), QStringLiteral("--exec=launch WoW"));
+  QVERIFY(wine.arguments.constFirst().contains(QStringLiteral("Battle.net.exe")));
+  QTemporaryDir bottlesDir;
+  QVERIFY(bottlesDir.isValid());
+  const QString bottlesPrefix = bottlesDir.path() + QStringLiteral("/folder-name");
+  writeFile(bottlesPrefix + QStringLiteral("/bottle.yml"), "Name: Actual Bottle\n");
+  const LaunchCommand bottles = GameLauncher::battleNetCommand(
+      QStringLiteral("pro"), bottlesPrefix, QStringLiteral("bottles"), false);
+  QCOMPARE(bottles.program, QStringLiteral("bottles-cli"));
+  const int bottleFlag = bottles.arguments.indexOf(QStringLiteral("-b"));
+  QVERIFY(bottleFlag >= 0);
+  QCOMPARE(bottles.arguments.at(bottleFlag + 1), QStringLiteral("Actual Bottle"));
+  QCOMPARE(bottles.arguments.constLast(), QStringLiteral("--exec=launch Pro"));
+  const QString scopedId =
+      BattleNetScanner::gameIdFor(QStringLiteral("wow"), prefix);
+  const LaunchCommand scoped =
+      GameLauncher::battleNetCommand(scopedId, prefix, QStringLiteral("wine"), false);
+  QVERIFY(scoped.isValid());
+  QCOMPARE(scoped.arguments.constLast(), QStringLiteral("--exec=launch WoW"));
+  const LaunchCommand proton = GameLauncher::battleNetCommand(
+      QStringLiteral("s2"), prefix, QStringLiteral("proton"), false);
+  QCOMPARE(proton.program, QStringLiteral("umu-run"));
+  QCOMPARE(proton.arguments.constLast(), QStringLiteral("--exec=launch S2"));
+  QVERIFY(!GameLauncher::battleNetCommand(QStringLiteral("bad;id"), prefix, QStringLiteral("wine"),
+                                          false)
+               .isValid());
+  QVERIFY(!GameLauncher::battleNetCommand(QStringLiteral("wow"), QStringLiteral("relative"),
+                                          QStringLiteral("wine"), false)
+               .isValid());
+  QVERIFY(!GameLauncher::battleNetCommand(QStringLiteral("../escape"), prefix,
+                                          QStringLiteral("wine"), false)
+               .isValid());
+}
+
 void CoreTests::launcherReportsInvalidAndStaleTargets() {
   GameLauncher launcher;
   QVERIFY(!launcher.launch(QStringLiteral("Lutris"), QStringLiteral("bad")));
@@ -1866,6 +2164,9 @@ void CoreTests::launcherReportsInvalidAndStaleTargets() {
   QVERIFY(!launcher.launch(QStringLiteral("Steam"), QStringLiteral("440"), false, {},
                            QStringLiteral("/path/that/does/not/exist")));
   QVERIFY(launcher.lastError().startsWith(QStringLiteral("The installed files are missing.")));
+  QVERIFY(!launcher.launch(QStringLiteral("Battle.net"), QStringLiteral("wow;rm"), false,
+                           QStringLiteral("wine"), {}, QStringLiteral("/tmp/omakade-bnet")));
+  QCOMPARE(launcher.lastError(), QStringLiteral("This game has an invalid Battle.net target."));
 }
 
 void CoreTests::igdbApiBuildsSafeQueriesAndParsesInsights() {
@@ -1960,6 +2261,7 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
     settings.setLutrisEnabled(false);
     settings.setFaugusEnabled(false);
     settings.setRetroArchEnabled(false);
+    settings.setBattleNetEnabled(false);
     settings.setCloseAfterLaunch(true);
   }
   AppSettings reloaded(path);
@@ -1972,6 +2274,7 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
   QVERIFY(reloaded.heroicEnabled());
   QVERIFY(!reloaded.faugusEnabled());
   QVERIFY(!reloaded.retroArchEnabled());
+  QVERIFY(!reloaded.battleNetEnabled());
   QVERIFY(reloaded.closeAfterLaunch());
 }
 


### PR DESCRIPTION
## Summary

Adds Battle.net as a first-class library source alongside Steam, Lutris, Heroic, Faugus, and RetroArch: discovery, import, launch, covers, settings, UI, and tests.

## Discovery and import

- Finds Wine, Proton, and Bottles prefixes that contain Battle.net's Agent `product.db` without crawling the home directory (`~/.wine`, wineprefixes, Bottles bottles, `~/Games/*`, Steam `compatdata/*/pfx`).
- Parses `product.db` with a small protobuf decoder (no protobuf dependency). Skips the Agent/app, imports installed/playable titles, and maps product codes to titles and `--exec=launch` codes.
- Each install is keyed as `productId@prefixHash` so the same title in two prefixes stays distinct. Launch strips the suffix for Battle.net.
- Malformed or oversized `product.db` files keep the cached library instead of emptying it.

## Launch

- Play/Manage go through Battle.net.exe in the same prefix via Wine, `umu-run` (Proton), or `bottles-cli`.
- Bottles uses `Name:` from `bottle.yml` when present.
- Invalid ids and missing clients produce actionable errors. Omakade does not write into the prefix.

## Artwork

- Uses local `cover.*` / `library_600x900.*` and `library_hero.*` / `header.*` when those files exist.
- Otherwise downloads Lutris public covers and banners, caches them under `covers/battlenet/`, and prunes against the artwork cache limit. In-flight downloads do not replace an existing local cover.

## Integration

- `battlenet_enabled` setting, BATTLE.NET filter chip, Settings source row, rescan, empty states, and Manage in Battle.net.
- Staggered startup scan with the other sources.

## Tests

- Scanner fixtures for Wine/Proton/Bottles layouts, two prefixes of the same product, ignored `icon.ico`, malformed and oversized `product.db` keep-cache, model favorites/hidden, Bottles YAML name, scoped launch ids, and command-injection rejection.
- Full suite (core tests, QML smoke, controller navigation, render smoke) passing locally.

Verified against a real Wine prefix at `~/Games/battlenet` with Heroes of the Storm: the game imported, launched through Battle.net, and received Lutris cover art.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Battle.net as a supported game source.
  * Automatically discovers installed Battle.net games in Wine, Proton, and Bottles environments.
  * Launches games through the Battle.net client.
  * Displays Battle.net games with play history, favorites, hidden status, and artwork.
  * Downloads missing covers and banners from public artwork sources.
  * Added settings to enable or rescan Battle.net libraries.

* **Documentation**
  * Updated product, compatibility, privacy, support, and user documentation to include Battle.net support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->