### PR TITLE
Fix responsive game details cover layout

### DIFF
--- a/build.log
+++ b/build.log
@@ -1,0 +1,65 @@
+[1/65] Copying omakade qml sources into build dir
+[2/65] Copying omakade qml resources into build dir
+[3/65] Populating .qmlls.ini file at /tmp/claude-1000/-home-bts-Projects-steam-launcher/c94ee6e4-e786-47a7-882c-a24fa0a981eb/scratchpad/wt22/build/dev/.qt/.qmlls.build.ini
+[4/65] Running qmlimportscanner for omakade
+[5/65] Automatic MOC and UIC for target omakade_core
+[6/65] Building CXX object CMakeFiles/omakade_core.dir/src/app/SingleInstance.cpp.o
+[7/65] Building CXX object CMakeFiles/omakade_core.dir/src/launch/SteamLauncher.cpp.o
+[8/65] Building CXX object CMakeFiles/omakade_core.dir/src/metadata/IgdbApi.cpp.o
+[9/65] Building CXX object CMakeFiles/omakade_core.dir/src/library/SteamOwnedGamesApi.cpp.o
+[10/65] Building CXX object CMakeFiles/omakade_core.dir/src/app/AppSettings.cpp.o
+[11/65] Building CXX object CMakeFiles/omakade_core.dir/src/library/LibraryFilterModel.cpp.o
+[12/65] Building CXX object CMakeFiles/omakade_core.dir/src/library/MockGameModel.cpp.o
+[13/65] Building CXX object CMakeFiles/omakade_core.dir/src/achievements/SteamAchievementApi.cpp.o
+[14/65] Building CXX object CMakeFiles/omakade_core.dir/src/launch/GameLauncher.cpp.o
+[15/65] Building CXX object CMakeFiles/omakade_core.dir/src/sources/steam/ValveKeyValues.cpp.o
+[16/65] Building CXX object CMakeFiles/omakade_core.dir/src/sources/lutris/LutrisScanner.cpp.o
+[17/65] Building CXX object CMakeFiles/omakade_core.dir/omakade_core_autogen/mocs_compilation.cpp.o
+[18/65] Building CXX object CMakeFiles/omakade_core.dir/src/achievements/AchievementModel.cpp.o
+[19/65] Building CXX object CMakeFiles/omakade_core.dir/src/sources/steam/SteamScanner.cpp.o
+[20/65] Building CXX object CMakeFiles/omakade_core.dir/src/input/ControllerInput.cpp.o
+[21/65] Building CXX object CMakeFiles/omakade_core.dir/src/library/LutrisGameModel.cpp.o
+[22/65] Building CXX object CMakeFiles/omakade_core.dir/src/sources/retroarch/RetroArchScanner.cpp.o
+[23/65] Building CXX object CMakeFiles/omakade_core.dir/src/metadata/GameInsightsService.cpp.o
+[24/65] Building CXX object CMakeFiles/omakade_core.dir/src/theme/OmarchyTheme.cpp.o
+[25/65] Building CXX object CMakeFiles/omakade_core.dir/src/library/FaugusGameModel.cpp.o
+[26/65] Building CXX object CMakeFiles/omakade_core.dir/src/library/HeroicGameModel.cpp.o
+[27/65] Building CXX object CMakeFiles/omakade_core.dir/src/library/RetroArchGameModel.cpp.o
+[28/65] Building CXX object CMakeFiles/omakade_core.dir/src/sources/faugus/FaugusScanner.cpp.o
+[29/65] Building CXX object CMakeFiles/omakade_core.dir/src/sources/heroic/HeroicScanner.cpp.o
+[30/65] Building CXX object CMakeFiles/omakade_core.dir/src/library/UnifiedGameModel.cpp.o
+[31/65] Building CXX object CMakeFiles/omakade_core.dir/src/achievements/SteamAccountService.cpp.o
+[32/65] Building CXX object CMakeFiles/omakade_core.dir/src/library/SteamGameModel.cpp.o
+[33/65] Linking CXX static library libomakade_core.a
+[34/65] Automatic MOC and UIC for target omakade
+[35/65] Running AUTOMOC file extraction for target omakade
+[36/65] Running rcc for resource omakade_icons
+[37/65] Running rcc for resource omakade_raw_qml_0_extra_qmldirs
+[38/65] Running rcc for resource qmake_Omakade
+[39/65] Generating .rcc/qmlcache/omakade_qmlcache_loader.cpp
+[40/65] Running moc --collect-json for target omakade
+[41/65] Automatic QML type registration for target omakade
+[42/65] Running rcc for resource omakade_raw_qml_0
+[43/65] Generating .rcc/qmlcache/omakade_qml_components_GameCard_qml.cpp, .rcc/qmlcache/omakade_qml_components_GameCard_qml.cpp.aotstats
+[44/65] Generating .rcc/qmlcache/omakade_qml_components_GlassButton_qml.cpp, .rcc/qmlcache/omakade_qml_components_GlassButton_qml.cpp.aotstats
+[45/65] Generating .rcc/qmlcache/omakade_qml_components_LibraryView_qml.cpp, .rcc/qmlcache/omakade_qml_components_LibraryView_qml.cpp.aotstats
+[46/65] Generating .rcc/qmlcache/omakade_qml_screens_GameDetails_qml.cpp, .rcc/qmlcache/omakade_qml_screens_GameDetails_qml.cpp.aotstats
+[47/65] Generating .rcc/qmlcache/omakade_qml_Main_qml.cpp, .rcc/qmlcache/omakade_qml_Main_qml.cpp.aotstats
+[48/65] Automatic MOC and UIC for target omakade_core_tests
+[49/65] Building CXX object CMakeFiles/omakade.dir/omakade_autogen/mocs_compilation.cpp.o
+[50/65] Building CXX object tests/CMakeFiles/omakade_core_tests.dir/omakade_core_tests_autogen/mocs_compilation.cpp.o
+[51/65] Building CXX object CMakeFiles/omakade.dir/build/dev/.qt/rcc/qrc_omakade_raw_qml_0_extra_qmldirs.cpp.o
+[52/65] Building CXX object CMakeFiles/omakade.dir/build/dev/.qt/rcc/qrc_qmake_Omakade.cpp.o
+[53/65] Building CXX object CMakeFiles/omakade.dir/build/dev/.qt/rcc/qrc_omakade_icons.cpp.o
+[54/65] Building CXX object CMakeFiles/omakade.dir/build/dev/.qt/rcc/qrc_omakade_raw_qml_0.cpp.o
+[55/65] Building CXX object CMakeFiles/omakade.dir/omakade_qmltyperegistrations.cpp.o
+[56/65] Building CXX object CMakeFiles/omakade.dir/build/dev/.rcc/qmlcache/omakade_qmlcache_loader.cpp.o
+[57/65] Building CXX object CMakeFiles/omakade.dir/build/dev/.rcc/qmlcache/omakade_qml_components_GlassButton_qml.cpp.o
+[58/65] Building CXX object CMakeFiles/omakade.dir/build/dev/.rcc/qmlcache/omakade_qml_components_LibraryView_qml.cpp.o
+[59/65] Building CXX object CMakeFiles/omakade.dir/build/dev/.rcc/qmlcache/omakade_qml_Main_qml.cpp.o
+[60/65] Building CXX object CMakeFiles/omakade.dir/build/dev/.rcc/qmlcache/omakade_qml_components_GameCard_qml.cpp.o
+[61/65] Building CXX object CMakeFiles/omakade.dir/src/app/main.cpp.o
+[62/65] Building CXX object CMakeFiles/omakade.dir/build/dev/.rcc/qmlcache/omakade_qml_screens_GameDetails_qml.cpp.o
+[63/65] Linking CXX executable omakade
+[64/65] Building CXX object tests/CMakeFiles/omakade_core_tests.dir/CoreTests.cpp.o
+[65/65] Linking CXX executable tests/omakade_core_tests

