### PR TITLE
Harden Couch Mode for 1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,14 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.cache/
 /.qt/
 compile_commands.json
+__pycache__/

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -405,9 +405,33 @@ ApplicationWindow {
         }
     }
 
-    function setCouchMode(enabled) {
+    function focusCurrentSurface() {
+        const container = root.navigationContainer()
+        const current = root.activeFocusItem
+        if (container && root.isWithin(current, container)
+                && current.visible && current.enabled) {
+            root.revealNavigationItem(container, current)
+        } else if (container) {
+            root.focusWithin(container, true)
+        } else {
+            root.focusLibrary()
+        }
+    }
+
+    function updateCouchMode(enabled, remember) {
         if (root.couchMode === enabled) {
             return
+        }
+        if (!enabled) {
+            if (root.couchTextEntryOpen) {
+                root.closeCouchTextEntry(false)
+            }
+            if (couchLibraryView.searchOpen) {
+                couchLibraryView.closeSearch(false)
+            }
+            if (couchLibraryView.browseOpen) {
+                couchLibraryView.closeBrowse()
+            }
         }
         if (enabled) {
             couchLibraryView.currentIndex = libraryView.currentIndex
@@ -416,9 +440,21 @@ ApplicationWindow {
             libraryView.currentIndex = couchLibraryView.currentIndex
         }
         root.couchMode = enabled
-        Preferences.couchModeEnabled = enabled
+        if (remember) {
+            Preferences.couchModeEnabled = enabled
+        }
         root.visibility = enabled ? Window.FullScreen : root.desktopVisibility
-        Qt.callLater(root.focusLibrary)
+        Qt.callLater(root.focusCurrentSurface)
+    }
+
+    function setCouchMode(enabled) {
+        root.updateCouchMode(enabled, true)
+    }
+
+    // A Sunshine activation is session-scoped. It must not change the preferred startup
+    // mode just because an already-running desktop window receives the request.
+    function activateCouchMode() {
+        root.updateCouchMode(true, false)
     }
 
     function toggleCouchMode() {
@@ -1654,6 +1690,7 @@ ApplicationWindow {
                 model: root.linkResults
 
                 delegate: Button {
+                    id: candidateDelegate
                     required property var modelData
                     required property int index
                     width: candidateList.width
@@ -1703,11 +1740,12 @@ ApplicationWindow {
 
                     background: Rectangle {
                         radius: Math.max(5, Theme.cornerRadius)
-                        color: parent.down || parent.hovered || parent.activeFocus
+                        color: candidateDelegate.down || candidateDelegate.hovered
+                               || candidateDelegate.activeFocus
                                ? root.alpha(Theme.foreground, 0.09)
                                : root.alpha(Theme.foreground, 0.04)
-                        border.width: parent.activeFocus ? 2 : 1
-                        border.color: parent.activeFocus
+                        border.width: candidateDelegate.activeFocus ? 2 : 1
+                        border.color: candidateDelegate.activeFocus
                                       ? Theme.accent
                                       : root.alpha(Theme.foreground, 0.14)
                     }
@@ -1887,15 +1925,16 @@ ApplicationWindow {
         Rectangle {
             id: settingsPanel
             anchors.centerIn: parent
-            readonly property real uiScale: root.couchMode
-                                                ? Math.max(1, Math.min(1.35,
-                                                                      root.height / 900))
-                                                : 1
-            width: Math.min(root.couchMode ? 1280 : 610,
+            readonly property real layoutScale: root.couchMode
+                                                    ? Math.max(1, Math.min(2,
+                                                                          root.height / 1080))
+                                                    : 1
+            readonly property real uiScale: root.couchMode ? 1.25 * layoutScale : 1
+            width: Math.min(root.couchMode ? 1280 * layoutScale : 610,
                             parent.width - (root.couchMode ? 96 : 48))
-            height: Math.min(root.couchMode ? 900 : 760,
+            height: Math.min(root.couchMode ? 900 * layoutScale : 760,
                              parent.height - (root.couchMode ? 72 : 48))
-            radius: Math.max(root.couchMode ? 14 : 8, Theme.cornerRadius)
+            radius: Math.max(root.couchMode ? 14 * layoutScale : 8, Theme.cornerRadius)
             color: root.alpha(Theme.background, 0.98)
             border.color: root.alpha(Theme.foreground, 0.2)
 
@@ -1906,8 +1945,8 @@ ApplicationWindow {
                 objectName: "settingsScroll"
                 readonly property real navigationContentY: contentItem ? contentItem.contentY : 0
                 anchors.fill: parent
-                anchors.margins: root.couchMode ? 42 : 28
-                anchors.bottomMargin: root.couchMode ? 70 : 28
+                anchors.margins: root.couchMode ? 42 * settingsPanel.layoutScale : 28
+                anchors.bottomMargin: root.couchMode ? 70 * settingsPanel.layoutScale : 28
                 rightPadding: 18
                 contentWidth: availableWidth
 

--- a/qml/components/CouchBrowsePanel.qml
+++ b/qml/components/CouchBrowsePanel.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Layouts
 
 FocusScope {
@@ -18,6 +17,9 @@ FocusScope {
         { label: "COLLECTION", kind: "collection" },
         { label: "TAG", kind: "tag" }
     ]
+    readonly property real uiScale: Math.max(1, Math.min(2,
+                                                         Math.min(width / 1920,
+                                                                  height / 1080)))
 
     signal closed()
     signal filtersChanged()
@@ -155,30 +157,30 @@ FocusScope {
 
     ColumnLayout {
         anchors.fill: parent
-        anchors.leftMargin: 72
-        anchors.rightMargin: 72
-        anchors.topMargin: 48
-        anchors.bottomMargin: 44
-        spacing: 24
+        anchors.leftMargin: 72 * root.uiScale
+        anchors.rightMargin: 72 * root.uiScale
+        anchors.topMargin: 48 * root.uiScale
+        anchors.bottomMargin: 44 * root.uiScale
+        spacing: 24 * root.uiScale
 
         RowLayout {
             Layout.fillWidth: true
 
             ColumnLayout {
                 Layout.fillWidth: true
-                spacing: 3
+                spacing: 3 * root.uiScale
                 Text {
                     text: "BROWSE YOUR WAY"
                     color: Theme.brightForeground
                     font.family: Theme.fontFamily
-                    font.pixelSize: 30
+                    font.pixelSize: 30 * root.uiScale
                     font.weight: Font.Bold
                 }
                 Text {
                     text: "Choose what appears in the library and how it is ordered."
                     color: Theme.mutedText
                     font.family: Theme.fontFamily
-                    font.pixelSize: 14
+                    font.pixelSize: 14 * root.uiScale
                 }
             }
 
@@ -202,22 +204,22 @@ FocusScope {
         Rectangle {
             Layout.fillWidth: true
             Layout.fillHeight: true
-            radius: Math.max(12, Theme.cornerRadius * 2)
+            radius: Math.max(12 * root.uiScale, Theme.cornerRadius * 2)
             color: root.alpha(Theme.background, 0.82)
             border.color: root.alpha(Theme.foreground, 0.16)
 
             RowLayout {
                 anchors.fill: parent
-                anchors.margins: 22
-                spacing: 22
+                anchors.margins: 22 * root.uiScale
+                spacing: 22 * root.uiScale
 
                 ListView {
                     id: categoryList
                     objectName: "couchBrowseCategories"
-                    Layout.preferredWidth: 340
+                    Layout.preferredWidth: 340 * root.uiScale
                     Layout.fillHeight: true
                     model: root.categories
-                    spacing: 8
+                    spacing: 8 * root.uiScale
                     clip: true
                     currentIndex: root.categoryIndex
 
@@ -248,8 +250,8 @@ FocusScope {
                         required property int index
                         required property var modelData
                         width: categoryList.width
-                        height: 68
-                        radius: Math.max(7, Theme.cornerRadius)
+                        height: 68 * root.uiScale
+                        radius: Math.max(7 * root.uiScale, Theme.cornerRadius)
                         color: categoryList.currentIndex === index
                                ? root.alpha(Theme.accent, 0.16)
                                : root.alpha(Theme.foreground, 0.04)
@@ -261,13 +263,13 @@ FocusScope {
 
                         Text {
                             anchors.left: parent.left
-                            anchors.leftMargin: 22
+                            anchors.leftMargin: 22 * root.uiScale
                             anchors.verticalCenter: parent.verticalCenter
                             text: modelData.label
                             color: categoryList.currentIndex === index
                                    ? Theme.brightForeground : Theme.foreground
                             font.family: Theme.fontFamily
-                            font.pixelSize: 16
+                            font.pixelSize: 16 * root.uiScale
                             font.weight: Font.DemiBold
                         }
 
@@ -283,7 +285,7 @@ FocusScope {
                 }
 
                 Rectangle {
-                    Layout.preferredWidth: 1
+                    Layout.preferredWidth: Math.max(1, root.uiScale)
                     Layout.fillHeight: true
                     color: root.alpha(Theme.foreground, 0.12)
                 }
@@ -294,7 +296,7 @@ FocusScope {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     model: root.optionModel
-                    spacing: 8
+                    spacing: 8 * root.uiScale
                     clip: true
                     boundsBehavior: Flickable.StopAtBounds
 
@@ -320,14 +322,15 @@ FocusScope {
                     }
 
                     delegate: Rectangle {
+                        id: optionDelegate
                         required property int index
                         required property var modelData
                         readonly property bool selected:
                             root.isSelected(root.categories[root.categoryIndex].kind,
                                             modelData.value)
                         width: optionList.width
-                        height: 64
-                        radius: Math.max(7, Theme.cornerRadius)
+                        height: 64 * root.uiScale
+                        radius: Math.max(7 * root.uiScale, Theme.cornerRadius)
                         color: optionList.currentIndex === index
                                ? root.alpha(Theme.accent, 0.15)
                                : selected ? root.alpha(Theme.foreground, 0.075)
@@ -342,8 +345,8 @@ FocusScope {
 
                         RowLayout {
                             anchors.fill: parent
-                            anchors.leftMargin: 22
-                            anchors.rightMargin: 22
+                            anchors.leftMargin: 22 * root.uiScale
+                            anchors.rightMargin: 22 * root.uiScale
 
                             Text {
                                 Layout.fillWidth: true
@@ -351,15 +354,15 @@ FocusScope {
                                 textFormat: Text.PlainText
                                 color: Theme.brightForeground
                                 font.family: Theme.fontFamily
-                                font.pixelSize: 16
+                                font.pixelSize: 16 * root.uiScale
                                 font.weight: Font.DemiBold
                                 elide: Text.ElideRight
                             }
                             Text {
-                                visible: parent.parent.selected
+                                visible: optionDelegate.selected
                                 text: "✓"
                                 color: Theme.accent
-                                font.pixelSize: 22
+                                font.pixelSize: 22 * root.uiScale
                                 font.weight: Font.Bold
                             }
                         }
@@ -384,7 +387,7 @@ FocusScope {
                   + Controller.backGlyph + "  CLOSE"
             color: Theme.mutedText
             font.family: Theme.fontFamily
-            font.pixelSize: 12
+            font.pixelSize: 12 * root.uiScale
             font.weight: Font.DemiBold
         }
     }

--- a/qml/components/CouchKeyboard.qml
+++ b/qml/components/CouchKeyboard.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Layouts
 
 FocusScope {
@@ -13,6 +12,9 @@ FocusScope {
     property string keyboardMode: "upper"
     property string gridObjectName: "couchKeyboardGrid"
     readonly property int columns: 10
+    readonly property real uiScale: Math.max(1, Math.min(2,
+                                                         Math.min(width / 1920,
+                                                                  height / 1080)))
     readonly property var upperKeys: [
         "A", "B", "C", "D", "E", "F", "G", "H", "I", "J",
         "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T",
@@ -120,37 +122,37 @@ FocusScope {
 
     Rectangle {
         anchors.centerIn: parent
-        width: Math.min(parent.width - 96, 1180)
-        height: Math.min(parent.height - 96, 760)
-        radius: Math.max(14, Theme.cornerRadius * 2)
+        width: Math.min(parent.width - 96 * root.uiScale, 1180 * root.uiScale)
+        height: Math.min(parent.height - 96 * root.uiScale, 760 * root.uiScale)
+        radius: Math.max(14 * root.uiScale, Theme.cornerRadius * 2)
         color: root.alpha(Theme.background, 0.98)
         border.width: 1
         border.color: root.alpha(Theme.foreground, 0.18)
 
         ColumnLayout {
             anchors.fill: parent
-            anchors.margins: 42
-            spacing: 22
+            anchors.margins: 42 * root.uiScale
+            spacing: 22 * root.uiScale
 
             RowLayout {
                 Layout.fillWidth: true
 
                 ColumnLayout {
                     Layout.fillWidth: true
-                    spacing: 3
+                    spacing: 3 * root.uiScale
 
                     Text {
                         text: root.title
                         color: Theme.brightForeground
                         font.family: Theme.fontFamily
-                        font.pixelSize: 26
+                        font.pixelSize: 26 * root.uiScale
                         font.weight: Font.Bold
                     }
                     Text {
                         text: "Use the directional pad and confirm button."
                         color: Theme.mutedText
                         font.family: Theme.fontFamily
-                        font.pixelSize: 13
+                        font.pixelSize: 13 * root.uiScale
                     }
                 }
 
@@ -162,16 +164,16 @@ FocusScope {
 
             Rectangle {
                 Layout.fillWidth: true
-                Layout.preferredHeight: 72
-                radius: Math.max(8, Theme.cornerRadius)
+                Layout.preferredHeight: 72 * root.uiScale
+                radius: Math.max(8 * root.uiScale, Theme.cornerRadius)
                 color: root.alpha(Theme.foreground, 0.07)
                 border.width: 2
                 border.color: Theme.accent
 
                 Text {
                     anchors.fill: parent
-                    anchors.leftMargin: 22
-                    anchors.rightMargin: 22
+                    anchors.leftMargin: 22 * root.uiScale
+                    anchors.rightMargin: 22 * root.uiScale
                     verticalAlignment: Text.AlignVCenter
                     text: root.value.length > 0
                           ? root.displayValue()
@@ -179,7 +181,7 @@ FocusScope {
                     textFormat: Text.PlainText
                     color: root.value.length > 0 ? Theme.brightForeground : Theme.mutedText
                     font.family: Theme.fontFamily
-                    font.pixelSize: 23
+                    font.pixelSize: 23 * root.uiScale
                     elide: Text.ElideRight
                 }
             }
@@ -238,11 +240,11 @@ FocusScope {
                     required property int index
                     required property string modelData
 
-                    width: keyGrid.cellWidth - 10
-                    height: keyGrid.cellHeight - 10
-                    x: 5
-                    y: 5
-                    radius: Math.max(7, Theme.cornerRadius)
+                    width: keyGrid.cellWidth - 10 * root.uiScale
+                    height: keyGrid.cellHeight - 10 * root.uiScale
+                    x: 5 * root.uiScale
+                    y: 5 * root.uiScale
+                    radius: Math.max(7 * root.uiScale, Theme.cornerRadius)
                     color: keyMouse.pressed
                            ? root.alpha(Theme.accent, 0.28)
                            : keyGrid.currentIndex === index
@@ -260,7 +262,7 @@ FocusScope {
                               : modelData
                         color: Theme.brightForeground
                         font.family: Theme.fontFamily
-                        font.pixelSize: modelData.length > 1 ? 13 : 22
+                        font.pixelSize: (modelData.length > 1 ? 13 : 22) * root.uiScale
                         font.weight: Font.DemiBold
                     }
 
@@ -279,20 +281,20 @@ FocusScope {
 
             Row {
                 Layout.alignment: Qt.AlignRight
-                spacing: 18
+                spacing: 18 * root.uiScale
 
                 Text {
                     text: Controller.primaryGlyph + "  TYPE"
                     color: Theme.mutedText
                     font.family: Theme.fontFamily
-                    font.pixelSize: 12
+                    font.pixelSize: 12 * root.uiScale
                     font.weight: Font.DemiBold
                 }
                 Text {
                     text: Controller.backGlyph + "  CANCEL"
                     color: Theme.mutedText
                     font.family: Theme.fontFamily
-                    font.pixelSize: 12
+                    font.pixelSize: 12 * root.uiScale
                     font.weight: Font.DemiBold
                 }
             }

--- a/qml/components/CouchLibraryView.qml
+++ b/qml/components/CouchLibraryView.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Window
 
@@ -26,7 +25,7 @@ FocusScope {
         { label: "RYUJINX", value: "Ryujinx", enabled: Preferences.ryujinxEnabled }
     ].filter(function(option) { return option.enabled === undefined || option.enabled })
     readonly property bool gridFocused: gameStrip.activeFocus
-    readonly property real uiScale: Math.max(0.68, Math.min(1.25,
+    readonly property real uiScale: Math.max(0.68, Math.min(2.0,
                                                            Math.min(width / 1920,
                                                                     height / 1080)))
 
@@ -143,8 +142,19 @@ FocusScope {
                                   : -1
             root.refreshCurrentGame()
         }
-        function onRowsInserted() { root.refreshCurrentGame() }
-        function onRowsRemoved() { root.refreshCurrentGame() }
+        function onRowsInserted() {
+            if (root.currentIndex < 0 && root.libraryModel.rowCount() > 0) {
+                root.currentIndex = 0
+            }
+            root.refreshCurrentGame()
+        }
+        function onRowsRemoved() {
+            root.currentIndex = root.libraryModel.rowCount() > 0
+                                ? Math.max(0, Math.min(root.currentIndex,
+                                                      root.libraryModel.rowCount() - 1))
+                                : -1
+            root.refreshCurrentGame()
+        }
         function onDataChanged() { root.refreshCurrentGame() }
     }
 

--- a/qml/components/GameCard.qml
+++ b/qml/components/GameCard.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Window
 
 FocusScope {

--- a/qml/components/GlassButton.qml
+++ b/qml/components/GlassButton.qml
@@ -8,9 +8,10 @@ Button {
     property bool primary: false
     property bool selected: false
     property bool compact: false
-    property real displayScale: root.Window.window && root.Window.window.couchMode
-                                ? Math.max(1, Math.min(1.2,
-                                                      root.Window.window.height / 900))
+    readonly property var hostWindow: root.Window.window
+    property real displayScale: hostWindow && hostWindow.couchMode
+                                ? Math.max(1, Math.min(2.4,
+                                                      hostWindow.height / 900))
                                 : 1
 
     function alpha(color, value) {

--- a/qml/components/LibraryView.qml
+++ b/qml/components/LibraryView.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Controls
 
 Item {
     id: root
@@ -82,7 +81,6 @@ Item {
         cacheBuffer: height * 0.25
         reuseItems: true
         focus: true
-        currentIndex: count > 0 ? Math.min(currentIndex, count - 1) : -1
         property real wheelTargetY: contentY
 
         NumberAnimation {
@@ -227,8 +225,12 @@ Item {
         }
 
         onCountChanged: {
-            if (count > 0 && currentIndex < 0) {
+            if (count === 0) {
+                currentIndex = -1
+            } else if (currentIndex < 0) {
                 currentIndex = 0
+            } else if (currentIndex >= count) {
+                currentIndex = count - 1
             }
         }
     }

--- a/qml/screens/GameDetails.qml
+++ b/qml/screens/GameDetails.qml
@@ -17,7 +17,7 @@ Item {
     property bool collectionEditorOpen: false
     property bool couchMode: false
     readonly property real uiScale: couchMode
-                                    ? Math.max(1, Math.min(1.25,
+                                    ? Math.max(1, Math.min(2.4,
                                                           Math.min(width / 1920,
                                                                    height / 1080) * 1.18))
                                     : 1
@@ -54,7 +54,7 @@ Item {
     }
 
     function revealFocusedItem(item) {
-        const flickable = detailsScroll.contentItem
+        const flickable = detailsScroll.navigationFlickable
         if (!item || !flickable) {
             return
         }
@@ -268,6 +268,7 @@ Item {
         ScrollView {
             id: detailsScroll
             objectName: "detailsScroll"
+            readonly property var navigationFlickable: contentItem
             readonly property real navigationContentY: contentItem ? contentItem.contentY : 0
             anchors.top: parent.top
             anchors.bottom: parent.bottom
@@ -290,7 +291,7 @@ Item {
                     color: Theme.brightForeground
                     font.family: Theme.fontFamily
                     font.pixelSize: root.couchMode
-                                    ? Math.max(42, Math.min(68, width * 0.075))
+                                    ? Math.max(42, Math.min(68, width * 0.075)) * root.uiScale
                                     : Math.max(28, Math.min(54, width * 0.07))
                     font.weight: Font.Bold
                     wrapMode: Text.Wrap

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -37,6 +37,7 @@
 #include <QQuickStyle>
 #include <QQuickWindow>
 #include <QScreen>
+#include <QSize>
 #include <QSqlDatabase>
 #include <QSqlError>
 #include <QSqlQuery>
@@ -61,6 +62,26 @@ QString optionValue(const QStringList& arguments, const QString& name) {
     }
   }
   return {};
+}
+
+bool optionSupplied(const QStringList& arguments, const QString& name) {
+  return std::ranges::any_of(arguments, [&name](const QString& argument) {
+    return argument == name || argument.startsWith(name + QLatin1Char('='));
+  });
+}
+
+bool parseRenderSize(const QString& value, QSize* result) {
+  const QStringList dimensions = value.split(QLatin1Char('x'));
+  bool widthValid = false;
+  bool heightValid = false;
+  const int width = dimensions.value(0).toInt(&widthValid);
+  const int height = dimensions.value(1).toInt(&heightValid);
+  if (dimensions.size() != 2 || !widthValid || !heightValid || width <= 0 || height <= 0 ||
+      width > 16384 || height > 16384) {
+    return false;
+  }
+  *result = QSize(width, height);
+  return true;
 }
 
 void runEmptyFilterFocusTest(QQuickWindow* window, QGuiApplication* application) {
@@ -133,6 +154,22 @@ int main(int argc, char* argv[]) {
   // there is one, and `--quit` closes the running window. Sunshine app entries use both.
   const QString playKey = optionValue(application.arguments(), QStringLiteral("--play"));
   const bool quitRequest = application.arguments().contains(QStringLiteral("--quit"));
+  if (optionSupplied(application.arguments(), QStringLiteral("--render-screenshot")) &&
+      screenshotPath.isEmpty()) {
+    qCritical() << "--render-screenshot requires a path";
+    return EXIT_FAILURE;
+  }
+  if (!quitRequest && optionSupplied(application.arguments(), QStringLiteral("--play")) &&
+      playKey.isEmpty()) {
+    qCritical() << "--play requires a launch key";
+    return EXIT_FAILURE;
+  }
+  QSize requestedRenderSize;
+  if (optionSupplied(application.arguments(), QStringLiteral("--render-size")) &&
+      !parseRenderSize(renderSize, &requestedRenderSize)) {
+    qCritical() << "--render-size requires WIDTHxHEIGHT between 1 and 16384";
+    return EXIT_FAILURE;
+  }
   const bool renderMode = !screenshotPath.isEmpty();
   const bool smokeTest = application.arguments().contains(QStringLiteral("--smoke-test"));
   const bool couchNavigationTest =
@@ -148,11 +185,7 @@ int main(int argc, char* argv[]) {
                         application.arguments().contains(QStringLiteral("--demo"));
   const bool benchmarkMode = application.arguments().contains(QStringLiteral("--benchmark"));
   const QString benchmarkMaxOption = QStringLiteral("--benchmark-max-ms");
-  const bool benchmarkLimitSupplied =
-      std::ranges::any_of(application.arguments(), [&benchmarkMaxOption](const QString& argument) {
-        return argument == benchmarkMaxOption ||
-               argument.startsWith(benchmarkMaxOption + QLatin1Char('='));
-      });
+  const bool benchmarkLimitSupplied = optionSupplied(application.arguments(), benchmarkMaxOption);
   bool benchmarkLimitValid = false;
   const int benchmarkMaxMs =
       optionValue(application.arguments(), benchmarkMaxOption).toInt(&benchmarkLimitValid);
@@ -513,9 +546,8 @@ int main(int argc, char* argv[]) {
     rootWindow->showFullScreen();
   }
   if (auto* quickWindow = qobject_cast<QQuickWindow*>(rootWindow)) {
-    const QStringList dimensions = renderSize.split(QLatin1Char('x'));
-    if ((renderMode || navigationTest) && dimensions.size() == 2) {
-      quickWindow->resize(dimensions.at(0).toInt(), dimensions.at(1).toInt());
+    if ((renderMode || navigationTest) && requestedRenderSize.isValid()) {
+      quickWindow->resize(requestedRenderSize);
     }
     if (renderMode) {
       // `--render-overlay=settings|picker` opens an overlay so visual checks can cover it.
@@ -720,9 +752,20 @@ int main(int argc, char* argv[]) {
             fail(QStringLiteral("Controller confirm did not type with the on-screen keyboard"));
             return;
           }
-          sendKey(Qt::Key_Escape);
-          if (couch->property("searchOpen").toBool() || !search->hasActiveFocus()) {
-            fail(QStringLiteral("Controller Back did not cancel couch Search"));
+          sendKey(Qt::Key_F11);
+          QObject* preferences =
+              qmlContext(quickWindow)->contextProperty(QStringLiteral("Preferences")).value<QObject*>();
+          if (quickWindow->property("couchMode").toBool() ||
+              couch->property("searchOpen").toBool() || keyboard->isVisible() ||
+              preferences == nullptr || preferences->property("couchModeEnabled").toBool()) {
+            fail(QStringLiteral("Leaving Couch Mode did not cancel Search cleanly"));
+            return;
+          }
+          const bool activated = QMetaObject::invokeMethod(quickWindow, "activateCouchMode");
+          QCoreApplication::processEvents();
+          if (!activated || !quickWindow->property("couchMode").toBool() ||
+              preferences->property("couchModeEnabled").toBool()) {
+            fail(QStringLiteral("Session Couch activation changed the startup preference"));
             return;
           }
           const bool openedTextEntry = QMetaObject::invokeMethod(
@@ -775,8 +818,8 @@ int main(int argc, char* argv[]) {
           }
           sendKey(Qt::Key_Return);
           QTimer::singleShot(80, quickWindow,
-                             [quickWindow, &application, &controller, couch, strip,
-                              settingsScroll, fail] {
+                             [quickWindow, &application, &controller, couch, settingsScroll,
+                              fail] {
             if (!quickWindow->property("diagnosticsOpen").toBool()) {
               fail(QStringLiteral("Couch Settings did not open"));
               return;
@@ -793,7 +836,7 @@ int main(int argc, char* argv[]) {
             controller.keyRequested(Qt::Key_Escape, Qt::NoModifier);
             QTimer::singleShot(
                 50, quickWindow,
-                [quickWindow, &application, &controller, couch, strip, fail] {
+                [quickWindow, &application, &controller, couch, fail] {
               if (quickWindow->property("diagnosticsOpen").toBool()) {
                 fail(QStringLiteral("Controller Back did not close couch Settings"));
                 return;
@@ -804,7 +847,7 @@ int main(int argc, char* argv[]) {
               QCoreApplication::processEvents();
               controller.keyRequested(Qt::Key_Return, Qt::NoModifier);
               QTimer::singleShot(80, quickWindow,
-                                 [quickWindow, &application, &controller, strip, fail] {
+                                 [quickWindow, &application, &controller, fail] {
                 auto* play =
                     quickWindow->findChild<QQuickItem*>(QStringLiteral("playButton"));
                 auto* favorite =
@@ -1561,8 +1604,7 @@ int main(int argc, char* argv[]) {
                        return;
                      }
                      if (fullscreen) {
-                       if (!QMetaObject::invokeMethod(rootWindow, "setCouchMode",
-                                                      Q_ARG(QVariant, true))) {
+                       if (!QMetaObject::invokeMethod(rootWindow, "activateCouchMode")) {
                          rootWindow->setProperty("couchMode", true);
                          rootWindow->showFullScreen();
                        }

--- a/src/input/ControllerInput.cpp
+++ b/src/input/ControllerInput.cpp
@@ -16,10 +16,11 @@ ControllerInput::ControllerInput(QObject* parent) : QObject(parent) {
       m_repeatTimer.setInterval(90);
     }
   });
-  connect(&m_initWatcher, &QFutureWatcher<bool>::finished, this, [this] {
-    m_sdlReady = m_initWatcher.result();
+  connect(&m_initWatcher, &QFutureWatcher<InitResult>::finished, this, [this] {
+    const InitResult result = m_initWatcher.result();
+    m_sdlReady = result.ready;
     if (!m_sdlReady) {
-      qWarning() << "Controller input unavailable:" << SDL_GetError();
+      qWarning().noquote() << "Controller input unavailable:" << result.error;
       return;
     }
     openAvailableControllers();
@@ -35,14 +36,17 @@ void ControllerInput::start() {
     // SDL would otherwise catch SIGTERM and SIGINT and turn them into SDL quit events that
     // nothing here reads, so pkill, logout, and service stops could never close Omakade.
     SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
-    return SDL_Init(SDL_INIT_GAMEPAD);
+    if (SDL_Init(SDL_INIT_GAMEPAD)) {
+      return InitResult{.ready = true, .error = {}};
+    }
+    return InitResult{.ready = false, .error = QString::fromUtf8(SDL_GetError())};
   }));
 }
 
 ControllerInput::~ControllerInput() {
   if (m_initWatcher.isRunning()) {
     m_initWatcher.waitForFinished();
-    m_sdlReady = m_initWatcher.result();
+    m_sdlReady = m_initWatcher.result().ready;
   }
   for (SDL_Gamepad* controller : std::as_const(m_controllers)) {
     SDL_CloseGamepad(controller);
@@ -63,7 +67,7 @@ QString ControllerInput::name() const {
                                    : QString::fromUtf8(controllerName);
 }
 
-int ControllerInput::controllerCount() const { return m_controllers.size(); }
+int ControllerInput::controllerCount() const { return static_cast<int>(m_controllers.size()); }
 
 QString ControllerInput::primaryGlyph() const {
   return buttonLabel(SDL_GAMEPAD_BUTTON_SOUTH, QStringLiteral("SOUTH"));
@@ -135,15 +139,19 @@ void ControllerInput::pollEvents() {
 void ControllerInput::openAvailableControllers() {
   int count = 0;
   SDL_JoystickID* ids = SDL_GetGamepads(&count);
+  bool changed = false;
   for (int index = 0; index < count; ++index) {
     if (!m_controllers.contains(ids[index])) {
       if (SDL_Gamepad* controller = SDL_OpenGamepad(ids[index])) {
         m_controllers.insert(ids[index], controller);
+        changed = true;
       }
     }
   }
   SDL_free(ids);
-  emit controllerChanged();
+  if (changed) {
+    emit controllerChanged();
+  }
 }
 
 void ControllerInput::closeController(SDL_JoystickID id) {

--- a/src/input/ControllerInput.h
+++ b/src/input/ControllerInput.h
@@ -44,6 +44,11 @@ signals:
   void keyRequested(int key, int modifiers);
 
 private:
+  struct InitResult {
+    bool ready = false;
+    QString error;
+  };
+
   void pollEvents();
   void openAvailableControllers();
   void closeController(SDL_JoystickID id);
@@ -53,7 +58,7 @@ private:
   [[nodiscard]] QString buttonLabel(SDL_GamepadButton button, const QString& fallback) const;
 
   QHash<SDL_JoystickID, SDL_Gamepad*> m_controllers;
-  QFutureWatcher<bool> m_initWatcher;
+  QFutureWatcher<InitResult> m_initWatcher;
   QTimer m_pollTimer;
   QTimer m_repeatTimer;
   int m_axisX = 0;

--- a/src/streaming/SunshineIntegration.cpp
+++ b/src/streaming/SunshineIntegration.cpp
@@ -133,8 +133,8 @@ int SunshineIntegration::outputScreenIndex(const QString& configuredOutput,
   if (numeric && index >= 0 && index < screenNames.size()) {
     return index;
   }
-  const int named = screenNames.indexOf(configuredOutput);
-  return named >= 0 ? named : 0;
+  const qsizetype named = screenNames.indexOf(configuredOutput);
+  return named >= 0 ? static_cast<int>(named) : 0;
 }
 
 void SunshineIntegration::detect() {
@@ -163,7 +163,7 @@ QString SunshineIntegration::serviceUnit() {
   // The Arch package installs app-dev.lizardbyte.app.Sunshine.service with a
   // sunshine.service alias that only exists once the unit is enabled, so prefer the real
   // unit name whenever its file is present.
-  const QString packaged = QStringLiteral("app-dev.lizardbyte.app.Sunshine.service");
+  QString packaged = QStringLiteral("app-dev.lizardbyte.app.Sunshine.service");
   for (const QString& directory :
        {QStringLiteral("/usr/lib/systemd/user/"), QStringLiteral("/etc/systemd/user/"),
         QDir::homePath() + QStringLiteral("/.config/systemd/user/"),
@@ -230,12 +230,12 @@ QJsonObject SunshineIntegration::mergeEntries(const QJsonObject& existing,
                                               const QJsonArray& ours) {
   QJsonObject result = existing;
   QJsonArray apps;
-  for (const QJsonValue& value : existing.value(QStringLiteral("apps")).toArray()) {
+  for (const auto& value : existing.value(QStringLiteral("apps")).toArray()) {
     if (!value.isObject() || !isOmakadeEntry(value.toObject())) {
       apps.append(value);
     }
   }
-  for (const QJsonValue& value : ours) {
+  for (const auto& value : ours) {
     apps.append(value);
   }
   result.insert(QStringLiteral("apps"), apps);
@@ -254,7 +254,7 @@ QString SunshineIntegration::exportImage(const QString& imageRoot, const QString
   // The source path is part of the name so a swapped cover gets fresh box art even when
   // the new file is older than the previous export.
   const QString hash = QString::fromLatin1(sha1((name + QChar::Null + source).toUtf8()).left(16));
-  const QString target = imageRoot + QLatin1Char('/') + hash + QStringLiteral(".png");
+  QString target = imageRoot + QLatin1Char('/') + hash + QStringLiteral(".png");
   const QFileInfo targetInfo(target);
   if (targetInfo.exists() &&
       targetInfo.lastModified() >= QFileInfo(source).lastModified()) {
@@ -360,8 +360,8 @@ SunshineIntegration::SyncResult SunshineIntegration::runSync(
     usedImages.insert(image);
     ours.append(gameEntry(title, game.launchKey, prefix, image));
   }
-  result.games = games.size();
-  result.entries = ours.size();
+  result.games = static_cast<int>(games.size());
+  result.entries = static_cast<int>(ours.size());
 
   const QJsonObject merged = mergeEntries(document.object(), ours);
   const bool unchanged = merged == document.object();

--- a/src/theme/OmarchyTheme.cpp
+++ b/src/theme/OmarchyTheme.cpp
@@ -13,8 +13,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <functional>
-
 namespace {
 QString defaultStateHome() {
   const QString xdgStateHome = qEnvironmentVariable("XDG_STATE_HOME");
@@ -123,12 +121,12 @@ void OmarchyTheme::reload() {
 }
 
 QString OmarchyTheme::currentRoot() const {
-  const QString stateRoot = m_stateHome + QStringLiteral("/omarchy/current");
+  QString stateRoot = m_stateHome + QStringLiteral("/omarchy/current");
   if (QFileInfo::exists(stateRoot + QStringLiteral("/theme/colors.toml"))) {
     return stateRoot;
   }
 
-  const QString configRoot = m_configHome + QStringLiteral("/omarchy/current");
+  QString configRoot = m_configHome + QStringLiteral("/omarchy/current");
   if (QFileInfo::exists(configRoot + QStringLiteral("/theme/colors.toml"))) {
     return configRoot;
   }
@@ -353,8 +351,7 @@ void OmarchyTheme::refreshHyprlandMetrics() {
   if (executable.isEmpty() || qEnvironmentVariable("HYPRLAND_INSTANCE_SIGNATURE").isEmpty()) {
     return;
   }
-  const auto query = [this, executable](const QString& option,
-                                        std::function<bool(const QJsonObject&)> apply) {
+  const auto query = [this, executable](const QString& option, const auto& apply) {
     auto* process = new QProcess(this);
     connect(process, &QProcess::finished, this,
             [this, process, apply](int exitCode, QProcess::ExitStatus status) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,21 @@ foreach(benchmark_case IN ITEMS text empty missing nonpositive)
   )
 endforeach()
 
+add_test(NAME omakade_cli_rejects_missing_play_value COMMAND omakade --play)
+add_test(NAME omakade_cli_rejects_missing_screenshot_path COMMAND omakade --render-screenshot)
+add_test(NAME omakade_cli_rejects_invalid_render_size
+  COMMAND omakade --smoke-test --render-size=wide
+)
+set_tests_properties(
+  omakade_cli_rejects_missing_play_value
+  omakade_cli_rejects_missing_screenshot_path
+  omakade_cli_rejects_invalid_render_size
+  PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1"
+    WILL_FAIL TRUE
+    TIMEOUT 5
+)
+
 add_test(NAME omakade_couch_thousand_game_navigation
   COMMAND omakade --couch --stress-test --couch-navigation-test --render-size=1920x1080
 )
@@ -154,6 +169,30 @@ foreach(couch_case IN ITEMS 720p 1440p ultrawide 4k)
     TIMEOUT 30
   )
 endforeach()
+
+foreach(couch_overlay IN ITEMS couch-search couch-browse couch-settings-bottom)
+  string(REPLACE "-" "_" couch_overlay_test ${couch_overlay})
+  add_test(NAME omakade_${couch_overlay_test}_4k_render
+    COMMAND omakade --couch --owned-layout-test
+            --render-overlay=${couch_overlay}
+            --render-screenshot=${CMAKE_CURRENT_BINARY_DIR}/omakade-${couch_overlay}-4k.png
+            --render-size=3840x2160
+  )
+  set_tests_properties(omakade_${couch_overlay_test}_4k_render PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1"
+    TIMEOUT 30
+  )
+endforeach()
+
+add_test(NAME omakade_couch_detail_4k_render
+  COMMAND omakade --couch --uninstalled-layout-test
+          --render-screenshot=${CMAKE_CURRENT_BINARY_DIR}/omakade-couch-detail-4k.png
+          --render-size=3840x2160
+)
+set_tests_properties(omakade_couch_detail_4k_render PROPERTIES
+  ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1"
+  TIMEOUT 30
+)
 
 add_test(NAME omakade_couch_render_200_percent
   COMMAND omakade --couch


### PR DESCRIPTION
## What changed
- fix mode transitions and Sunshine preference handling
- scale the full couch UI for native 4K
- harden controller setup, selection state, and CLI validation
- expand navigation and 4K render coverage

## Tested
- 38/38 release tests
- 38/38 ASan and UBSan tests
- clang-tidy, qmllint, and actionlint
- SBOM, metadata, and staged install checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Couch mode now scales more effectively across window sizes and 4K displays.
  - Fullscreen activation can temporarily enter couch mode without changing the saved preference.
  - Couch-mode settings, browsing, keyboard, and game details layouts have improved sizing and spacing.

- **Bug Fixes**
  - Improved focus restoration when leaving couch mode.
  - Library selection remains valid when games are added or removed.
  - Controller errors are reported more clearly, and unnecessary controller updates are avoided.
  - Invalid command-line options now produce clear startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->