--- a/cfg.log
+++ b/cfg.log
@@ -1,0 +1,24 @@
+-- The CXX compiler identification is GNU 16.2.1
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Check for working CXX compiler: /usr/bin/c++ - skipped
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- Found PkgConfig: /usr/bin/pkg-config (found version "3.0.6")
+-- Checking for module 'sdl3'
+--   Found sdl3, version 3.4.14
+-- Checking for module 'libsecret-1'
+--   Found libsecret-1, version 0.21.7
+-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
+-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
+-- Found Threads: TRUE
+-- Performing Test HAVE_STDATOMIC
+-- Performing Test HAVE_STDATOMIC - Success
+-- Found WrapAtomic: TRUE
+-- Found OpenGL: /usr/lib/libOpenGL.so
+-- Found WrapOpenGL: TRUE
+-- Could NOT find WrapVulkanHeaders (missing: Vulkan_INCLUDE_DIR) 
+-- Could NOT find WrapVulkanHeaders (missing: Vulkan_INCLUDE_DIR) 
+-- Configuring done (0.7s)
+-- Generating done (0.0s)
+-- Build files have been written to: /tmp/claude-1000/-home-bts-Projects-steam-launcher/c94ee6e4-e786-47a7-882c-a24fa0a981eb/scratchpad/wt22/build/dev

--- a/qml/screens/GameDetails.qml
+++ b/qml/screens/GameDetails.qml
@@ -48,6 +48,13 @@ Item {
         if (!item || !flickable) {
             return
         }
+        let ancestor = item
+        while (ancestor) {
+            if (ancestor === coverSidebar || ancestor === backButton) {
+                return
+            }
+            ancestor = ancestor.parent
+        }
         const position = item.mapToItem(flickable, 0, 0)
         const margin = 16
         if (position.y < margin) {
@@ -139,117 +146,130 @@ Item {
         onClicked: root.backRequested()
     }
 
-    ScrollView {
-        id: detailsScroll
-        objectName: "detailsScroll"
-        readonly property real navigationContentY: contentItem ? contentItem.contentY : 0
+    Item {
+        id: detailsArea
         anchors.fill: parent
         anchors.topMargin: 80
         anchors.leftMargin: Math.max(28, parent.width * 0.055)
         anchors.rightMargin: Math.max(28, parent.width * 0.055)
         anchors.bottomMargin: 22
-        rightPadding: 18
-        contentWidth: availableWidth
-        clip: true
+        readonly property real columnSpacing: Math.max(28, width * 0.045)
 
-        RowLayout {
-            width: parent.width
-            spacing: Math.max(28, width * 0.045)
+        ColumnLayout {
+            id: coverSidebar
+            anchors.top: parent.top
+            anchors.left: parent.left
+            width: Math.max(0, Math.min((detailsArea.height - reservedControlHeight) / 1.5,
+                                        detailsArea.width * 0.44))
+            spacing: 8
+            readonly property real reservedControlHeight:
+                (coverActions.visible ? coverActions.implicitHeight + spacing : 0)
+                + (linkActions.visible ? linkActions.implicitHeight + spacing : 0)
 
-            ColumnLayout {
-                Layout.preferredWidth: Math.min(330, root.width * 0.28)
-                Layout.alignment: Qt.AlignTop
-                spacing: 8
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: width * 1.5
+                radius: Math.max(6, Theme.cornerRadius)
+                clip: true
+                border.color: root.alpha(Theme.foreground, 0.22)
+                gradient: Gradient {
+                    orientation: Gradient.Horizontal
+                    GradientStop { position: 0.0; color: root.game.accentStart || Theme.accent }
+                    GradientStop { position: 1.0; color: root.game.accentEnd || Theme.blue }
+                }
+
+                Image {
+                    id: coverArtwork
+                    anchors.fill: parent
+                    source: root.game.coverPath || ""
+                    asynchronous: true
+                    cache: false
+                    fillMode: Image.PreserveAspectFit
+                    sourceSize.width: Math.ceil(width * Math.max(1, Screen.devicePixelRatio) / 64) * 64
+                    sourceSize.height: Math.ceil(height * Math.max(1, Screen.devicePixelRatio) / 64) * 64
+                    opacity: status === Image.Ready ? 1 : 0
+                }
 
                 Rectangle {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: width * 1.5
-                    radius: Math.max(6, Theme.cornerRadius)
-                    clip: true
-                    border.color: root.alpha(Theme.foreground, 0.22)
+                    visible: coverArtwork.status !== Image.Ready
+                    width: parent.width * 0.95
+                    height: width
+                    radius: width / 2
+                    x: parent.width * 0.44
+                    y: -height * 0.18
+                    color: root.alpha(Theme.brightForeground, 0.10)
+                }
+
+                Text {
+                    visible: coverArtwork.status !== Image.Ready
+                    anchors.centerIn: parent
+                    text: root.game.coverMark || "◇"
+                    color: root.alpha(Theme.brightForeground, 0.9)
+                    font.family: Theme.fontFamily
+                    font.pixelSize: Math.max(74, parent.width * 0.34)
+                }
+
+                Rectangle {
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    height: parent.height * 0.34
                     gradient: Gradient {
-                        orientation: Gradient.Horizontal
-                        GradientStop { position: 0.0; color: root.game.accentStart || Theme.accent }
-                        GradientStop { position: 1.0; color: root.game.accentEnd || Theme.blue }
-                    }
-
-                    Image {
-                        id: coverArtwork
-                        anchors.fill: parent
-                        source: root.game.coverPath || ""
-                        asynchronous: true
-                        cache: false
-                        fillMode: Image.PreserveAspectCrop
-                        sourceSize.width: Math.ceil(width * Math.max(1, Screen.devicePixelRatio) / 64) * 64
-                        sourceSize.height: Math.ceil(height * Math.max(1, Screen.devicePixelRatio) / 64) * 64
-                        opacity: status === Image.Ready ? 1 : 0
-                    }
-
-                    Rectangle {
-                        visible: coverArtwork.status !== Image.Ready
-                        width: parent.width * 0.95
-                        height: width
-                        radius: width / 2
-                        x: parent.width * 0.44
-                        y: -height * 0.18
-                        color: root.alpha(Theme.brightForeground, 0.10)
-                    }
-
-                    Text {
-                        visible: coverArtwork.status !== Image.Ready
-                        anchors.centerIn: parent
-                        text: root.game.coverMark || "◇"
-                        color: root.alpha(Theme.brightForeground, 0.9)
-                        font.family: Theme.fontFamily
-                        font.pixelSize: Math.max(74, parent.width * 0.34)
-                    }
-
-                    Rectangle {
-                        anchors.left: parent.left
-                        anchors.right: parent.right
-                        anchors.bottom: parent.bottom
-                        height: parent.height * 0.34
-                        gradient: Gradient {
-                            GradientStop { position: 0.0; color: "transparent" }
-                            GradientStop { position: 1.0; color: root.alpha(Theme.darkerBackground, 0.84) }
-                        }
-                    }
-                }
-
-                RowLayout {
-                    Layout.fillWidth: true
-                    visible: !DemoMode
-                    spacing: 8
-                    GlassButton {
-                        Layout.fillWidth: true
-                        compact: true
-                        text: "CHANGE COVER"
-                        onClicked: root.coverRequested()
-                    }
-                    GlassButton {
-                        visible: root.game.customCover || false
-                        compact: true
-                        text: "RESET"
-                        onClicked: root.coverResetRequested()
-                    }
-                }
-
-                RowLayout {
-                    Layout.fillWidth: true
-                    visible: !DemoMode
-                    spacing: 8
-                    GlassButton {
-                        Layout.fillWidth: true
-                        compact: true
-                        text: root.game.linked ? "UNLINK INSTALLATIONS" : "LINK INSTALLATION"
-                        onClicked: root.game.linked ? root.unlinkRequested() : root.linkRequested()
+                        GradientStop { position: 0.0; color: "transparent" }
+                        GradientStop { position: 1.0; color: root.alpha(Theme.darkerBackground, 0.84) }
                     }
                 }
             }
 
-            ColumnLayout {
+            RowLayout {
+                id: coverActions
                 Layout.fillWidth: true
-                Layout.alignment: Qt.AlignTop
+                visible: !DemoMode
+                spacing: 8
+                GlassButton {
+                    Layout.fillWidth: true
+                    compact: true
+                    text: "CHANGE COVER"
+                    onClicked: root.coverRequested()
+                }
+                GlassButton {
+                    visible: root.game.customCover || false
+                    compact: true
+                    text: "RESET"
+                    onClicked: root.coverResetRequested()
+                }
+            }
+
+            RowLayout {
+                id: linkActions
+                Layout.fillWidth: true
+                visible: !DemoMode
+                spacing: 8
+                GlassButton {
+                    Layout.fillWidth: true
+                    compact: true
+                    text: root.game.linked ? "UNLINK INSTALLATIONS" : "LINK INSTALLATION"
+                    onClicked: root.game.linked ? root.unlinkRequested() : root.linkRequested()
+                }
+            }
+        }
+
+        ScrollView {
+            id: detailsScroll
+            objectName: "detailsScroll"
+            readonly property real navigationContentY: contentItem ? contentItem.contentY : 0
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            anchors.left: coverSidebar.right
+            anchors.leftMargin: detailsArea.columnSpacing
+            anchors.right: parent.right
+            rightPadding: 18
+            contentWidth: availableWidth
+            clip: true
+
+            ColumnLayout {
+                id: detailsContent
+                width: detailsScroll.availableWidth
                 spacing: 16
 
                 Text {
@@ -258,7 +278,7 @@ Item {
                     textFormat: Text.PlainText
                     color: Theme.brightForeground
                     font.family: Theme.fontFamily
-                    font.pixelSize: Math.max(28, Math.min(54, root.width * 0.045))
+                    font.pixelSize: Math.max(28, Math.min(54, width * 0.07))
                     font.weight: Font.Bold
                     wrapMode: Text.Wrap
                 }
@@ -332,8 +352,11 @@ Item {
                         font.pixelSize: 9
                         font.weight: Font.DemiBold
                     }
-                    RowLayout {
-                        spacing: 8
+                    GridLayout {
+                        Layout.fillWidth: true
+                        columns: Math.max(1, Math.floor(detailsContent.width / 160))
+                        columnSpacing: 8
+                        rowSpacing: 8
                         Repeater {
                             model: root.installations
                             GlassButton {
@@ -351,7 +374,8 @@ Item {
                 }
 
                 GridLayout {
-                    columns: root.width < 1050 ? 2 : 4
+                    Layout.fillWidth: true
+                    columns: detailsContent.width < 620 ? 2 : 4
                     columnSpacing: 10
                     rowSpacing: 8
 
@@ -362,6 +386,7 @@ Item {
                               ? "INSTALL IN STEAM" : "PLAY"
                         iconText: root.selectedInstallation.installed === false ? "↓" : "▶"
                         primary: true
+                        Layout.fillWidth: true
                         onClicked: root.playRequested()
                         Component.onCompleted: forceActiveFocus()
                     }
@@ -369,6 +394,7 @@ Item {
                     GlassButton {
                         text: root.game.favorite ? "FAVORITE" : "ADD FAVORITE"
                         iconText: root.game.favorite ? "♥" : "♡"
+                        Layout.fillWidth: true
                         onClicked: root.favoriteRequested()
                     }
 
@@ -379,11 +405,13 @@ Item {
                                  || root.selectedInstallation.source === "Faugus"
                                  || root.selectedInstallation.source === "RetroArch"
                         text: "MANAGE IN " + (root.selectedInstallation.source || "LAUNCHER").toUpperCase()
+                        Layout.fillWidth: true
                         onClicked: root.manageRequested()
                     }
 
                     GlassButton {
                         text: root.game.hidden ? "UNHIDE" : "HIDE"
+                        Layout.fillWidth: true
                         onClicked: root.hiddenRequested()
                     }
                 }
@@ -403,20 +431,26 @@ Item {
                         font.letterSpacing: 0.6
                     }
 
-                    RowLayout {
-                        spacing: 6
+                    GridLayout {
+                        id: statusLayout
+                        Layout.fillWidth: true
+                        columns: detailsContent.width < 560 ? 2 : 5
+                        columnSpacing: 6
+                        rowSpacing: 6
                         Text {
                             text: "STATUS"
                             color: Theme.mutedText
                             font.family: Theme.fontFamily
                             font.pixelSize: 9
                             Layout.preferredWidth: 76
+                            Layout.columnSpan: statusLayout.columns === 2 ? 2 : 1
                         }
                         Repeater {
                             model: ["backlog", "playing", "completed", "abandoned"]
                             GlassButton {
                                 required property string modelData
                                 compact: true
+                                Layout.fillWidth: true
                                 text: modelData.toUpperCase()
                                 selected: (root.game.completionStatus || "") === modelData
                                 onClicked: root.completionStatusRequested(
@@ -517,22 +551,27 @@ Item {
                         }
                     }
 
-                    RowLayout {
+                    GridLayout {
+                        id: collectionEditor
                         Layout.fillWidth: true
                         visible: root.collectionEditorOpen
-                        spacing: 8
+                        columns: detailsContent.width < 600 ? 2 : 4
+                        columnSpacing: 8
+                        rowSpacing: 8
                         Text {
                             text: "NEW"
                             color: Theme.mutedText
                             font.family: Theme.fontFamily
                             font.pixelSize: 9
                             Layout.preferredWidth: 76
+                            Layout.columnSpan: collectionEditor.columns === 2 ? 2 : 1
                         }
                         TextField {
                             id: collectionField
                             property bool controllerNavigation: false
                             Layout.fillWidth: true
                             Layout.maximumWidth: 360
+                            Layout.columnSpan: collectionEditor.columns === 2 ? 2 : 1
                             placeholderText: "New collection"
                             color: Theme.foreground
                             placeholderTextColor: root.alpha(Theme.foreground, 0.42)
@@ -556,6 +595,7 @@ Item {
                         }
                         GlassButton {
                             compact: true
+                            Layout.fillWidth: collectionEditor.columns === 2
                             text: "CREATE + ADD"
                             onClicked: {
                                 root.collectionCreateRequested(collectionField.text)
@@ -564,6 +604,7 @@ Item {
                         }
                         GlassButton {
                             compact: true
+                            Layout.fillWidth: collectionEditor.columns === 2
                             text: "CANCEL"
                             onClicked: root.closeCollectionEditor()
                         }
@@ -573,7 +614,7 @@ Item {
                 GridLayout {
                     Layout.fillWidth: true
                     Layout.topMargin: 12
-                    columns: root.width < 1050 ? 1 : 3
+                    columns: detailsContent.width < 520 ? 1 : 3
                     columnSpacing: 10
                     rowSpacing: 10
 
@@ -701,7 +742,7 @@ Item {
                     GridLayout {
                         Layout.fillWidth: true
                         visible: insightsSection.metrics.length > 0
-                        columns: insightsSection.metrics.length === 4 && root.width < 1120
+                        columns: insightsSection.metrics.length === 4 && detailsContent.width < 620
                                  ? 2 : Math.max(1, insightsSection.metrics.length)
                         columnSpacing: 10
                         rowSpacing: 10
@@ -892,7 +933,7 @@ Item {
                         id: achievementGrid
                         Layout.fillWidth: true
                         visible: Achievements.total > 0
-                        columns: root.width < 1160 ? 1 : 2
+                        columns: detailsContent.width < 620 ? 1 : 2
                         columnSpacing: 10
                         rowSpacing: 10
 
@@ -980,6 +1021,7 @@ Item {
                                             elide: Text.ElideRight
                                         }
                                         Text {
+                                            Layout.fillWidth: true
                                             text: (unlocked && unlockTime > 0
                                                    ? "UNLOCKED " + Qt.formatDateTime(new Date(unlockTime * 1000), "MMM d, yyyy").toUpperCase() + "  ·  "
                                                    : "")
@@ -988,6 +1030,7 @@ Item {
                                             font.family: Theme.fontFamily
                                             font.pixelSize: 8
                                             font.weight: Font.DemiBold
+                                            elide: Text.ElideRight
                                         }
                                     }
                                 }
@@ -995,7 +1038,7 @@ Item {
                         }
                     }
                 }
-            }
         }
     }
+}
 }

--- a/qml/screens/GameDetails.qml
+++ b/qml/screens/GameDetails.qml
@@ -159,7 +159,8 @@ Item {
             id: coverSidebar
             anchors.top: parent.top
             anchors.left: parent.left
-            width: Math.max(0, Math.min((detailsArea.height - reservedControlHeight) / 1.5,
+            width: Math.max(0, Math.min(root.width * 0.28,
+                                        (detailsArea.height - reservedControlHeight) / 1.5,
                                         detailsArea.width * 0.44))
             spacing: 8
             readonly property real reservedControlHeight:
@@ -386,7 +387,6 @@ Item {
                               ? "INSTALL IN STEAM" : "PLAY"
                         iconText: root.selectedInstallation.installed === false ? "↓" : "▶"
                         primary: true
-                        Layout.fillWidth: true
                         onClicked: root.playRequested()
                         Component.onCompleted: forceActiveFocus()
                     }
@@ -394,7 +394,6 @@ Item {
                     GlassButton {
                         text: root.game.favorite ? "FAVORITE" : "ADD FAVORITE"
                         iconText: root.game.favorite ? "♥" : "♡"
-                        Layout.fillWidth: true
                         onClicked: root.favoriteRequested()
                     }
 
@@ -405,13 +404,11 @@ Item {
                                  || root.selectedInstallation.source === "Faugus"
                                  || root.selectedInstallation.source === "RetroArch"
                         text: "MANAGE IN " + (root.selectedInstallation.source || "LAUNCHER").toUpperCase()
-                        Layout.fillWidth: true
                         onClicked: root.manageRequested()
                     }
 
                     GlassButton {
                         text: root.game.hidden ? "UNHIDE" : "HIDE"
-                        Layout.fillWidth: true
                         onClicked: root.hiddenRequested()
                     }
                 }

--- a/qml/screens/GameDetails.qml
+++ b/qml/screens/GameDetails.qml
@@ -740,10 +740,14 @@ Item {
                     }
 
                     GridLayout {
+                        id: insightsGrid
                         Layout.fillWidth: true
                         visible: insightsSection.metrics.length > 0
-                        columns: insightsSection.metrics.length === 4 && detailsContent.width < 620
-                                 ? 2 : Math.max(1, insightsSection.metrics.length)
+                        readonly property real minimumMetricWidth: 130
+                        columns: Math.max(1, Math.min(
+                                              insightsSection.metrics.length,
+                                              Math.floor((detailsContent.width + columnSpacing)
+                                                         / (minimumMetricWidth + columnSpacing))))
                         columnSpacing: 10
                         rowSpacing: 10
 
@@ -753,7 +757,7 @@ Item {
                             Rectangle {
                                 required property var modelData
                                 Layout.fillWidth: true
-                                Layout.minimumWidth: 130
+                                Layout.minimumWidth: insightsGrid.minimumMetricWidth
                                 Layout.maximumWidth: 340
                                 Layout.preferredHeight: 72
                                 radius: Math.max(5, Theme.cornerRadius)


### PR DESCRIPTION
## Summary

- size the game cover from the available viewport height while reserving room for its actions
- keep the cover and cover actions fixed while the details panel scrolls independently
- base responsive breakpoints on the details panel width so controls and achievement cards do not clip in narrow windows
- preserve the full cover artwork and constrain long achievement metadata inside its card

## Validation

- `make -C build/dev -j2`
- `QT_QPA_PLATFORM=offscreen ./build/dev/tests/omakade_core_tests` (64 passed)
- `QT_QPA_PLATFORM=offscreen QT_QUICK_BACKEND=software ./build/dev/omakade --smoke-test`
- controller navigation test at the default layout
- controller navigation test at `820x590`
- manually resized and verified at `820x590`, `1165x1030`, `1380x880`, and `2560x1080`

The manual checks confirmed that the cover and both actions remain visible, the sidebar stays fixed during scrolling, and the details controls reflow without clipping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Layout**
  * Added a responsive game details layout with a dedicated cover-art sidebar and independently scrollable content.
  * Improved cover artwork presentation with fallback styling and clearer cover/link actions.
* **Usability**
  * Adjusted installation, status, collection, statistics, insights, and achievement controls to adapt to available space.
  * Enhanced scrolling, text sizing, card sizing, and action-button behavior across different window widths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->