### PR TITLE
Prepare Omakade 1.6.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -26,10 +26,14 @@ body:
       label: Game source
       options:
         - Steam
+        - GOG
         - Lutris
         - Heroic
         - Faugus
         - RetroArch
+        - PCSX2
+        - Ryujinx
+        - Battle.net
         - Omakade UI or packaging
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   the same game when switching layouts.
 - Use a controller throughout Settings and game organization, including text
   entry, case, and symbols.
+- Let games keep controller focus after launching; ignore controller input while
+  Omakade is in the background.
 - Hide the cursor during keyboard and controller navigation and restore it
   when the mouse moves.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@
 
 - Added the first dedicated ten-foot library with a large featured game,
   horizontal cover browsing, controller hints, and controller-tested focus.
+- Added detail and grid library views with stronger selection treatment,
+  smoother held navigation, and repeat behavior for both analog sticks and the
+  directional pad.
 - Added persistent Couch Mode startup, `omakade --couch`, F11 and controller
   Start switching, and automatic Couch Mode for Sunshine sessions.
+- Hid the mouse cursor during controller and keyboard use, restored it on real
+  mouse movement, and kept it visible in Desktop Mode.
 - Added controller-driven library search with an on-screen keyboard.
 - Expanded the on-screen keyboard to support controller text entry, case and
   symbols across game organization, linking, and account settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   directly; Windows games use UMU with a separate prefix for each game.
 - Keep Heroic-managed GOG games launching through Heroic with their existing
   settings.
+- Remove uninstalled direct GOG games on rescan and preserve cached entries when
+  a Heroic GOG inventory cannot be read.
 - Fix Proton detection and launching for Omarchy Battle.net prefixes. Thanks
   @TheAirick for the report.
 - Add aarch64 packages alongside x86_64, with checksums and provenance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### GOG
+
+- Added GOG as a first-class source with direct discovery of standard
+  `goggame-*.info` installations and separate source controls and filters.
+- Added direct native Linux launching and Windows launching using UMU, while
+  continuing to delegate Heroic-managed GOG games to Heroic so their launch
+  settings remain intact.
+
 ### Couch Mode
 
 - Added the first dedicated ten-foot library with a large featured game,
@@ -17,6 +25,13 @@
   visual checks for reduced motion, light themes, and opaque surfaces.
 - Made the complete Settings and Sources view wide, readable, and controller
   guided in Couch Mode.
+
+### Interface and reliability
+
+- Cleaned up in-flight Hyprland metric probes during shutdown.
+- Fixed Omarchy Battle.net prefixes being misclassified as Wine instead of
+  Proton, and matched their UMU launch environment. Thanks @TheAirick for the
+  detailed report.
 
 ### Release engineering
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,29 @@
 # Changelog
 
-## Unreleased
-
-### GOG
-
-- Added GOG as a first-class source with direct discovery of standard
-  `goggame-*.info` installations and separate source controls and filters.
-- Added direct native Linux launching and Windows launching using UMU, while
-  continuing to delegate Heroic-managed GOG games to Heroic so their launch
-  settings remain intact.
+## 1.6.0
 
 ### Couch Mode
 
-- Added the first dedicated ten-foot library with a large featured game,
-  horizontal cover browsing, controller hints, and controller-tested focus.
-- Added detail and grid library views with stronger selection treatment,
-  smoother held navigation, and repeat behavior for both analog sticks and the
-  directional pad.
-- Added persistent Couch Mode startup, `omakade --couch`, F11 and controller
-  Start switching, and automatic Couch Mode for Sunshine sessions.
-- Hid the mouse cursor during controller and keyboard use, restored it on real
-  mouse movement, and kept it visible in Desktop Mode.
-- Added controller-driven library search with an on-screen keyboard.
-- Expanded the on-screen keyboard to support controller text entry, case and
-  symbols across game organization, linking, and account settings.
-- Added a couch-native browser for views, sorting, availability, sources,
-  completion status, collections, and tags.
-- Added 1,000-game couch startup and navigation gates, reconnect coverage, and
-  visual checks for reduced motion, light themes, and opaque surfaces.
-- Made the complete Settings and Sources view wide, readable, and controller
-  guided in Couch Mode.
+- Browse your library in detail or grid view with controller navigation,
+  search, filters, and an on-screen keyboard.
+- Open Couch Mode with F11, controller Start, or `omakade --couch`. Sunshine
+  sessions open it automatically, and you can make it your startup view.
+- Hold the stick or directional pad to move through games. Selection stays on
+  the same game when switching layouts.
+- Use a controller throughout Settings and game organization, including text
+  entry, case, and symbols.
+- Hide the cursor during keyboard and controller navigation and restore it
+  when the mouse moves.
 
-### Interface and reliability
+### GOG and compatibility
 
-- Cleaned up in-flight Hyprland metric probes during shutdown.
-- Fixed Omarchy Battle.net prefixes being misclassified as Wine instead of
-  Proton, and matched their UMU launch environment. Thanks @TheAirick for the
-  detailed report.
-
-### Release engineering
-
-- Added native aarch64 CI and release packages alongside x86_64.
-- Added per-architecture SBOMs, vulnerability scanning, checksums, and
-  provenance attestations.
+- Discover and launch direct GOG installations. Native Linux games launch
+  directly; Windows games use UMU with a separate prefix for each game.
+- Keep Heroic-managed GOG games launching through Heroic with their existing
+  settings.
+- Fix Proton detection and launching for Omarchy Battle.net prefixes. Thanks
+  @TheAirick for the report.
+- Add aarch64 packages alongside x86_64, with checksums and provenance.
 
 ## 1.5.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ add_library(omakade_core STATIC
   src/app/SingleInstance.h
   src/input/ControllerInput.cpp
   src/input/ControllerInput.h
+  src/input/CouchCursorManager.cpp
+  src/input/CouchCursorManager.h
   src/library/LibraryFilterModel.cpp
   src/library/LibraryFilterModel.h
   src/library/GameRoles.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-project(Omakade VERSION 1.5.0 LANGUAGES CXX)
+project(Omakade VERSION 1.6.0 LANGUAGES CXX)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(SDL3 REQUIRED IMPORTED_TARGET sdl3)

--- a/PLAN.md
+++ b/PLAN.md
@@ -777,9 +777,8 @@ Gate:
 
 ### M6: Controller-first couch mode
 
-Status: implemented in the local 1.6 candidate and under review. This is a
-dedicated ten-foot experience, not the desktop layout enlarged to fill a
-television.
+Status: implemented in the local 1.6.0 candidate, with review fixes covered by
+regression checks. The dedicated ten-foot interface supports television use.
 
 Deliver:
 
@@ -815,8 +814,9 @@ Candidate status:
 - Detail and grid views, clear selection, held analog and directional-pad
   navigation, cursor handoff, reconnect behavior, and large-library paths have
   automated coverage.
-- The maintainer completed a local controller and visual smoke test. Independent
-  review and the publication checks in `RELEASING.md` remain open.
+- Review findings are fixed and covered by regression checks. The maintainer
+  tested the earlier candidate; final-candidate testing and the publication
+  checks in `RELEASING.md` remain open.
 
 ### M7: Sunshine and Moonlight streaming
 
@@ -851,8 +851,8 @@ Couch mode (M6) is the headline 1.6 feature, building on this streaming work.
 1.6 is the couch-mode release. Work is ordered so secondary platform tasks do
 not compromise the quality or completeness of M6:
 
-1. Complete independent review of M6 and close any visual, accessibility,
-   performance, or controller-only findings.
+1. Verify the final M6 candidate locally and close any remaining visual,
+   accessibility, performance, or controller-only findings.
 2. Finish the real-library compatibility matrix in issue 9, prioritizing native
    and Flatpak launcher variants that are only contract-tested today.
 3. Add a supported aarch64 package path for issue 13, using contributor hardware

--- a/PLAN.md
+++ b/PLAN.md
@@ -777,9 +777,9 @@ Gate:
 
 ### M6: Controller-first couch mode
 
-Status: the headline feature for 1.6. This is a dedicated ten-foot experience,
-not the desktop layout enlarged to fill a television. Input fixes to the
-existing desktop interface remain patch work and do not replace this milestone.
+Status: implemented in the local 1.6 candidate and under review. This is a
+dedicated ten-foot experience, not the desktop layout enlarged to fill a
+television.
 
 Deliver:
 
@@ -808,6 +808,15 @@ Gate:
 - A 1,000-game cached library remains responsive and starts within the existing
   performance targets
 - Leaving couch mode restores the prior desktop layout and focus position
+
+Candidate status:
+
+- Debug and Release test matrices pass 41 of 41 tests.
+- Detail and grid views, clear selection, held analog and directional-pad
+  navigation, cursor handoff, reconnect behavior, and large-library paths have
+  automated coverage.
+- The maintainer completed a local controller and visual smoke test. Independent
+  review and the publication checks in `RELEASING.md` remain open.
 
 ### M7: Sunshine and Moonlight streaming
 
@@ -842,8 +851,8 @@ Couch mode (M6) is the headline 1.6 feature, building on this streaming work.
 1.6 is the couch-mode release. Work is ordered so secondary platform tasks do
 not compromise the quality or completeness of M6:
 
-1. Deliver the complete M6 experience and its visual, accessibility,
-   performance, and controller-only acceptance gates.
+1. Complete independent review of M6 and close any visual, accessibility,
+   performance, or controller-only findings.
 2. Finish the real-library compatibility matrix in issue 9, prioritizing native
    and Flatpak launcher variants that are only contract-tested today.
 3. Add a supported aarch64 package path for issue 13, using contributor hardware

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # Omakade product and delivery plan
 
-Implementation status: M0 through M5 and M7 are complete. Steam, Lutris,
+Implementation status: M0 through M5 and M7 are complete. Steam, GOG, Lutris,
 Heroic, Faugus, RetroArch, PCSX2, Ryujinx, and Battle.net import, launch
 delegation, source filters, organization, settings, release checks, explicit
 linking, RetroAchievements, and Sunshine/Moonlight integration are implemented.
@@ -9,8 +9,8 @@ M6 is the headline milestone for 1.6.
 ## Product statement
 
 Omakade is a beautiful, local-first game library built for Omarchy. It brings
-installed games from Steam, Lutris, Heroic, Faugus, RetroArch, PCSX2, Ryujinx,
-and Battle.net into one coherent place.
+installed games from Steam, GOG, Lutris, Heroic, Faugus, RetroArch, PCSX2,
+Ryujinx, and Battle.net into one coherent place.
 It owns discovery, presentation, search, achievements, organization, and the
 launch action. Existing platforms continue to own authentication, installation,
 updates, compatibility tools, cloud saves, DRM, and overlays.
@@ -404,6 +404,19 @@ must not replace local installed-game discovery.
 - Contract-test every supported Heroic release because local formats and launch
   links can change.
 - Keep installation, accounts, Wine settings, and cloud saves in Heroic.
+
+### GOG
+
+- Discover installed games using bounded `goggame-*.info` manifests,
+  including existing Heroic-managed GOG installations.
+- Treat manifest paths as untrusted input and confine executable and working
+  directory resolution to the installation directory.
+- Launch native Linux builds directly and Windows builds using UMU with an
+  isolated per-game prefix.
+- Keep Heroic-managed GOG installs delegated to Heroic so their runner,
+  environment, wrapper, and script settings remain intact.
+- Keep account authentication, purchasing, installation, updates, and cloud
+  saves outside Omakade.
 
 ### Desktop applications and manual games
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,9 @@ into one quiet, cover-focused home that follows the active Omarchy theme.
 > Omakade is an independent community project. It is not an official Omarchy
 > application.
 
-## Current main branch
+## Features
 
-The latest tagged release is 1.5.0. This section follows `main` and may include
-changes made after the latest release.
-
-Omakade includes:
+Omakade 1.6.0 includes:
 
 - Native and Flatpak Steam, Lutris, Heroic, Faugus, RetroArch, PCSX2, and
   Ryujinx discovery, plus direct GOG installation discovery,
@@ -79,22 +76,22 @@ verify the package, and install it. If Omakade is already installed, `pacman -U`
 upgrades it in place without removing your settings or library data:
 
 ```bash
-curl -fLO https://github.com/btsouth/omakade/releases/download/v1.5.0/omakade-1.5.0-1-x86_64.pkg.tar.zst
-curl -fLO https://github.com/btsouth/omakade/releases/download/v1.5.0/SHA256SUMS
+curl -fLO https://github.com/btsouth/omakade/releases/download/v1.6.0/omakade-1.6.0-1-x86_64.pkg.tar.zst
+curl -fLO https://github.com/btsouth/omakade/releases/download/v1.6.0/SHA256SUMS
 sha256sum -c SHA256SUMS --ignore-missing
-sudo pacman -U ./omakade-1.5.0-1-x86_64.pkg.tar.zst
+sudo pacman -U ./omakade-1.6.0-1-x86_64.pkg.tar.zst
 ```
 
 ### Install or upgrade from a browser download
 
 1. Open the [latest release](https://github.com/btsouth/omakade/releases/latest).
-2. Under **Assets**, download `omakade-1.5.0-1-x86_64.pkg.tar.zst` and
+2. Under **Assets**, download `omakade-1.6.0-1-x86_64.pkg.tar.zst` and
    `SHA256SUMS` into the same folder.
 3. Open a terminal in that folder and run:
 
 ```bash
 sha256sum -c SHA256SUMS --ignore-missing
-sudo pacman -U ./omakade-1.5.0-1-x86_64.pkg.tar.zst
+sudo pacman -U ./omakade-1.6.0-1-x86_64.pkg.tar.zst
 ```
 
 Launch Omakade from the application launcher or run `omakade` in a terminal.

--- a/README.md
+++ b/README.md
@@ -163,8 +163,10 @@ ctest --preset dev
 
 Use `Ctrl+F` to search, arrow keys to navigate, Enter to open details, Escape
 to return, and F11 to enter or leave Couch Mode. The controller Start button
-does the same. Couch Mode remembers the preferred launch mode. `Ctrl+M` toggles
-reduced motion and `Ctrl+D` opens settings and source diagnostics.
+does the same. Couch Mode offers detail and grid library views and remembers
+the preferred launch mode. Its cursor hides during controller or keyboard use,
+returns on mouse movement, and remains visible in Desktop Mode. `Ctrl+M`
+toggles reduced motion and `Ctrl+D` opens settings and source diagnostics.
 
 ## Local data
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ changes made after the latest release.
 Omakade includes:
 
 - Native and Flatpak Steam, Lutris, Heroic, Faugus, RetroArch, PCSX2, and
-  Ryujinx discovery,
+  Ryujinx discovery, plus direct GOG installation discovery,
   including Steam non-Steam shortcuts and games sideloaded into Heroic, plus
   Battle.net games from Wine, Proton, and Bottles prefixes
 - One-click details and delegated launching through the owning platform
@@ -53,6 +53,12 @@ Omakade includes:
 Omakade reads launcher data without modifying it. Core discovery, browsing,
 artwork, and launching work offline. Run `omakade --demo` to explore the UI
 with a deterministic fictional library.
+
+Direct GOG discovery checks `~/GOG Games`, `~/Games/GOG`, `~/Games/Heroic`,
+and immediate game folders under `~/Games`. Set `OMAKADE_GOG_LIBRARY_PATHS`
+to a colon-separated list of additional library roots. Native Linux builds
+launch directly; Windows builds use `umu-run` with an isolated per-game prefix.
+GOG games installed through Heroic continue to launch through Heroic.
 
 ## Install on Omarchy or Arch
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ After that, Omakade updates with normal Omarchy system updates.
 
 ### Install or upgrade from the terminal
 
+These commands are for x86_64. For ARM64, replace `x86_64` with `aarch64`
+in the package filename and download URL.
+
 These commands download Omakade and its checksum into the current directory,
 verify the package, and install it. If Omakade is already installed, `pacman -U`
 upgrades it in place without removing your settings or library data:

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,6 +8,7 @@ Please include these details with a bug report:
   PCSX2, Ryujinx, or Battle.net (and whether Battle.net runs under Wine,
   Proton, or Bottles)
 - The source shown for the affected game
+- `umu-launcher` version for a direct Windows GOG game
 - Steps that reproduce the problem
 
 Open diagnostics with `Ctrl+D` to see library and cache status. Do not post a

--- a/docs/1.6-REVIEW.md
+++ b/docs/1.6-REVIEW.md
@@ -1,6 +1,6 @@
 # Omakade 1.6 review handoff
 
-Review the current `codex/1.6-couch-polish` branch before publication.
+The local `codex/1.6-couch-polish` branch contains the 1.6.0 release candidate.
 
 ## Included
 
@@ -17,9 +17,18 @@ Review the current `codex/1.6-couch-polish` branch before publication.
 - Debug: 41 of 41 tests pass
 - Release: 41 of 41 tests pass
 - QML lint exits successfully with existing non-blocking warnings
+- Desktop and AppStream metadata validation passes
+- SBOM generator: 2 of 2 tests pass
+- Staged installation and offscreen smoke test pass
+- Local workflow checks pass for YAML, shell syntax, architecture matrices,
+  version consistency, and tag-only publication and attestation guards
 - Automated visual fixtures cover common sizes, themes, reduced motion, and
   opaque surfaces
-- The maintainer completed a local controller and visual smoke test
+- Review findings fixed: layout switches retain selection and the empty-state
+  message updates as the filtered library changes
+- Regression checks cover both fixes in the standard couch navigation tests
+- The maintainer tested the earlier candidate; the final candidate needs a new
+  local controller and visual smoke test
 
 ## Review focus
 
@@ -36,5 +45,21 @@ Review the current `codex/1.6-couch-polish` branch before publication.
 ## Publication status
 
 This branch is a local review candidate. Do not publish it yet. The final
-candidate still needs independent review, final CI and release workflow checks,
-and explicit maintainer approval under `RELEASING.md`.
+candidate still needs final CI and release workflow checks, exact-candidate
+maintainer testing, and explicit publication approval under `RELEASING.md`.
+
+## Final manual checks
+
+- Start with `./build/release/omakade --couch` and navigate without a mouse.
+- Select a game away from the first row, switch Detail to Grid and back, and
+  confirm the same game remains selected and focused.
+- Search for a nonexistent game, then clear the search. Confirm the empty
+  message appears and disappears correctly.
+- Hold and release the stick and directional pad, then check Settings, search,
+  filters, and game details.
+- Move the mouse after controller use, then switch to Desktop Mode and confirm
+  cursor behavior.
+- Launch a Steam game and any available native or Windows GOG game.
+
+ARM64 package testing and the real-library gaps in `COMPATIBILITY.md` remain
+open. Local offscreen checks do not substitute for those reports.

--- a/docs/1.6-REVIEW.md
+++ b/docs/1.6-REVIEW.md
@@ -27,6 +27,8 @@ The local `codex/1.6-couch-polish` branch contains the 1.6.0 release candidate.
 - Review findings fixed: layout switches retain selection and the empty-state
   message updates as the filtered library changes
 - Regression checks cover both fixes in the standard couch navigation tests
+- Background controller input is ignored, held navigation is cancelled on focus
+  loss, and queued input is discarded when focus returns
 - The maintainer tested the earlier candidate; the final candidate needs a new
   local controller and visual smoke test
 
@@ -59,7 +61,9 @@ maintainer testing, and explicit publication approval under `RELEASING.md`.
   filters, and game details.
 - Move the mouse after controller use, then switch to Desktop Mode and confirm
   cursor behavior.
-- Launch a Steam game and any available native or Windows GOG game.
+- Launch a Steam game and any available native or Windows GOG game. Press the
+  face buttons, Start, and directional controls while playing: Omakade must not
+  regain focus or change its library. Return to Omakade and check navigation.
 
 ARM64 package testing and the real-library gaps in `COMPATIBILITY.md` remain
 open. Local offscreen checks do not substitute for those reports.

--- a/docs/1.6-REVIEW.md
+++ b/docs/1.6-REVIEW.md
@@ -1,0 +1,40 @@
+# Omakade 1.6 review handoff
+
+Review the current `codex/1.6-couch-polish` branch before publication.
+
+## Included
+
+- Dedicated Couch Mode with detail and grid library views
+- Clear focus and selection across the library, details, settings, and dialogs
+- Held analog and directional-pad navigation with controlled repeat
+- Controller-first search, filters, organization, settings, and text entry
+- Cursor hiding during couch navigation and restoration on mouse movement
+- Direct native and Windows GOG discovery and launching
+- Existing Sunshine and Moonlight Couch Mode entry points
+
+## Validation completed
+
+- Debug: 41 of 41 tests pass
+- Release: 41 of 41 tests pass
+- QML lint exits successfully with existing non-blocking warnings
+- Automated visual fixtures cover common sizes, themes, reduced motion, and
+  opaque surfaces
+- The maintainer completed a local controller and visual smoke test
+
+## Review focus
+
+- First focus after launch without touching the mouse
+- Held analog and directional-pad movement, including release and direction
+  changes
+- Focus order and restoration in both library views and game details
+- Selection visibility against bright and dark artwork
+- Cursor behavior when switching between controller, keyboard, mouse, and
+  Desktop Mode
+- Search, filters, sorting, organization, settings, dialogs, and launch actions
+- Direct GOG path validation and safe handling of malformed manifests
+
+## Publication status
+
+This branch is a local review candidate. Do not publish it yet. The final
+candidate still needs independent review, final CI and release workflow checks,
+and explicit maintainer approval under `RELEASING.md`.

--- a/docs/1.6-REVIEW.md
+++ b/docs/1.6-REVIEW.md
@@ -1,6 +1,12 @@
 # Omakade 1.6 review handoff
 
-The local `codex/1.6-couch-polish` branch contains the 1.6.0 release candidate.
+The local `codex/1.6-gog-release-fixes` branch contains the revised 1.6.0 release candidate.
+
+The maintainer tested and approved `470d952`, including the remaining ARM64
+hardware and real-library validation gaps. Publication was cancelled before a
+release was created after late review identified two reproducible GOG cache bugs.
+The unpublished tag was removed. This revision fixes both bugs and needs a fresh
+local smoke test before publication.
 
 ## Included
 
@@ -14,7 +20,7 @@ The local `codex/1.6-couch-polish` branch contains the 1.6.0 release candidate.
 
 ## Validation completed
 
-- Debug: 41 of 41 tests pass
+- Previously approved candidate `470d952`: Debug 41 of 41 tests pass
 - Release: 41 of 41 tests pass
 - QML lint exits successfully with existing non-blocking warnings
 - Desktop and AppStream metadata validation passes
@@ -29,8 +35,9 @@ The local `codex/1.6-couch-polish` branch contains the 1.6.0 release candidate.
 - Regression checks cover both fixes in the standard couch navigation tests
 - Background controller input is ignored, held navigation is cancelled on focus
   loss, and queued input is discarded when focus returns
-- The maintainer tested the earlier candidate; the final candidate needs a new
-  local controller and visual smoke test
+- Regression tests reproduce and cover cold-cache Heroic GOG ownership errors
+  and removal of the last direct GOG game, including missing-root cache retention
+- The revised candidate needs a local controller and library-rescan smoke test
 
 ## Review focus
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -25,9 +25,11 @@ The current local 1.6 candidate passes all 41 tests in both Debug and Release
 builds. Automated coverage includes Couch Mode detail and grid layouts, focus
 paths, held analog and directional-pad navigation, controller reconnects,
 keyboard and mouse handoff, cursor visibility, and a cached 1,000-game library.
-The maintainer also completed a local controller and visual smoke test.
+Regression coverage also checks selection across layout switches and empty-state
+updates after filtering. The maintainer tested the earlier candidate; the final
+1.6.0 candidate still needs a local controller and visual smoke test.
 
-Independent review, CI on the final pushed commit, the release workflow, and
+CI on the final pushed commit, the release workflow, exact-candidate testing, and
 the real-library reports below remain release gates.
 
 ## Automated visual matrix

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -39,7 +39,8 @@ CI. Additional real-user reports expand compatibility coverage after v1.
 
 Lutris native and Flatpak discovery, Heroic native and Flatpak discovery,
 Faugus and RetroArch native and Flatpak discovery, PCSX2 and Ryujinx scanner
-contracts (native and Flatpak roots), Epic, GOG, and Amazon manifests, and
+contracts (native and Flatpak roots), direct GOG manifests and launch tasks,
+Epic, GOG, and Amazon manifests, and
 Battle.net product.db discovery across Wine, Proton, and Bottles
 prefixes are covered by repeatable local fixtures. These
 paths still need reports from users with those launchers installed before the

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -2,7 +2,7 @@
 
 ## Reference Omarchy system
 
-Verified through September 1, 2026:
+Verified through September 4, 2026:
 
 | Component | Version | Result |
 | --- | --- | --- |
@@ -18,6 +18,17 @@ Verified through September 1, 2026:
 The reference library contains 45 installed Steam games. Theme colors, font,
 launcher transparency, one-click details, keyboard navigation, and the
 controller input path have been exercised on this system.
+
+## 1.6 candidate validation
+
+The current local 1.6 candidate passes all 41 tests in both Debug and Release
+builds. Automated coverage includes Couch Mode detail and grid layouts, focus
+paths, held analog and directional-pad navigation, controller reconnects,
+keyboard and mouse handoff, cursor visibility, and a cached 1,000-game library.
+The maintainer also completed a local controller and visual smoke test.
+
+Independent review, CI on the final pushed commit, the release workflow, and
+the real-library reports below remain release gates.
 
 ## Automated visual matrix
 

--- a/packaging/arch/PKGBUILD.in
+++ b/packaging/arch/PKGBUILD.in
@@ -6,6 +6,7 @@ arch=('x86_64' 'aarch64')
 url='https://btsouth.github.io/omakade/'
 license=('GPL-3.0-or-later')
 depends=('glib2' 'hicolor-icon-theme' 'libsecret' 'libzip' 'qt6-base' 'qt6-declarative' 'qt6-imageformats' 'qt6-svg' 'qt6-wayland' 'sdl3')
+optdepends=('umu-launcher: launch Windows GOG and Proton Battle.net games')
 makedepends=('cmake' 'ninja' 'pkgconf')
 options=('!debug')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/btsouth/omakade/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz")

--- a/packaging/io.github.tsouth89.Omakade.metainfo.xml
+++ b/packaging/io.github.tsouth89.Omakade.metainfo.xml
@@ -11,7 +11,7 @@
   <description>
     <p>
       Omakade is a local-first game library for Omarchy. It discovers installed
-      Steam, Lutris, Heroic, Faugus, RetroArch, PCSX2, Ryujinx, and Battle.net games, uses local artwork,
+      Steam, GOG, Lutris, Heroic, Faugus, RetroArch, PCSX2, Ryujinx, and Battle.net games, uses local artwork,
       follows the active Omarchy theme, and delegates launching back to the owning platform.
     </p>
   </description>

--- a/packaging/io.github.tsouth89.Omakade.metainfo.xml
+++ b/packaging/io.github.tsouth89.Omakade.metainfo.xml
@@ -26,6 +26,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.6.0" date="2026-09-04" />
     <release version="1.5.0" date="2026-09-04" />
     <release version="1.4.0" date="2026-09-02" />
     <release version="1.3.0" date="2026-09-01" />

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -767,10 +767,8 @@ ApplicationWindow {
     }
 
     onActiveChanged: {
-        // Only give the grid focus when nothing has it, so alt-tabbing back does not pull
-        // focus away from a toolbar control or an empty-state button.
-        if (active && root.navigationContainer() === null && !root.activeFocusItem) {
-            Qt.callLater(root.focusLibrary)
+        if (active) {
+            Qt.callLater(root.focusCurrentSurface)
         }
     }
     onClosing: function(close) {
@@ -1470,6 +1468,7 @@ ApplicationWindow {
         enabled: visible && root.navigationContainer() === null
         libraryModel: Library
         scanning: root.libraryScanning
+        viewOverride: CouchLibraryViewOverride
 
         onGameActivated: index => root.openGame(index)
         onFavoriteToggled: function(index) {
@@ -2881,6 +2880,11 @@ ApplicationWindow {
 
     Connections {
         target: Controller
+        function onControllerChanged() {
+            if (Controller.connected && root.couchMode) {
+                Qt.callLater(root.focusCurrentSurface)
+            }
+        }
         function onFocusDirectionRequested(key) {
             const container = root.navigationContainer()
             if (!root.couchMode && !container && !libraryView.gridFocused

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -46,6 +46,7 @@ ApplicationWindow {
       : pcsx2SourceButton.visible && pcsx2SourceButton.enabled ? pcsx2SourceButton
       : retroArchSourceButton.visible && retroArchSourceButton.enabled ? retroArchSourceButton
       : faugusSourceButton.visible && faugusSourceButton.enabled ? faugusSourceButton
+      : gogSourceButton.visible && gogSourceButton.enabled ? gogSourceButton
       : heroicSourceButton.visible && heroicSourceButton.enabled ? heroicSourceButton
       : lutrisSourceButton.visible && lutrisSourceButton.enabled ? lutrisSourceButton
       : battleNetSourceButton.visible && battleNetSourceButton.enabled ? battleNetSourceButton
@@ -242,7 +243,7 @@ ApplicationWindow {
     function rescanLibraries() {
         if (SteamLibrary && Preferences.steamEnabled) SteamLibrary.refresh()
         if (LutrisLibrary && Preferences.lutrisEnabled) LutrisLibrary.refresh()
-        if (HeroicLibrary && Preferences.heroicEnabled) HeroicLibrary.refresh()
+        if (HeroicLibrary && (Preferences.heroicEnabled || Preferences.gogEnabled)) HeroicLibrary.refresh()
         if (FaugusLibrary && Preferences.faugusEnabled) FaugusLibrary.refresh()
         if (RetroArchLibrary && Preferences.retroArchEnabled) RetroArchLibrary.refresh()
         if (Pcsx2Library && Preferences.pcsx2Enabled) Pcsx2Library.refresh()
@@ -1164,6 +1165,18 @@ ApplicationWindow {
                         }
                     }
                     GlassButton {
+                        id: gogSourceButton
+                        objectName: "gogSourceButton"
+                        text: "GOG"
+                        compact: true
+                        visible: Preferences.gogEnabled
+                        selected: Library.sourceFilter === "GOG"
+                        onClicked: {
+                            Library.sourceFilter = "GOG"
+                            libraryView.currentIndex = Library.rowCount() > 0 ? 0 : -1
+                        }
+                    }
+                    GlassButton {
                         id: faugusSourceButton
                         objectName: "faugusSourceButton"
                         text: "FAUGUS"
@@ -1402,6 +1415,8 @@ ApplicationWindow {
                 filtersActive: root.organizationFiltersActive || Library.searchText !== ""
                 onClearFiltersRequested: root.clearLibraryFilters()
                 emptyTitle: root.emptyTitleForFilters() !== "" ? root.emptyTitleForFilters()
+                            : Library.sourceFilter === "GOG" && HeroicLibrary && !HeroicLibrary.gogDetected
+                            ? "GOG was not found"
                             : Library.sourceFilter === "Heroic" && HeroicLibrary && !HeroicLibrary.heroicDetected
                             ? "Heroic was not found"
                             : Library.sourceFilter === "Faugus" && FaugusLibrary && !FaugusLibrary.faugusDetected
@@ -1434,6 +1449,8 @@ ApplicationWindow {
                               ? Pcsx2Library.errorText
                               : Library.sourceFilter === "Ryujinx" && RyujinxLibrary && RyujinxLibrary.errorText.length > 0
                               ? RyujinxLibrary.errorText
+                              : Library.sourceFilter === "GOG" && HeroicLibrary && HeroicLibrary.errorText.length > 0
+                              ? HeroicLibrary.errorText
                               : Library.sourceFilter === "Heroic" && HeroicLibrary && HeroicLibrary.errorText.length > 0
                               ? HeroicLibrary.errorText
                               : Library.sourceFilter === "Lutris" && LutrisLibrary && LutrisLibrary.errorText.length > 0
@@ -1442,7 +1459,7 @@ ApplicationWindow {
                               ? BattleNetLibrary.errorText
                               : SteamLibrary && SteamLibrary.errorText.length > 0
                                 ? SteamLibrary.errorText
-                                : "Install a game in Steam, Lutris, Heroic, Faugus, RetroArch, PCSX2, Ryujinx, or Battle.net, then rescan your library."
+                                : "Install a game in Steam, GOG, Lutris, Heroic, Faugus, RetroArch, PCSX2, Ryujinx, or Battle.net, then rescan your library."
                 onGameActivated: index => root.openGame(index)
                 onFavoriteToggled: index => Library.toggleFavorite(index)
                 onCoverRequested: function(source, appId) {
@@ -1989,6 +2006,11 @@ ApplicationWindow {
                           error: HeroicLibrary ? HeroicLibrary.errorText : "",
                           paths: HeroicLibrary ? HeroicLibrary.detectedPaths : [],
                           lastScan: HeroicLibrary ? HeroicLibrary.lastScan : 0 },
+                        { name: "GOG", enabled: Preferences.gogEnabled,
+                          status: HeroicLibrary ? HeroicLibrary.statusText : "Unavailable",
+                          error: HeroicLibrary ? HeroicLibrary.errorText : "",
+                          paths: HeroicLibrary ? HeroicLibrary.detectedPaths : [],
+                          lastScan: HeroicLibrary ? HeroicLibrary.lastScan : 0 },
                         { name: "FAUGUS", enabled: Preferences.faugusEnabled,
                           status: FaugusLibrary ? FaugusLibrary.statusText : "Unavailable",
                           error: FaugusLibrary ? FaugusLibrary.errorText : "",
@@ -2046,6 +2068,10 @@ ApplicationWindow {
                                         Preferences.heroicEnabled = !Preferences.heroicEnabled
                                         nowEnabled = Preferences.heroicEnabled
                                         if (Preferences.heroicEnabled) HeroicLibrary.refresh()
+                                    } else if (modelData.name === "GOG") {
+                                        Preferences.gogEnabled = !Preferences.gogEnabled
+                                        nowEnabled = Preferences.gogEnabled
+                                        if (Preferences.gogEnabled) HeroicLibrary.refresh()
                                     } else if (modelData.name === "FAUGUS") {
                                         Preferences.faugusEnabled = !Preferences.faugusEnabled
                                         nowEnabled = Preferences.faugusEnabled
@@ -2077,6 +2103,7 @@ ApplicationWindow {
                                     else if (modelData.name === "BATTLE.NET" && BattleNetLibrary) BattleNetLibrary.refresh()
                                     else if (modelData.name === "LUTRIS") LutrisLibrary.refresh()
                                     else if (modelData.name === "HEROIC") HeroicLibrary.refresh()
+                                    else if (modelData.name === "GOG") HeroicLibrary.refresh()
                                     else if (modelData.name === "FAUGUS") FaugusLibrary.refresh()
                                     else if (modelData.name === "PCSX2") Pcsx2Library.refresh()
                                     else if (modelData.name === "RYUJINX") RyujinxLibrary.refresh()

--- a/qml/components/CouchLibraryView.qml
+++ b/qml/components/CouchLibraryView.qml
@@ -9,6 +9,7 @@ FocusScope {
     property string viewOverride: ""
     property bool scanning: false
     property int currentIndex: 0
+    property bool updatingGameViews: false
     property var currentGame: ({})
     property var pendingCurrent: null
     property bool searchOpen: false
@@ -56,6 +57,21 @@ FocusScope {
 
     function activeGameView() {
         return root.detailView ? gameStrip : gameGrid
+    }
+
+    function syncGameViews() {
+        // Attaching a model initializes the view's index. Keep that temporary
+        // index from replacing the selected game while switching layouts.
+        const selectedIndex = root.currentIndex
+        root.updatingGameViews = true
+        gameStrip.model = root.detailView ? root.libraryModel : null
+        gameGrid.model = root.detailView ? null : root.libraryModel
+        const view = root.activeGameView()
+        view.currentIndex = selectedIndex
+        if (selectedIndex >= 0) {
+            view.positionViewAtIndex(selectedIndex, GridView.Contain)
+        }
+        root.updatingGameViews = false
     }
 
     function focusGrid() {
@@ -133,14 +149,11 @@ FocusScope {
     }
 
     onCurrentIndexChanged: refreshCurrentGame()
-    onLibraryModelChanged: refreshCurrentGame()
-    onDetailViewChanged: {
-        const view = root.activeGameView()
-        view.currentIndex = root.currentIndex
-        if (root.currentIndex >= 0) {
-            view.positionViewAtIndex(root.currentIndex, GridView.Contain)
-        }
+    onLibraryModelChanged: {
+        syncGameViews()
+        refreshCurrentGame()
     }
+    onDetailViewChanged: syncGameViews()
 
     Connections {
         target: root.libraryModel
@@ -597,9 +610,10 @@ FocusScope {
     }
 
     Column {
+        objectName: "couchEmptyState"
         anchors.centerIn: parent
         spacing: 14 * root.uiScale
-        visible: root.libraryModel.rowCount() === 0
+        visible: root.activeGameView().count === 0
 
         Text {
             anchors.horizontalCenter: parent.horizontalCenter
@@ -634,7 +648,7 @@ FocusScope {
         spacing: 14 * root.uiScale
         clip: true
         cacheBuffer: Math.max(0, width)
-        model: visible ? root.libraryModel : null
+        model: null
         currentIndex: root.currentIndex
         keyNavigationEnabled: true
         highlightFollowsCurrentItem: true
@@ -659,7 +673,7 @@ FocusScope {
         boundsBehavior: Flickable.StopAtBounds
 
         onCurrentIndexChanged: {
-            if (visible) {
+            if (visible && !root.updatingGameViews) {
                 root.currentIndex = currentIndex
             }
         }
@@ -827,7 +841,7 @@ FocusScope {
         cellWidth: 212 * root.uiScale
         cellHeight: 350 * root.uiScale
         readonly property int columnCount: Math.max(1, Math.floor(width / cellWidth))
-        model: visible ? root.libraryModel : null
+        model: null
         currentIndex: root.currentIndex
         keyNavigationEnabled: true
         highlightFollowsCurrentItem: true
@@ -838,7 +852,7 @@ FocusScope {
         cacheBuffer: Math.max(0, height)
 
         onCurrentIndexChanged: {
-            if (visible) {
+            if (visible && !root.updatingGameViews) {
                 root.currentIndex = currentIndex
             }
         }
@@ -1142,6 +1156,7 @@ FocusScope {
 
     Component.onCompleted: {
         currentIndex = libraryModel.rowCount() > 0 ? 0 : -1
+        syncGameViews()
         refreshCurrentGame()
         Qt.callLater(focusGrid)
     }

--- a/qml/components/CouchLibraryView.qml
+++ b/qml/components/CouchLibraryView.qml
@@ -631,12 +631,28 @@ FocusScope {
         anchors.bottomMargin: 22 * root.uiScale
         height: 260 * root.uiScale
         orientation: ListView.Horizontal
-        spacing: 18 * root.uiScale
+        spacing: 14 * root.uiScale
         clip: true
+        cacheBuffer: width
         model: visible ? root.libraryModel : null
         currentIndex: root.currentIndex
         keyNavigationEnabled: true
-        highlightMoveDuration: Preferences.reducedMotion ? 0 : 130
+        highlightFollowsCurrentItem: true
+        highlight: Item {
+            Rectangle {
+                anchors.top: parent.top
+                anchors.topMargin: root.uiScale
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: parent.width
+                height: 233 * root.uiScale
+                radius: 16 * root.uiScale
+                color: root.alpha(Theme.accent, 0.18)
+                border.width: 2 * root.uiScale
+                border.color: root.alpha(Theme.accent, 0.72)
+            }
+        }
+        highlightMoveDuration: Preferences.reducedMotion ? 0 : 90
+        highlightResizeDuration: Preferences.reducedMotion ? 0 : 90
         highlightRangeMode: ListView.ApplyRange
         preferredHighlightBegin: width * 0.08
         preferredHighlightEnd: width * 0.72
@@ -678,8 +694,9 @@ FocusScope {
             required property color accentStart
             required property color accentEnd
 
-            width: 146 * root.uiScale
+            width: 160 * root.uiScale
             height: gameStrip.height
+            z: 1
             Accessible.name: title
             Accessible.role: Accessible.ListItem
 
@@ -690,22 +707,11 @@ FocusScope {
             }
 
             Rectangle {
-                anchors.horizontalCenter: cover.horizontalCenter
-                anchors.verticalCenter: cover.verticalCenter
-                width: cover.width + 14 * root.uiScale
-                height: cover.height + 14 * root.uiScale
-                radius: cover.radius + 6 * root.uiScale
-                visible: gameStrip.currentIndex === card.index
-                color: root.alpha(Theme.accent, 0.18)
-                border.width: 2 * root.uiScale
-                border.color: root.alpha(Theme.accent, 0.72)
-            }
-
-            Rectangle {
                 id: cover
                 anchors.top: parent.top
+                anchors.topMargin: 8 * root.uiScale
                 anchors.horizontalCenter: parent.horizontalCenter
-                width: parent.width
+                width: 146 * root.uiScale
                 height: width * 1.5
                 radius: 10 * root.uiScale
                 clip: true
@@ -792,7 +798,7 @@ FocusScope {
             opacity: gameStrip.currentIndex === card.index ? 1 : 0.58
             Behavior on opacity {
                 enabled: !Preferences.reducedMotion
-                NumberAnimation { duration: 130; easing.type: Easing.OutCubic }
+                NumberAnimation { duration: 90; easing.type: Easing.OutCubic }
             }
         }
     }
@@ -824,9 +830,12 @@ FocusScope {
         model: visible ? root.libraryModel : null
         currentIndex: root.currentIndex
         keyNavigationEnabled: true
-        highlightMoveDuration: Preferences.reducedMotion ? 0 : 110
+        highlightFollowsCurrentItem: true
+        highlight: Item {}
+        highlightMoveDuration: Preferences.reducedMotion ? 0 : 90
         boundsBehavior: Flickable.StopAtBounds
         clip: true
+        cacheBuffer: height
 
         onCurrentIndexChanged: {
             if (visible) {
@@ -872,14 +881,15 @@ FocusScope {
 
             width: 196 * root.uiScale
             height: 330 * root.uiScale
-            scale: current ? 1.035 : 1
+            transformOrigin: Item.TopLeft
+            scale: current ? 1.025 : 1
             z: current ? 2 : 1
             Accessible.name: title
             Accessible.role: Accessible.ListItem
 
             Behavior on scale {
                 enabled: !Preferences.reducedMotion
-                NumberAnimation { duration: 120; easing.type: Easing.OutCubic }
+                NumberAnimation { duration: 90; easing.type: Easing.OutCubic }
             }
 
             Component.onCompleted: {

--- a/qml/components/CouchLibraryView.qml
+++ b/qml/components/CouchLibraryView.qml
@@ -76,7 +76,11 @@ FocusScope {
             return
         }
         if (root.gridFocused) {
-            viewButton.forceActiveFocus(Qt.TabFocusReason)
+            if (root.detailView) {
+                viewButton.forceActiveFocus(Qt.TabFocusReason)
+            } else {
+                layoutButton.forceActiveFocus(Qt.TabFocusReason)
+            }
         } else {
             focusGrid()
         }
@@ -594,7 +598,7 @@ FocusScope {
     Column {
         anchors.centerIn: parent
         spacing: 14 * root.uiScale
-        visible: gameStrip.count === 0
+        visible: root.libraryModel.rowCount() === 0
 
         Text {
             anchors.horizontalCenter: parent.horizontalCenter
@@ -628,17 +632,20 @@ FocusScope {
         orientation: ListView.Horizontal
         spacing: 18 * root.uiScale
         clip: true
-        model: root.libraryModel
+        model: visible ? root.libraryModel : null
         currentIndex: root.currentIndex
         keyNavigationEnabled: true
-        KeyNavigation.up: allButton
         highlightMoveDuration: Preferences.reducedMotion ? 0 : 130
         highlightRangeMode: ListView.ApplyRange
         preferredHighlightBegin: width * 0.08
         preferredHighlightEnd: width * 0.72
         boundsBehavior: Flickable.StopAtBounds
 
-        onCurrentIndexChanged: root.currentIndex = currentIndex
+        onCurrentIndexChanged: {
+            if (visible) {
+                root.currentIndex = currentIndex
+            }
+        }
 
         Keys.onUpPressed: function(event) {
             viewButton.forceActiveFocus(Qt.TabFocusReason)
@@ -813,14 +820,27 @@ FocusScope {
         cellWidth: 212 * root.uiScale
         cellHeight: 350 * root.uiScale
         readonly property int columnCount: Math.max(1, Math.floor(width / cellWidth))
-        model: root.libraryModel
+        model: visible ? root.libraryModel : null
         currentIndex: root.currentIndex
         keyNavigationEnabled: true
         highlightMoveDuration: Preferences.reducedMotion ? 0 : 110
         boundsBehavior: Flickable.StopAtBounds
         clip: true
 
-        onCurrentIndexChanged: root.currentIndex = currentIndex
+        onCurrentIndexChanged: {
+            if (visible) {
+                root.currentIndex = currentIndex
+            }
+        }
+
+        Keys.onUpPressed: function(event) {
+            if (currentIndex >= 0 && currentIndex < columnCount) {
+                allButton.forceActiveFocus(Qt.TabFocusReason)
+                event.accepted = true
+            } else {
+                event.accepted = false
+            }
+        }
 
         Keys.onReturnPressed: function(event) {
             if (currentIndex >= 0) {

--- a/qml/components/CouchLibraryView.qml
+++ b/qml/components/CouchLibraryView.qml
@@ -633,7 +633,7 @@ FocusScope {
         orientation: ListView.Horizontal
         spacing: 14 * root.uiScale
         clip: true
-        cacheBuffer: width
+        cacheBuffer: Math.max(0, width)
         model: visible ? root.libraryModel : null
         currentIndex: root.currentIndex
         keyNavigationEnabled: true
@@ -835,7 +835,7 @@ FocusScope {
         highlightMoveDuration: Preferences.reducedMotion ? 0 : 90
         boundsBehavior: Flickable.StopAtBounds
         clip: true
-        cacheBuffer: height
+        cacheBuffer: Math.max(0, height)
 
         onCurrentIndexChanged: {
             if (visible) {

--- a/qml/components/CouchLibraryView.qml
+++ b/qml/components/CouchLibraryView.qml
@@ -6,6 +6,7 @@ FocusScope {
     id: root
 
     required property var libraryModel
+    property string viewOverride: ""
     property bool scanning: false
     property int currentIndex: 0
     property var currentGame: ({})
@@ -24,7 +25,9 @@ FocusScope {
         { label: "PCSX2", value: "PCSX2", enabled: Preferences.pcsx2Enabled },
         { label: "RYUJINX", value: "Ryujinx", enabled: Preferences.ryujinxEnabled }
     ].filter(function(option) { return option.enabled === undefined || option.enabled })
-    readonly property bool gridFocused: gameStrip.activeFocus
+    readonly property bool detailView: (viewOverride.length > 0
+                                        ? viewOverride : Preferences.couchLibraryView) !== "grid"
+    readonly property bool gridFocused: root.activeGameView().activeFocus
     readonly property real uiScale: Math.max(0.68, Math.min(2.0,
                                                            Math.min(width / 1920,
                                                                     height / 1080)))
@@ -50,19 +53,29 @@ FocusScope {
         }
     }
 
+    function activeGameView() {
+        return root.detailView ? gameStrip : gameGrid
+    }
+
     function focusGrid() {
-        if (gameStrip.count > 0) {
-            gameStrip.forceActiveFocus(Qt.TabFocusReason)
+        const view = root.activeGameView()
+        if (view.count > 0) {
+            view.forceActiveFocus(Qt.TabFocusReason)
         } else {
             settingsButton.forceActiveFocus(Qt.TabFocusReason)
         }
+    }
+
+    function toggleLibraryView() {
+        Preferences.couchLibraryView = root.detailView ? "grid" : "detail"
+        root.focusGrid()
     }
 
     function toggleControls() {
         if (searchOpen || browseOpen) {
             return
         }
-        if (gameStrip.activeFocus) {
+        if (root.gridFocused) {
             viewButton.forceActiveFocus(Qt.TabFocusReason)
         } else {
             focusGrid()
@@ -116,6 +129,13 @@ FocusScope {
 
     onCurrentIndexChanged: refreshCurrentGame()
     onLibraryModelChanged: refreshCurrentGame()
+    onDetailViewChanged: {
+        const view = root.activeGameView()
+        view.currentIndex = root.currentIndex
+        if (root.currentIndex >= 0) {
+            view.positionViewAtIndex(root.currentIndex, GridView.Contain)
+        }
+    }
 
     Connections {
         target: root.libraryModel
@@ -129,6 +149,7 @@ FocusScope {
             }
         }
         function onModelReset() {
+            const needsInitialFocus = root.currentIndex < 0
             const pending = root.pendingCurrent
             root.pendingCurrent = null
             const matched = pending
@@ -141,12 +162,21 @@ FocusScope {
                                                         root.libraryModel.rowCount() - 1))
                                   : -1
             root.refreshCurrentGame()
+            if (needsInitialFocus && root.currentIndex >= 0 && root.visible
+                    && !root.searchOpen && !root.browseOpen) {
+                Qt.callLater(root.focusGrid)
+            }
         }
         function onRowsInserted() {
-            if (root.currentIndex < 0 && root.libraryModel.rowCount() > 0) {
+            const needsInitialFocus = root.currentIndex < 0
+            if (needsInitialFocus && root.libraryModel.rowCount() > 0) {
                 root.currentIndex = 0
             }
             root.refreshCurrentGame()
+            if (needsInitialFocus && root.currentIndex >= 0 && root.visible
+                    && !root.searchOpen && !root.browseOpen) {
+                Qt.callLater(root.focusGrid)
+            }
         }
         function onRowsRemoved() {
             root.currentIndex = root.libraryModel.rowCount() > 0
@@ -160,7 +190,7 @@ FocusScope {
 
     Rectangle {
         anchors.fill: parent
-        color: Theme.darkerBackground
+        color: root.alpha(Theme.darkerBackground, Math.max(0.90, Theme.surfaceAlpha))
     }
 
     Rectangle {
@@ -178,7 +208,7 @@ FocusScope {
             }
             GradientStop {
                 position: 1
-                color: Theme.darkerBackground
+                color: root.alpha(Theme.darkerBackground, 0.96)
             }
         }
     }
@@ -217,6 +247,17 @@ FocusScope {
             GradientStop { position: 0.58; color: root.alpha(Theme.darkerBackground, 0.34) }
             GradientStop { position: 1; color: root.alpha(Theme.darkerBackground, 0.12) }
         }
+    }
+
+    Rectangle {
+        anchors.left: topBar.left
+        anchors.right: topBar.right
+        anchors.top: topBar.top
+        anchors.bottom: topBar.bottom
+        anchors.margins: -12 * root.uiScale
+        radius: Math.max(12 * root.uiScale, Theme.cornerRadius * 2)
+        color: root.alpha(Theme.background, Math.min(0.78, Theme.surfaceAlpha * 0.78))
+        border.color: root.alpha(Theme.foreground, 0.12)
     }
 
     RowLayout {
@@ -272,16 +313,18 @@ FocusScope {
 
             GlassButton {
                 id: allButton
+                objectName: "couchAllButton"
                 text: "ALL"
                 compact: true
                 displayScale: Math.max(1, root.uiScale * 1.18)
                 selected: root.libraryModel.mode === 0
                 onClicked: root.selectMode(0)
                 KeyNavigation.right: favoritesButton
-                KeyNavigation.down: viewButton
+                KeyNavigation.down: root.detailView ? viewButton : gameGrid
             }
             GlassButton {
                 id: favoritesButton
+                objectName: "couchFavoritesFilterButton"
                 text: "FAVORITES"
                 compact: true
                 displayScale: Math.max(1, root.uiScale * 1.18)
@@ -289,18 +332,32 @@ FocusScope {
                 onClicked: root.selectMode(1)
                 KeyNavigation.left: allButton
                 KeyNavigation.right: recentButton
-                KeyNavigation.down: viewButton
+                KeyNavigation.down: root.detailView ? viewButton : gameGrid
             }
             GlassButton {
                 id: recentButton
+                objectName: "couchRecentButton"
                 text: "RECENT"
                 compact: true
                 displayScale: Math.max(1, root.uiScale * 1.18)
                 selected: root.libraryModel.mode === 2
                 onClicked: root.selectMode(2)
                 KeyNavigation.left: favoritesButton
+                KeyNavigation.right: layoutButton
+                KeyNavigation.down: root.detailView ? favoriteButton : gameGrid
+            }
+            GlassButton {
+                id: layoutButton
+                objectName: "couchLayoutButton"
+                text: root.detailView ? "VIEW · DETAIL" : "VIEW · GRID"
+                iconText: root.detailView ? "▤" : "▦"
+                compact: true
+                displayScale: Math.max(1, root.uiScale * 1.18)
+                selected: true
+                onClicked: root.toggleLibraryView()
+                KeyNavigation.left: recentButton
                 KeyNavigation.right: browseButton
-                KeyNavigation.down: favoriteButton
+                KeyNavigation.down: root.detailView ? favoriteButton : gameGrid
             }
             GlassButton {
                 id: browseButton
@@ -309,9 +366,9 @@ FocusScope {
                 compact: true
                 displayScale: Math.max(1, root.uiScale * 1.18)
                 onClicked: root.openBrowse()
-                KeyNavigation.left: recentButton
+                KeyNavigation.left: layoutButton
                 KeyNavigation.right: searchButton
-                KeyNavigation.down: favoriteButton
+                KeyNavigation.down: root.detailView ? favoriteButton : gameGrid
             }
             GlassButton {
                 id: searchButton
@@ -326,7 +383,7 @@ FocusScope {
                 onClicked: root.openSearch()
                 KeyNavigation.left: browseButton
                 KeyNavigation.right: settingsButton
-                KeyNavigation.down: favoriteButton
+                KeyNavigation.down: root.detailView ? favoriteButton : gameGrid
             }
             GlassButton {
                 id: settingsButton
@@ -337,7 +394,7 @@ FocusScope {
                 onClicked: root.settingsRequested()
                 KeyNavigation.left: searchButton
                 KeyNavigation.right: desktopButton
-                KeyNavigation.down: favoriteButton
+                KeyNavigation.down: root.detailView ? favoriteButton : gameGrid
             }
             GlassButton {
                 id: desktopButton
@@ -347,7 +404,7 @@ FocusScope {
                 displayScale: Math.max(1, root.uiScale * 1.18)
                 onClicked: root.desktopRequested()
                 KeyNavigation.left: settingsButton
-                KeyNavigation.down: favoriteButton
+                KeyNavigation.down: root.detailView ? favoriteButton : gameGrid
             }
         }
     }
@@ -360,7 +417,7 @@ FocusScope {
         anchors.rightMargin: 116 * root.uiScale
         width: 330 * root.uiScale
         height: width * 1.5
-        visible: gameStrip.count > 0 && root.width >= 1200
+        visible: root.detailView && gameStrip.count > 0 && root.width >= 1200
 
         Rectangle {
             anchors.fill: parent
@@ -449,11 +506,12 @@ FocusScope {
         anchors.bottomMargin: 42 * root.uiScale
         width: Math.min(parent.width * 0.58, 920 * root.uiScale)
         spacing: 12 * root.uiScale
-        visible: gameStrip.count > 0
+        visible: root.detailView && gameStrip.count > 0
 
         Text {
             width: parent.width
-            text: ((root.currentGame.source || "LIBRARY")
+            text: ((root.currentIndex + 1) + " / " + root.libraryModel.rowCount()
+                   + "  ·  " + (root.currentGame.source || "LIBRARY")
                    + (root.currentGame.year ? "  ·  " + root.currentGame.year : "")).toUpperCase()
             textFormat: Text.PlainText
             color: Theme.accent
@@ -559,6 +617,7 @@ FocusScope {
     ListView {
         id: gameStrip
         objectName: "couchGameStrip"
+        visible: root.detailView
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: hintBar.top
@@ -572,6 +631,7 @@ FocusScope {
         model: root.libraryModel
         currentIndex: root.currentIndex
         keyNavigationEnabled: true
+        KeyNavigation.up: allButton
         highlightMoveDuration: Preferences.reducedMotion ? 0 : 130
         highlightRangeMode: ListView.ApplyRange
         preferredHighlightBegin: width * 0.08
@@ -622,6 +682,18 @@ FocusScope {
             }
 
             Rectangle {
+                anchors.horizontalCenter: cover.horizontalCenter
+                anchors.verticalCenter: cover.verticalCenter
+                width: cover.width + 14 * root.uiScale
+                height: cover.height + 14 * root.uiScale
+                radius: cover.radius + 6 * root.uiScale
+                visible: gameStrip.currentIndex === card.index
+                color: root.alpha(Theme.accent, 0.18)
+                border.width: 2 * root.uiScale
+                border.color: root.alpha(Theme.accent, 0.72)
+            }
+
+            Rectangle {
                 id: cover
                 anchors.top: parent.top
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -629,9 +701,9 @@ FocusScope {
                 height: width * 1.5
                 radius: 10 * root.uiScale
                 clip: true
-                border.width: gameStrip.currentIndex === card.index ? 4 : 1
+                border.width: gameStrip.currentIndex === card.index ? 5 : 1
                 border.color: gameStrip.currentIndex === card.index
-                              ? Theme.accent : root.alpha(Theme.foreground, 0.18)
+                              ? Theme.brightForeground : root.alpha(Theme.foreground, 0.16)
                 gradient: Gradient {
                     GradientStop { position: 0; color: card.accentStart }
                     GradientStop { position: 1; color: card.accentEnd }
@@ -673,6 +745,15 @@ FocusScope {
                         font.pixelSize: 12 * root.uiScale
                     }
                 }
+
+                Rectangle {
+                    visible: gameStrip.currentIndex === card.index
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    height: 8 * root.uiScale
+                    color: Theme.accent
+                }
             }
 
             Text {
@@ -700,10 +781,243 @@ FocusScope {
                 onDoubleClicked: root.gameActivated(card.index)
             }
 
-            opacity: gameStrip.currentIndex === card.index ? 1 : 0.78
+            opacity: gameStrip.currentIndex === card.index ? 1 : 0.58
             Behavior on opacity {
                 enabled: !Preferences.reducedMotion
                 NumberAnimation { duration: 130; easing.type: Easing.OutCubic }
+            }
+        }
+    }
+
+    Rectangle {
+        anchors.fill: gameGrid
+        anchors.margins: -16 * root.uiScale
+        visible: gameGrid.visible
+        radius: Math.max(16 * root.uiScale, Theme.cornerRadius * 2)
+        color: root.alpha(Theme.background, Math.min(0.64, Theme.surfaceAlpha * 0.64))
+        border.color: root.alpha(Theme.foreground, 0.11)
+    }
+
+    GridView {
+        id: gameGrid
+        objectName: "couchGameGrid"
+        visible: !root.detailView
+        anchors.top: topBar.bottom
+        anchors.bottom: hintBar.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: 38 * root.uiScale
+        anchors.bottomMargin: 24 * root.uiScale
+        anchors.leftMargin: 58 * root.uiScale
+        anchors.rightMargin: 58 * root.uiScale
+        cellWidth: 212 * root.uiScale
+        cellHeight: 350 * root.uiScale
+        readonly property int columnCount: Math.max(1, Math.floor(width / cellWidth))
+        model: root.libraryModel
+        currentIndex: root.currentIndex
+        keyNavigationEnabled: true
+        highlightMoveDuration: Preferences.reducedMotion ? 0 : 110
+        boundsBehavior: Flickable.StopAtBounds
+        clip: true
+
+        onCurrentIndexChanged: root.currentIndex = currentIndex
+
+        Keys.onReturnPressed: function(event) {
+            if (currentIndex >= 0) {
+                root.gameActivated(currentIndex)
+            }
+            event.accepted = true
+        }
+        Keys.onEnterPressed: function(event) {
+            if (currentIndex >= 0) {
+                root.gameActivated(currentIndex)
+            }
+            event.accepted = true
+        }
+
+        delegate: Item {
+            id: gridCard
+            required property int index
+            required property string title
+            required property string subtitle
+            required property string coverPath
+            required property string coverMark
+            required property string source
+            required property string appId
+            required property bool favorite
+            required property color accentStart
+            required property color accentEnd
+            readonly property bool current: gameGrid.currentIndex === index
+
+            width: 196 * root.uiScale
+            height: 330 * root.uiScale
+            scale: current ? 1.035 : 1
+            z: current ? 2 : 1
+            Accessible.name: title
+            Accessible.role: Accessible.ListItem
+
+            Behavior on scale {
+                enabled: !Preferences.reducedMotion
+                NumberAnimation { duration: 120; easing.type: Easing.OutCubic }
+            }
+
+            Component.onCompleted: {
+                if (coverPath.length === 0) {
+                    root.coverRequested(source, appId)
+                }
+            }
+
+            Rectangle {
+                anchors.fill: parent
+                radius: Math.max(12 * root.uiScale, Theme.cornerRadius * 1.5)
+                color: root.alpha(Theme.background, gridCard.current ? 0.90 : 0.58)
+                border.width: gridCard.current ? 4 * root.uiScale : 1
+                border.color: gridCard.current
+                              ? Theme.accent : root.alpha(Theme.foreground, 0.14)
+
+                Rectangle {
+                    anchors.fill: parent
+                    anchors.margins: gridCard.current ? 7 * root.uiScale : 0
+                    radius: Math.max(8 * root.uiScale, Theme.cornerRadius)
+                    visible: gridCard.current
+                    color: "transparent"
+                    border.width: 1
+                    border.color: root.alpha(Theme.brightForeground, 0.46)
+                }
+            }
+
+            Rectangle {
+                id: gridCover
+                anchors.top: parent.top
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.margins: 10 * root.uiScale
+                height: 258 * root.uiScale
+                radius: Math.max(8 * root.uiScale, Theme.cornerRadius)
+                clip: true
+                gradient: Gradient {
+                    GradientStop { position: 0; color: gridCard.accentStart }
+                    GradientStop { position: 1; color: gridCard.accentEnd }
+                }
+
+                Image {
+                    anchors.fill: parent
+                    source: gridCard.coverPath
+                    asynchronous: true
+                    cache: false
+                    fillMode: Image.PreserveAspectCrop
+                    sourceSize.width: Math.ceil(width * Math.max(1, Screen.devicePixelRatio) / 64) * 64
+                    sourceSize.height: Math.ceil(height * Math.max(1, Screen.devicePixelRatio) / 64) * 64
+                }
+
+                Text {
+                    anchors.centerIn: parent
+                    visible: gridCard.coverPath.length === 0
+                    text: gridCard.coverMark
+                    color: root.alpha(Theme.brightForeground, 0.88)
+                    font.family: Theme.fontFamily
+                    font.pixelSize: 48 * root.uiScale
+                }
+
+                Rectangle {
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    height: gridCard.current ? 10 * root.uiScale : 4 * root.uiScale
+                    color: gridCard.current ? Theme.accent
+                                            : root.alpha(Theme.brightForeground, 0.20)
+                }
+
+                Rectangle {
+                    visible: gridCard.favorite
+                    anchors.top: parent.top
+                    anchors.right: parent.right
+                    anchors.margins: 10 * root.uiScale
+                    width: 32 * root.uiScale
+                    height: width
+                    radius: width / 2
+                    color: root.alpha(Theme.darkerBackground, 0.82)
+                    border.color: root.alpha(Theme.brightForeground, 0.28)
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: "♥"
+                        color: Theme.brightForeground
+                        font.pixelSize: 14 * root.uiScale
+                    }
+                }
+
+                Rectangle {
+                    visible: gridCard.current
+                    anchors.left: parent.left
+                    anchors.top: parent.top
+                    anchors.margins: 10 * root.uiScale
+                    width: selectedText.implicitWidth + 16 * root.uiScale
+                    height: 28 * root.uiScale
+                    radius: height / 2
+                    color: Theme.accent
+
+                    Text {
+                        id: selectedText
+                        anchors.centerIn: parent
+                        text: "SELECTED"
+                        color: Theme.darkerBackground
+                        font.family: Theme.fontFamily
+                        font.pixelSize: 10 * root.uiScale
+                        font.weight: Font.Bold
+                        font.letterSpacing: 0.8
+                    }
+                }
+            }
+
+            Text {
+                anchors.top: gridCover.bottom
+                anchors.topMargin: 10 * root.uiScale
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: 11 * root.uiScale
+                anchors.rightMargin: 11 * root.uiScale
+                text: gridCard.title
+                textFormat: Text.PlainText
+                color: gridCard.current ? Theme.brightForeground : Theme.foreground
+                font.family: Theme.fontFamily
+                font.pixelSize: 16 * root.uiScale
+                font.weight: gridCard.current ? Font.Bold : Font.DemiBold
+                elide: Text.ElideRight
+            }
+
+            Text {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                anchors.leftMargin: 11 * root.uiScale
+                anchors.rightMargin: 11 * root.uiScale
+                anchors.bottomMargin: 8 * root.uiScale
+                text: (gridCard.source || gridCard.subtitle || "LIBRARY").toUpperCase()
+                textFormat: Text.PlainText
+                color: gridCard.current ? Theme.accent : Theme.mutedText
+                font.family: Theme.fontFamily
+                font.pixelSize: 10 * root.uiScale
+                font.weight: Font.DemiBold
+                font.letterSpacing: 0.8
+                elide: Text.ElideRight
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    gameGrid.currentIndex = gridCard.index
+                    gameGrid.forceActiveFocus(Qt.MouseFocusReason)
+                }
+                onDoubleClicked: root.gameActivated(gridCard.index)
+            }
+
+            opacity: gridCard.current ? 1 : 0.72
+            Behavior on opacity {
+                enabled: !Preferences.reducedMotion
+                NumberAnimation { duration: 100 }
             }
         }
     }

--- a/qml/components/CouchLibraryView.qml
+++ b/qml/components/CouchLibraryView.qml
@@ -20,6 +20,7 @@ FocusScope {
         { label: "BATTLE.NET", value: "Battle.net", enabled: Preferences.battleNetEnabled },
         { label: "LUTRIS", value: "Lutris", enabled: Preferences.lutrisEnabled },
         { label: "HEROIC", value: "Heroic", enabled: Preferences.heroicEnabled },
+        { label: "GOG", value: "GOG", enabled: Preferences.gogEnabled },
         { label: "FAUGUS", value: "Faugus", enabled: Preferences.faugusEnabled },
         { label: "RETROARCH", value: "RetroArch", enabled: Preferences.retroArchEnabled },
         { label: "PCSX2", value: "PCSX2", enabled: Preferences.pcsx2Enabled },

--- a/qml/components/GlassButton.qml
+++ b/qml/components/GlassButton.qml
@@ -25,6 +25,7 @@ Button {
     rightPadding: leftPadding
     spacing: 8 * displayScale
     focusPolicy: Qt.StrongFocus
+    KeyNavigation.priority: KeyNavigation.BeforeItem
 
     // Qt only presses a Button on Return or Enter when the platform theme says so. Controller
     // and keyboard confirm must work on every desktop, so handle both keys here.

--- a/qml/screens/GameDetails.qml
+++ b/qml/screens/GameDetails.qml
@@ -433,6 +433,7 @@ Item {
                         visible: root.selectedInstallation.source === "Steam"
                                  || root.selectedInstallation.source === "Lutris"
                                  || root.selectedInstallation.source === "Heroic"
+                                 || root.selectedInstallation.source === "GOG"
                                  || root.selectedInstallation.source === "Faugus"
                                  || root.selectedInstallation.source === "RetroArch"
                                  || root.selectedInstallation.source === "PCSX2"

--- a/src/app/AppSettings.cpp
+++ b/src/app/AppSettings.cpp
@@ -197,6 +197,18 @@ void AppSettings::setCouchModeEnabled(bool value) {
   emit couchModeEnabledChanged();
 }
 
+QString AppSettings::couchLibraryView() const { return m_couchLibraryView; }
+
+void AppSettings::setCouchLibraryView(const QString& value) {
+  const QString normalized = value == QStringLiteral("grid") ? value : QStringLiteral("detail");
+  if (m_couchLibraryView == normalized) {
+    return;
+  }
+  m_couchLibraryView = normalized;
+  save();
+  emit couchLibraryViewChanged();
+}
+
 QString AppSettings::defaultPath() {
   return QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) +
          QStringLiteral("/omakade/config.toml");
@@ -259,6 +271,12 @@ void AppSettings::load() {
   m_battleNetEnabled = readEnabled(QStringLiteral("battlenet_enabled"), true);
   m_closeAfterLaunch = readEnabled(QStringLiteral("close_after_launch"), false);
   m_couchModeEnabled = readEnabled(QStringLiteral("couch_mode_enabled"), false);
+  const QRegularExpression couchLibraryView(
+      QStringLiteral("(?m)^couch_library_view\\s*=\\s*\"(detail|grid)\"\\s*$"));
+  const QRegularExpressionMatch couchLibraryViewMatch = couchLibraryView.match(contents);
+  if (couchLibraryViewMatch.hasMatch()) {
+    m_couchLibraryView = couchLibraryViewMatch.captured(1);
+  }
   m_sunshineOmakadeApp = readEnabled(QStringLiteral("sunshine_omakade_app"), false);
   m_sunshineGameApps = readEnabled(QStringLiteral("sunshine_game_apps"), false);
 }
@@ -321,9 +339,11 @@ void AppSettings::save() const {
   }
   contents += QStringLiteral("close_after_launch = %1\n"
                              "couch_mode_enabled = %2\n"
-                             "sunshine_omakade_app = %3\nsunshine_game_apps = %4\n")
+                             "couch_library_view = \"%3\"\n"
+                             "sunshine_omakade_app = %4\nsunshine_game_apps = %5\n")
                   .arg(m_closeAfterLaunch ? QStringLiteral("true") : QStringLiteral("false"))
                   .arg(m_couchModeEnabled ? QStringLiteral("true") : QStringLiteral("false"))
+                  .arg(m_couchLibraryView)
                   .arg(m_sunshineOmakadeApp ? QStringLiteral("true") : QStringLiteral("false"))
                   .arg(m_sunshineGameApps ? QStringLiteral("true") : QStringLiteral("false"));
   file.write(contents.toUtf8());

--- a/src/app/AppSettings.cpp
+++ b/src/app/AppSettings.cpp
@@ -108,6 +108,17 @@ void AppSettings::setHeroicEnabled(bool value) {
   emit sourcesChanged();
 }
 
+bool AppSettings::gogEnabled() const { return m_gogEnabled; }
+
+void AppSettings::setGogEnabled(bool value) {
+  if (m_gogEnabled == value) {
+    return;
+  }
+  m_gogEnabled = value;
+  save();
+  emit sourcesChanged();
+}
+
 bool AppSettings::faugusEnabled() const { return m_faugusEnabled; }
 
 void AppSettings::setFaugusEnabled(bool value) {
@@ -258,6 +269,7 @@ void AppSettings::load() {
   m_steamEnabled = readEnabled(QStringLiteral("steam_enabled"), true);
   m_lutrisEnabled = readEnabled(QStringLiteral("lutris_enabled"), true);
   m_heroicEnabled = readEnabled(QStringLiteral("heroic_enabled"), true);
+  m_gogEnabled = readEnabled(QStringLiteral("gog_enabled"), true);
   m_faugusEnabled = readEnabled(QStringLiteral("faugus_enabled"), true);
   m_retroArchEnabled = readEnabled(QStringLiteral("retroarch_enabled"), true);
   const QRegularExpression pcsx2Key(
@@ -316,8 +328,8 @@ void AppSettings::save() const {
       QStringLiteral("reduced_motion = %1\nartwork_cache_limit_mb = %2\nsteam_id = \"%3\"\n"
                      "igdb_client_id = \"%4\"\nretroachievements_username = \"%5\"\n"
                      "steam_enabled = %6\nlutris_enabled = %7\nheroic_enabled = %8\n"
-                     "faugus_enabled = %9\nretroarch_enabled = %10\n"
-                     "battlenet_enabled = %11\n")
+                     "gog_enabled = %9\nfaugus_enabled = %10\nretroarch_enabled = %11\n"
+                     "battlenet_enabled = %12\n")
           .arg(m_reducedMotion ? QStringLiteral("true") : QStringLiteral("false"))
           .arg(m_artworkCacheLimitMb)
           .arg(m_steamId)
@@ -326,6 +338,7 @@ void AppSettings::save() const {
           .arg(m_steamEnabled ? QStringLiteral("true") : QStringLiteral("false"))
           .arg(m_lutrisEnabled ? QStringLiteral("true") : QStringLiteral("false"))
           .arg(m_heroicEnabled ? QStringLiteral("true") : QStringLiteral("false"))
+          .arg(m_gogEnabled ? QStringLiteral("true") : QStringLiteral("false"))
           .arg(m_faugusEnabled ? QStringLiteral("true") : QStringLiteral("false"))
           .arg(m_retroArchEnabled ? QStringLiteral("true") : QStringLiteral("false"))
           .arg(m_battleNetEnabled ? QStringLiteral("true") : QStringLiteral("false"));

--- a/src/app/AppSettings.h
+++ b/src/app/AppSettings.h
@@ -28,6 +28,8 @@ class AppSettings final : public QObject {
                  closeAfterLaunchChanged)
   Q_PROPERTY(bool couchModeEnabled READ couchModeEnabled WRITE setCouchModeEnabled NOTIFY
                  couchModeEnabledChanged)
+  Q_PROPERTY(QString couchLibraryView READ couchLibraryView WRITE setCouchLibraryView NOTIFY
+                 couchLibraryViewChanged)
   Q_PROPERTY(bool sunshineOmakadeApp READ sunshineOmakadeApp WRITE setSunshineOmakadeApp NOTIFY
                  sunshineChanged)
   Q_PROPERTY(bool sunshineGameApps READ sunshineGameApps WRITE setSunshineGameApps NOTIFY
@@ -72,6 +74,8 @@ public:
   void setCloseAfterLaunch(bool value);
   [[nodiscard]] bool couchModeEnabled() const;
   void setCouchModeEnabled(bool value);
+  [[nodiscard]] QString couchLibraryView() const;
+  void setCouchLibraryView(const QString& value);
   [[nodiscard]] bool sunshineOmakadeApp() const;
   void setSunshineOmakadeApp(bool value);
   [[nodiscard]] bool sunshineGameApps() const;
@@ -86,6 +90,7 @@ signals:
   void sourcesChanged();
   void closeAfterLaunchChanged();
   void couchModeEnabledChanged();
+  void couchLibraryViewChanged();
   void sunshineChanged();
 
 private:
@@ -111,6 +116,7 @@ private:
   bool m_battleNetEnabled = true;
   bool m_closeAfterLaunch = false;
   bool m_couchModeEnabled = false;
+  QString m_couchLibraryView = QStringLiteral("detail");
   bool m_sunshineOmakadeApp = false;
   bool m_sunshineGameApps = false;
 };

--- a/src/app/AppSettings.h
+++ b/src/app/AppSettings.h
@@ -17,6 +17,7 @@ class AppSettings final : public QObject {
   Q_PROPERTY(bool steamEnabled READ steamEnabled WRITE setSteamEnabled NOTIFY sourcesChanged)
   Q_PROPERTY(bool lutrisEnabled READ lutrisEnabled WRITE setLutrisEnabled NOTIFY sourcesChanged)
   Q_PROPERTY(bool heroicEnabled READ heroicEnabled WRITE setHeroicEnabled NOTIFY sourcesChanged)
+  Q_PROPERTY(bool gogEnabled READ gogEnabled WRITE setGogEnabled NOTIFY sourcesChanged)
   Q_PROPERTY(bool faugusEnabled READ faugusEnabled WRITE setFaugusEnabled NOTIFY sourcesChanged)
   Q_PROPERTY(
       bool retroArchEnabled READ retroArchEnabled WRITE setRetroArchEnabled NOTIFY sourcesChanged)
@@ -54,6 +55,8 @@ public:
   void setLutrisEnabled(bool value);
   [[nodiscard]] bool heroicEnabled() const;
   void setHeroicEnabled(bool value);
+  [[nodiscard]] bool gogEnabled() const;
+  void setGogEnabled(bool value);
   [[nodiscard]] bool faugusEnabled() const;
   void setFaugusEnabled(bool value);
   [[nodiscard]] bool retroArchEnabled() const;
@@ -107,6 +110,7 @@ private:
   bool m_steamEnabled = true;
   bool m_lutrisEnabled = true;
   bool m_heroicEnabled = true;
+  bool m_gogEnabled = true;
   bool m_faugusEnabled = true;
   bool m_retroArchEnabled = true;
   bool m_pcsx2Enabled = false;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -765,6 +765,18 @@ int main(int argc, char* argv[]) {
             fail(QStringLiteral("Couch layout control did not activate the persistent grid"));
             return;
           }
+          controller.toolbarRequested();
+          QCoreApplication::processEvents();
+          if (!layout->hasActiveFocus()) {
+            fail(QStringLiteral("Controller Controls did not reach the Grid layout action"));
+            return;
+          }
+          controller.toolbarRequested();
+          QCoreApplication::processEvents();
+          if (!grid->hasActiveFocus()) {
+            fail(QStringLiteral("Controller Controls did not return to the game grid"));
+            return;
+          }
           const int gridColumns = grid->property("columnCount").toInt();
           grid->setProperty("currentIndex", gridColumns + 1);
           sendKey(Qt::Key_Up);

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -4,6 +4,7 @@
 #include "app/AppSettings.h"
 #include "app/SingleInstance.h"
 #include "input/ControllerInput.h"
+#include "input/CouchCursorManager.h"
 #include "launch/GameLauncher.h"
 #include "launch/PlayRequest.h"
 #include "streaming/SunshineIntegration.h"
@@ -526,6 +527,18 @@ int main(int argc, char* argv[]) {
 
   auto* rootWindow = qobject_cast<QWindow*>(engine.rootObjects().constFirst());
   if (rootWindow != nullptr) {
+    auto* couchCursor = new CouchCursorManager(rootWindow, 1600, rootWindow);
+    couchCursor->setObjectName(QStringLiteral("couchCursorManager"));
+    QObject::connect(rootWindow, SIGNAL(couchModeChanged()), couchCursor,
+                     SLOT(syncCouchMode()));
+    QObject::connect(&controller, &ControllerInput::keyRequested, couchCursor,
+                     &CouchCursorManager::navigationActivity);
+    QObject::connect(&controller, &ControllerInput::focusDirectionRequested, couchCursor,
+                     &CouchCursorManager::navigationActivity);
+    QObject::connect(&controller, &ControllerInput::favoriteRequested, couchCursor,
+                     &CouchCursorManager::navigationActivity);
+    QObject::connect(&controller, &ControllerInput::toolbarRequested, couchCursor,
+                     &CouchCursorManager::navigationActivity);
     QObject::connect(&controller, &ControllerInput::keyRequested, rootWindow,
                      [&application, rootWindow](int key, int modifiers) {
                        QWindow* target = application.focusWindow();
@@ -652,6 +665,8 @@ int main(int argc, char* argv[]) {
           application.exit(EXIT_FAILURE);
         };
         auto* couch = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchLibrary"));
+        auto* couchCursor =
+            quickWindow->findChild<QObject*>(QStringLiteral("couchCursorManager"));
         auto* strip = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchGameStrip"));
         auto* grid = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchGameGrid"));
         auto* view = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchViewButton"));
@@ -686,6 +701,7 @@ int main(int argc, char* argv[]) {
         QObject* preferences =
             qmlContext(quickWindow)->contextProperty(QStringLiteral("Preferences")).value<QObject*>();
         if (!quickWindow->property("couchMode").toBool() || couch == nullptr ||
+            couchCursor == nullptr ||
             !couch->isVisible() || strip == nullptr || grid == nullptr || view == nullptr ||
             all == nullptr || favorites == nullptr || recent == nullptr || layout == nullptr ||
             favorite == nullptr || settings == nullptr ||
@@ -703,13 +719,17 @@ int main(int argc, char* argv[]) {
         strip->forceActiveFocus();
         controller.keyRequested(Qt::Key_Right, Qt::NoModifier);
         QTimer::singleShot(50, quickWindow,
-                           [quickWindow, &application, &controller, couch, strip, grid, view, all,
-                            favorites, recent, layout, favorite, browse, browsePanel,
+                           [quickWindow, &application, &controller, couch, couchCursor, strip, grid,
+                            view, all, favorites, recent, layout, favorite, browse, browsePanel,
                             browseCategories, browseOptions, search, settings, settingsScroll,
                             keyboard, keyboardGrid, textEntryKeyboard, textEntryGrid, desktopSearch,
                             preferences, fail] {
           if (!strip->hasActiveFocus() || strip->property("currentIndex").toInt() != 1) {
             fail(QStringLiteral("Controller Right did not advance the couch game strip"));
+            return;
+          }
+          if (!couchCursor->property("cursorHidden").toBool()) {
+            fail(QStringLiteral("Controller navigation did not hide the couch cursor"));
             return;
           }
           const auto sendKey = [&controller](int key) {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -738,6 +738,38 @@ int main(int argc, char* argv[]) {
             QTimer::singleShot(30, &eventLoop, &QEventLoop::quit);
             eventLoop.exec();
           };
+          auto* emptyState = couch->findChild<QQuickItem*>(QStringLiteral("couchEmptyState"));
+          QObject* regressionLibrary =
+              qmlContext(quickWindow)->contextProperty(QStringLiteral("Library")).value<QObject*>();
+          if (emptyState == nullptr || regressionLibrary == nullptr) {
+            fail(QStringLiteral("Couch regression fixtures were not available"));
+            return;
+          }
+          strip->setProperty("currentIndex", 7);
+          for (const QString& layoutName : {QStringLiteral("grid"), QStringLiteral("detail")}) {
+            QMetaObject::invokeMethod(couch, "toggleLibraryView");
+            QCoreApplication::processEvents();
+            QQuickItem* activeView = layoutName == QStringLiteral("grid") ? grid : strip;
+            if (activeView->property("currentIndex").toInt() != 7 ||
+                couch->property("currentIndex").toInt() != 7 || !activeView->hasActiveFocus()) {
+              fail(QStringLiteral("Couch layout switch lost selection or focus in %1").arg(layoutName));
+              return;
+            }
+          }
+          regressionLibrary->setProperty("searchText", QStringLiteral("omakade-no-matching-game-regression"));
+          QCoreApplication::processEvents();
+          if (!emptyState->isVisible()) {
+            fail(QStringLiteral("Empty couch library did not show its empty state"));
+            return;
+          }
+          regressionLibrary->setProperty("searchText", QString{});
+          QCoreApplication::processEvents();
+          if (emptyState->isVisible()) {
+            fail(QStringLiteral("Populated couch library retained its empty state"));
+            return;
+          }
+          strip->setProperty("currentIndex", 1);
+          strip->forceActiveFocus();
           const auto focusDescription = [quickWindow] {
             QQuickItem* focused = quickWindow->activeFocusItem();
             QStringList chain;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -297,6 +297,7 @@ int main(int argc, char* argv[]) {
     unifiedGames.setSourceEnabled(QStringLiteral("Steam"), preferences.steamEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("Lutris"), preferences.lutrisEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("Heroic"), preferences.heroicEnabled());
+    unifiedGames.setSourceEnabled(QStringLiteral("GOG"), preferences.gogEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("Faugus"), preferences.faugusEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("RetroArch"), preferences.retroArchEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("PCSX2"), preferences.pcsx2Enabled());
@@ -332,6 +333,10 @@ int main(int argc, char* argv[]) {
         refreshStarted = true;
       } else if (key.source.compare(QStringLiteral("Heroic"), Qt::CaseInsensitive) == 0 &&
                  heroicLibrary != nullptr && preferences.heroicEnabled()) {
+        heroicLibrary->refresh();
+        refreshStarted = true;
+      } else if (key.source.compare(QStringLiteral("GOG"), Qt::CaseInsensitive) == 0 &&
+                 heroicLibrary != nullptr && preferences.gogEnabled()) {
         heroicLibrary->refresh();
         refreshStarted = true;
       } else if (key.source.compare(QStringLiteral("Faugus"), Qt::CaseInsensitive) == 0 &&
@@ -1182,7 +1187,7 @@ int main(int argc, char* argv[]) {
                   fail(QStringLiteral("Focused source filter was not revealed"));
                   return;
                 }
-                for (int step = 0; step < 6; ++step) {
+                for (int step = 0; step < 7; ++step) {
                   controller.focusDirectionRequested(Qt::Key_Left);
                 }
                 controller.focusDirectionRequested(Qt::Key_Up);
@@ -1216,7 +1221,7 @@ int main(int argc, char* argv[]) {
                 fail(QStringLiteral("Controller Down did not reach source filters"));
                 return;
               }
-              for (int step = 0; step < 6; ++step) {
+              for (int step = 0; step < 7; ++step) {
                 controller.focusDirectionRequested(Qt::Key_Left);
               }
               if (!allSources->hasActiveFocus()) {
@@ -1722,7 +1727,7 @@ int main(int argc, char* argv[]) {
   if (lutrisLibrary != nullptr && preferences.lutrisEnabled()) {
     QTimer::singleShot(150, lutrisLibrary, &LutrisGameModel::refresh);
   }
-  if (heroicLibrary != nullptr && preferences.heroicEnabled()) {
+  if (heroicLibrary != nullptr && (preferences.heroicEnabled() || preferences.gogEnabled())) {
     QTimer::singleShot(300, heroicLibrary, &HeroicGameModel::refresh);
   }
   if (faugusLibrary != nullptr && preferences.faugusEnabled()) {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -150,6 +150,8 @@ int main(int argc, char* argv[]) {
   const QString screenshotPath =
       optionValue(application.arguments(), QStringLiteral("--render-screenshot"));
   const QString renderSize = optionValue(application.arguments(), QStringLiteral("--render-size"));
+  const QString renderOverlay =
+      optionValue(application.arguments(), QStringLiteral("--render-overlay"));
   // `--play Source:runner:id` launches one library game, through the running window when
   // there is one, and `--quit` closes the running window. Sunshine app entries use both.
   const QString playKey = optionValue(application.arguments(), QStringLiteral("--play"));
@@ -462,19 +464,6 @@ int main(int argc, char* argv[]) {
         QStringLiteral(":/icons/resources/icons/io.github.tsouth89.Omakade.svg"));
   }
 
-  QObject::connect(&controller, &ControllerInput::keyRequested, &application,
-                   [&application](int key, int modifiers) {
-                     QWindow* window = application.focusWindow();
-                     if (window == nullptr) {
-                       return;
-                     }
-                     const auto keyboardModifiers = static_cast<Qt::KeyboardModifiers>(modifiers);
-                     QCoreApplication::postEvent(
-                         window, new QKeyEvent(QEvent::KeyPress, key, keyboardModifiers));
-                     QCoreApplication::postEvent(
-                         window, new QKeyEvent(QEvent::KeyRelease, key, keyboardModifiers));
-                   });
-
   QQmlApplicationEngine engine;
   QObject::connect(&engine, &QQmlApplicationEngine::warnings, [](const QList<QQmlError>& warnings) {
     for (const QQmlError& warning : warnings) {
@@ -510,6 +499,9 @@ int main(int argc, char* argv[]) {
                                            ownedLayoutTest ? 250 : 0);
   engine.rootContext()->setContextProperty(QStringLiteral("CouchModeRequested"),
                                            startInCouchMode);
+  engine.rootContext()->setContextProperty(
+      QStringLiteral("CouchLibraryViewOverride"),
+      renderOverlay == QStringLiteral("couch-grid") ? QStringLiteral("grid") : QString{});
 
   QObject::connect(
       &engine, &QQmlApplicationEngine::objectCreationFailed, &application,
@@ -528,6 +520,24 @@ int main(int argc, char* argv[]) {
   }
 
   auto* rootWindow = qobject_cast<QWindow*>(engine.rootObjects().constFirst());
+  if (rootWindow != nullptr) {
+    QObject::connect(&controller, &ControllerInput::keyRequested, rootWindow,
+                     [&application, rootWindow](int key, int modifiers) {
+                       QWindow* target = application.focusWindow();
+                       if (target == nullptr) {
+                         // A freshly shown fullscreen window may not have compositor focus yet.
+                         // Controller input must still enter Omakade instead of being discarded.
+                         target = rootWindow;
+                         rootWindow->requestActivate();
+                       }
+                       const auto keyboardModifiers =
+                           static_cast<Qt::KeyboardModifiers>(modifiers);
+                       QKeyEvent press(QEvent::KeyPress, key, keyboardModifiers);
+                       QKeyEvent release(QEvent::KeyRelease, key, keyboardModifiers);
+                       QCoreApplication::sendEvent(target, &press);
+                       QCoreApplication::sendEvent(target, &release);
+                     });
+  }
   if (rootWindow != nullptr && startInCouchMode && !renderMode && !navigationTest && !smokeTest) {
     // Couch mode fills the chosen display. Sunshine selects its configured output first.
     const QList<QScreen*> screens = QGuiApplication::screens();
@@ -545,20 +555,26 @@ int main(int argc, char* argv[]) {
     }
     rootWindow->showFullScreen();
   }
+  if (rootWindow != nullptr && !renderMode && !navigationTest) {
+    const auto activateWindow = [rootWindow] {
+      rootWindow->requestActivate();
+      QMetaObject::invokeMethod(rootWindow, "focusCurrentSurface");
+    };
+    QTimer::singleShot(0, rootWindow, activateWindow);
+    QTimer::singleShot(160, rootWindow, activateWindow);
+  }
   if (auto* quickWindow = qobject_cast<QQuickWindow*>(rootWindow)) {
     if ((renderMode || navigationTest) && requestedRenderSize.isValid()) {
       quickWindow->resize(requestedRenderSize);
     }
     if (renderMode) {
       // `--render-overlay=settings|picker` opens an overlay so visual checks can cover it.
-      const QString overlay =
-          optionValue(application.arguments(), QStringLiteral("--render-overlay"));
-      if (overlay == QStringLiteral("settings") ||
-          overlay == QStringLiteral("couch-settings-top") ||
-          overlay == QStringLiteral("couch-settings-bottom")) {
+      if (renderOverlay == QStringLiteral("settings") ||
+          renderOverlay == QStringLiteral("couch-settings-top") ||
+          renderOverlay == QStringLiteral("couch-settings-bottom")) {
         quickWindow->setProperty("diagnosticsOpen", true);
-        if (overlay == QStringLiteral("settings") ||
-            overlay == QStringLiteral("couch-settings-bottom")) {
+        if (renderOverlay == QStringLiteral("settings") ||
+            renderOverlay == QStringLiteral("couch-settings-bottom")) {
           QTimer::singleShot(400, quickWindow, [quickWindow] {
             // Scroll to the end so the lower sections land in the capture.
             auto* scroll = quickWindow->findChild<QQuickItem*>(QStringLiteral("settingsScroll"));
@@ -570,21 +586,21 @@ int main(int argc, char* argv[]) {
             }
           });
         }
-      } else if (overlay == QStringLiteral("picker")) {
+      } else if (renderOverlay == QStringLiteral("picker")) {
         QMetaObject::invokeMethod(
             quickWindow, "openFilterPicker", Q_ARG(QVariant, QStringLiteral("collection")),
             Q_ARG(QVariant, QVariant(QStringList{QStringLiteral("Couch co-op"),
                                                  QStringLiteral("Cozy evenings"),
                                                  QStringLiteral("Finish this year")})));
-      } else if (overlay == QStringLiteral("couch-search")) {
+      } else if (renderOverlay == QStringLiteral("couch-search")) {
         if (auto* couch = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchLibrary"))) {
           QMetaObject::invokeMethod(couch, "openSearch");
         }
-      } else if (overlay == QStringLiteral("couch-browse")) {
+      } else if (renderOverlay == QStringLiteral("couch-browse")) {
         if (auto* couch = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchLibrary"))) {
           QMetaObject::invokeMethod(couch, "openBrowse");
         }
-      } else if (overlay == QStringLiteral("couch-entry")) {
+      } else if (renderOverlay == QStringLiteral("couch-entry")) {
         if (auto* target = quickWindow->findChild<QQuickItem*>(QStringLiteral("searchField"))) {
           target->setProperty("text", QStringLiteral("Secret-42!"));
           QMetaObject::invokeMethod(
@@ -607,10 +623,12 @@ int main(int argc, char* argv[]) {
     QObject::connect(
         quickWindow, &QQuickWindow::frameSwapped, &application,
         [&application, &controller, &startupTimer, benchmarkMode, benchmarkLimitSupplied,
-         benchmarkMaxMs] {
+         benchmarkMaxMs, renderMode, navigationTest, smokeTest] {
           const qint64 firstFrameMs = startupTimer.elapsed();
           qInfo() << "First frame in" << firstFrameMs << "ms";
-          controller.start();
+          if (!renderMode && !navigationTest && !smokeTest && !benchmarkMode) {
+            controller.start();
+          }
           if (benchmarkMode) {
             if (benchmarkLimitSupplied && firstFrameMs > benchmarkMaxMs) {
               qCritical() << "First frame exceeded benchmark limit of" << benchmarkMaxMs << "ms";
@@ -630,7 +648,13 @@ int main(int argc, char* argv[]) {
         };
         auto* couch = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchLibrary"));
         auto* strip = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchGameStrip"));
+        auto* grid = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchGameGrid"));
         auto* view = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchViewButton"));
+        auto* all = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchAllButton"));
+        auto* favorites =
+            quickWindow->findChild<QQuickItem*>(QStringLiteral("couchFavoritesFilterButton"));
+        auto* recent = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchRecentButton"));
+        auto* layout = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchLayoutButton"));
         auto* favorite =
             quickWindow->findChild<QQuickItem*>(QStringLiteral("couchFavoriteButton"));
         auto* settings =
@@ -654,9 +678,13 @@ int main(int argc, char* argv[]) {
             quickWindow->findChild<QQuickItem*>(QStringLiteral("couchTextEntryGrid"));
         auto* desktopSearch =
             quickWindow->findChild<QQuickItem*>(QStringLiteral("searchField"));
+        QObject* preferences =
+            qmlContext(quickWindow)->contextProperty(QStringLiteral("Preferences")).value<QObject*>();
         if (!quickWindow->property("couchMode").toBool() || couch == nullptr ||
-            !couch->isVisible() || strip == nullptr || view == nullptr || favorite == nullptr ||
-            settings == nullptr || settingsScroll == nullptr || search == nullptr ||
+            !couch->isVisible() || strip == nullptr || grid == nullptr || view == nullptr ||
+            all == nullptr || favorites == nullptr || recent == nullptr || layout == nullptr ||
+            favorite == nullptr || settings == nullptr ||
+            settingsScroll == nullptr || search == nullptr || preferences == nullptr ||
             browse == nullptr ||
             browsePanel == nullptr || browseCategories == nullptr || browseOptions == nullptr ||
             keyboard == nullptr || keyboardGrid == nullptr || textEntryKeyboard == nullptr ||
@@ -664,14 +692,17 @@ int main(int argc, char* argv[]) {
           fail(QStringLiteral("Couch navigation test could not find the couch controls"));
           return;
         }
+        preferences->setProperty("couchLibraryView", QStringLiteral("detail"));
+        QCoreApplication::processEvents();
         strip->setProperty("currentIndex", 0);
         strip->forceActiveFocus();
         controller.keyRequested(Qt::Key_Right, Qt::NoModifier);
         QTimer::singleShot(50, quickWindow,
-                           [quickWindow, &application, &controller, couch, strip, view, favorite,
-                            browse, browsePanel, browseCategories, browseOptions, search, settings,
-                            settingsScroll, keyboard, keyboardGrid, textEntryKeyboard,
-                            textEntryGrid, desktopSearch, fail] {
+                           [quickWindow, &application, &controller, couch, strip, grid, view, all,
+                            favorites, recent, layout, favorite, browse, browsePanel,
+                            browseCategories, browseOptions, search, settings, settingsScroll,
+                            keyboard, keyboardGrid, textEntryKeyboard, textEntryGrid, desktopSearch,
+                            preferences, fail] {
           if (!strip->hasActiveFocus() || strip->property("currentIndex").toInt() != 1) {
             fail(QStringLiteral("Controller Right did not advance the couch game strip"));
             return;
@@ -681,6 +712,17 @@ int main(int argc, char* argv[]) {
             QEventLoop eventLoop;
             QTimer::singleShot(30, &eventLoop, &QEventLoop::quit);
             eventLoop.exec();
+          };
+          const auto focusDescription = [quickWindow] {
+            QQuickItem* focused = quickWindow->activeFocusItem();
+            QStringList chain;
+            while (focused != nullptr && chain.size() < 5) {
+              chain.append(QStringLiteral("%1[%2]")
+                               .arg(QString::fromLatin1(focused->metaObject()->className()),
+                                    focused->objectName()));
+              focused = focused->parentItem();
+            }
+            return chain.isEmpty() ? QStringLiteral("none") : chain.join(QStringLiteral(" <- "));
           };
           sendKey(Qt::Key_Up);
           if (!view->hasActiveFocus()) {
@@ -705,12 +747,43 @@ int main(int argc, char* argv[]) {
             return;
           }
           sendKey(Qt::Key_Up);
-          for (int step = 0; step < 3; ++step) {
-            sendKey(Qt::Key_Right);
+          const QList<QQuickItem*> detailToolbarPath = {all, favorites, recent, layout};
+          for (int step = 0; step < detailToolbarPath.size(); ++step) {
+            if (!detailToolbarPath.at(step)->hasActiveFocus()) {
+              fail(QStringLiteral("Controller detail toolbar step %1 failed; focus=%2")
+                       .arg(step)
+                       .arg(focusDescription()));
+              return;
+            }
+            if (step + 1 < detailToolbarPath.size()) {
+              sendKey(Qt::Key_Right);
+            }
           }
-          if (!browse->hasActiveFocus()) {
-            fail(QStringLiteral("Controller could not reach couch Browse"));
+          sendKey(Qt::Key_Return);
+          if (!grid->isVisible() || !grid->hasActiveFocus() ||
+              preferences->property("couchLibraryView").toString() != QStringLiteral("grid")) {
+            fail(QStringLiteral("Couch layout control did not activate the persistent grid"));
             return;
+          }
+          const int gridColumns = grid->property("columnCount").toInt();
+          grid->setProperty("currentIndex", gridColumns + 1);
+          sendKey(Qt::Key_Up);
+          if (!grid->hasActiveFocus() || grid->property("currentIndex").toInt() != 1) {
+            fail(QStringLiteral("Controller Grid Up did not move to the previous game row"));
+            return;
+          }
+          sendKey(Qt::Key_Up);
+          const QList<QQuickItem*> toolbarPath = {all, favorites, recent, layout, browse};
+          for (int step = 0; step < toolbarPath.size(); ++step) {
+            if (!toolbarPath.at(step)->hasActiveFocus()) {
+              fail(QStringLiteral("Controller grid toolbar step %1 failed; focus=%2")
+                       .arg(step)
+                       .arg(focusDescription()));
+              return;
+            }
+            if (step + 1 < toolbarPath.size()) {
+              sendKey(Qt::Key_Right);
+            }
           }
           sendKey(Qt::Key_Return);
           if (!couch->property("browseOpen").toBool() || !browsePanel->isVisible() ||
@@ -753,11 +826,9 @@ int main(int argc, char* argv[]) {
             return;
           }
           sendKey(Qt::Key_F11);
-          QObject* preferences =
-              qmlContext(quickWindow)->contextProperty(QStringLiteral("Preferences")).value<QObject*>();
           if (quickWindow->property("couchMode").toBool() ||
               couch->property("searchOpen").toBool() || keyboard->isVisible() ||
-              preferences == nullptr || preferences->property("couchModeEnabled").toBool()) {
+              preferences->property("couchModeEnabled").toBool()) {
             fail(QStringLiteral("Leaving Couch Mode did not cancel Search cleanly"));
             return;
           }
@@ -979,8 +1050,15 @@ int main(int argc, char* argv[]) {
                                    [quickWindow, &application, &controller, fail] {
                   auto* currentStrip = quickWindow->findChild<QQuickItem*>(
                       QStringLiteral("couchGameStrip"));
+                  auto* currentGrid = quickWindow->findChild<QQuickItem*>(
+                      QStringLiteral("couchGameGrid"));
+                  const bool libraryFocused =
+                      (currentStrip != nullptr && currentStrip->isVisible() &&
+                       currentStrip->hasActiveFocus()) ||
+                      (currentGrid != nullptr && currentGrid->isVisible() &&
+                       currentGrid->hasActiveFocus());
                   if (quickWindow->property("detailOpen").toBool() ||
-                      currentStrip == nullptr || !currentStrip->hasActiveFocus()) {
+                      !libraryFocused) {
                     fail(QStringLiteral("Controller Back did not restore the couch library"));
                     return;
                   }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -527,6 +527,15 @@ int main(int argc, char* argv[]) {
 
   auto* rootWindow = qobject_cast<QWindow*>(engine.rootObjects().constFirst());
   if (rootWindow != nullptr) {
+    const auto syncControllerFocus = [&application, &controller] {
+      controller.setInputEnabled(application.applicationState() == Qt::ApplicationActive &&
+                                 application.focusWindow() != nullptr);
+    };
+    QObject::connect(&application, &QGuiApplication::applicationStateChanged, &controller,
+                     syncControllerFocus);
+    QObject::connect(&application, &QGuiApplication::focusWindowChanged, &controller,
+                     syncControllerFocus);
+    syncControllerFocus();
     auto* couchCursor = new CouchCursorManager(rootWindow, 1600, rootWindow);
     couchCursor->setObjectName(QStringLiteral("couchCursorManager"));
     QObject::connect(rootWindow, SIGNAL(couchModeChanged()), couchCursor,
@@ -540,13 +549,11 @@ int main(int argc, char* argv[]) {
     QObject::connect(&controller, &ControllerInput::toolbarRequested, couchCursor,
                      &CouchCursorManager::navigationActivity);
     QObject::connect(&controller, &ControllerInput::keyRequested, rootWindow,
-                     [&application, rootWindow](int key, int modifiers) {
+                     [&application](int key, int modifiers) {
                        QWindow* target = application.focusWindow();
-                       if (target == nullptr) {
-                         // A freshly shown fullscreen window may not have compositor focus yet.
-                         // Controller input must still enter Omakade instead of being discarded.
-                         target = rootWindow;
-                         rootWindow->requestActivate();
+                       if (application.applicationState() != Qt::ApplicationActive ||
+                           target == nullptr) {
+                         return;
                        }
                        const auto keyboardModifiers =
                            static_cast<Qt::KeyboardModifiers>(modifiers);

--- a/src/input/ControllerInput.cpp
+++ b/src/input/ControllerInput.cpp
@@ -6,14 +6,20 @@
 
 #include <SDL3/SDL.h>
 
+namespace {
+constexpr int kInitialRepeatDelayMs = 260;
+constexpr int kRepeatIntervalMs = 80;
+} // namespace
+
 ControllerInput::ControllerInput(QObject* parent) : QObject(parent) {
   m_pollTimer.setInterval(8);
   connect(&m_pollTimer, &QTimer::timeout, this, &ControllerInput::pollEvents);
-  m_repeatTimer.setInterval(260);
+  m_repeatTimer.setTimerType(Qt::PreciseTimer);
+  m_repeatTimer.setInterval(kInitialRepeatDelayMs);
   connect(&m_repeatTimer, &QTimer::timeout, this, [this] {
-    if (m_axisKey != 0) {
-      emitDirection(m_axisKey);
-      m_repeatTimer.setInterval(75);
+    if (m_repeatKey != 0) {
+      emitDirection(m_repeatKey);
+      m_repeatTimer.setInterval(kRepeatIntervalMs);
     }
   });
   connect(&m_initWatcher, &QFutureWatcher<InitResult>::finished, this, [this] {
@@ -108,7 +114,10 @@ void ControllerInput::pollEvents() {
       closeController(event.gdevice.which);
       break;
     case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
-      handleButton(event.gbutton.button);
+      handleButtonPressed(event.gbutton.button);
+      break;
+    case SDL_EVENT_GAMEPAD_BUTTON_UP:
+      handleButtonReleased(event.gbutton.button);
       break;
     case SDL_EVENT_GAMEPAD_AXIS_MOTION:
       if (event.gaxis.axis == SDL_GAMEPAD_AXIS_LEFTX) {
@@ -160,13 +169,15 @@ void ControllerInput::closeController(SDL_JoystickID id) {
     m_axisX = 0;
     m_axisY = 0;
     m_axisKey = 0;
+    m_dpadKeys.clear();
+    m_repeatKey = 0;
     m_repeatTimer.stop();
-    m_repeatTimer.setInterval(260);
+    m_repeatTimer.setInterval(kInitialRepeatDelayMs);
     emit controllerChanged();
   }
 }
 
-void ControllerInput::handleButton(int button) {
+void ControllerInput::handleButtonPressed(int button) {
   switch (button) {
   case SDL_GAMEPAD_BUTTON_SOUTH:
     emit keyRequested(Qt::Key_Return, Qt::NoModifier);
@@ -184,20 +195,49 @@ void ControllerInput::handleButton(int button) {
     emit keyRequested(Qt::Key_F11, Qt::NoModifier);
     break;
   case SDL_GAMEPAD_BUTTON_DPAD_UP:
-    emitDirection(Qt::Key_Up);
+    setDpadPressed(Qt::Key_Up, true);
     break;
   case SDL_GAMEPAD_BUTTON_DPAD_DOWN:
-    emitDirection(Qt::Key_Down);
+    setDpadPressed(Qt::Key_Down, true);
     break;
   case SDL_GAMEPAD_BUTTON_DPAD_LEFT:
-    emitDirection(Qt::Key_Left);
+    setDpadPressed(Qt::Key_Left, true);
     break;
   case SDL_GAMEPAD_BUTTON_DPAD_RIGHT:
-    emitDirection(Qt::Key_Right);
+    setDpadPressed(Qt::Key_Right, true);
     break;
   default:
     break;
   }
+}
+
+void ControllerInput::handleButtonReleased(int button) {
+  switch (button) {
+  case SDL_GAMEPAD_BUTTON_DPAD_UP:
+    setDpadPressed(Qt::Key_Up, false);
+    break;
+  case SDL_GAMEPAD_BUTTON_DPAD_DOWN:
+    setDpadPressed(Qt::Key_Down, false);
+    break;
+  case SDL_GAMEPAD_BUTTON_DPAD_LEFT:
+    setDpadPressed(Qt::Key_Left, false);
+    break;
+  case SDL_GAMEPAD_BUTTON_DPAD_RIGHT:
+    setDpadPressed(Qt::Key_Right, false);
+    break;
+  default:
+    break;
+  }
+}
+
+void ControllerInput::setDpadPressed(int key, bool pressed) {
+  m_dpadKeys.removeAll(key);
+  if (pressed) {
+    // If two directions are held, the most recently pressed direction wins. Releasing it
+    // resumes the direction that is still held instead of stopping navigation completely.
+    m_dpadKeys.append(key);
+  }
+  updateRepeatKey();
 }
 
 void ControllerInput::emitDirection(int key) {
@@ -220,11 +260,20 @@ void ControllerInput::updateAxisKey() {
     return;
   }
   m_axisKey = key;
-  if (key == 0) {
-    m_repeatTimer.stop();
-    m_repeatTimer.setInterval(260);
-  } else {
-    emitDirection(key);
+  updateRepeatKey();
+}
+
+void ControllerInput::updateRepeatKey() {
+  const int key = m_dpadKeys.isEmpty() ? m_axisKey : m_dpadKeys.constLast();
+  if (key == m_repeatKey) {
+    return;
+  }
+
+  m_repeatKey = key;
+  m_repeatTimer.stop();
+  m_repeatTimer.setInterval(kInitialRepeatDelayMs);
+  if (m_repeatKey != 0) {
+    emitDirection(m_repeatKey);
     m_repeatTimer.start();
   }
 }

--- a/src/input/ControllerInput.cpp
+++ b/src/input/ControllerInput.cpp
@@ -9,11 +9,11 @@
 ControllerInput::ControllerInput(QObject* parent) : QObject(parent) {
   m_pollTimer.setInterval(8);
   connect(&m_pollTimer, &QTimer::timeout, this, &ControllerInput::pollEvents);
-  m_repeatTimer.setInterval(320);
+  m_repeatTimer.setInterval(260);
   connect(&m_repeatTimer, &QTimer::timeout, this, [this] {
     if (m_axisKey != 0) {
       emitDirection(m_axisKey);
-      m_repeatTimer.setInterval(90);
+      m_repeatTimer.setInterval(75);
     }
   });
   connect(&m_initWatcher, &QFutureWatcher<InitResult>::finished, this, [this] {
@@ -161,7 +161,7 @@ void ControllerInput::closeController(SDL_JoystickID id) {
     m_axisY = 0;
     m_axisKey = 0;
     m_repeatTimer.stop();
-    m_repeatTimer.setInterval(320);
+    m_repeatTimer.setInterval(260);
     emit controllerChanged();
   }
 }
@@ -222,7 +222,7 @@ void ControllerInput::updateAxisKey() {
   m_axisKey = key;
   if (key == 0) {
     m_repeatTimer.stop();
-    m_repeatTimer.setInterval(320);
+    m_repeatTimer.setInterval(260);
   } else {
     emitDirection(key);
     m_repeatTimer.start();

--- a/src/input/ControllerInput.cpp
+++ b/src/input/ControllerInput.cpp
@@ -101,6 +101,26 @@ void ControllerInput::setFocusNavigation(bool enabled) {
   emit focusNavigationChanged();
 }
 
+void ControllerInput::setInputEnabled(bool enabled) {
+  if (m_inputEnabled == enabled) {
+    return;
+  }
+  m_inputEnabled = enabled;
+  m_repeatTimer.stop();
+  m_repeatTimer.setInterval(kInitialRepeatDelayMs);
+  m_axisX = 0;
+  m_axisY = 0;
+  m_axisKey = 0;
+  m_repeatKey = 0;
+  m_dpadKeys.clear();
+  if (m_sdlReady) {
+    // Do not replay input queued while another application owned focus.
+    SDL_FlushEvent(SDL_EVENT_GAMEPAD_BUTTON_DOWN);
+    SDL_FlushEvent(SDL_EVENT_GAMEPAD_BUTTON_UP);
+    SDL_FlushEvent(SDL_EVENT_GAMEPAD_AXIS_MOTION);
+  }
+}
+
 void ControllerInput::pollEvents() {
   SDL_Event event;
   while (SDL_PollEvent(&event)) {
@@ -114,12 +134,19 @@ void ControllerInput::pollEvents() {
       closeController(event.gdevice.which);
       break;
     case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
-      handleButtonPressed(event.gbutton.button);
+      if (m_inputEnabled) {
+        handleButtonPressed(event.gbutton.button);
+      }
       break;
     case SDL_EVENT_GAMEPAD_BUTTON_UP:
-      handleButtonReleased(event.gbutton.button);
+      if (m_inputEnabled) {
+        handleButtonReleased(event.gbutton.button);
+      }
       break;
     case SDL_EVENT_GAMEPAD_AXIS_MOTION:
+      if (!m_inputEnabled) {
+        break;
+      }
       if (event.gaxis.axis == SDL_GAMEPAD_AXIS_LEFTX) {
         m_axisX = event.gaxis.value;
         updateAxisKey();

--- a/src/input/ControllerInput.h
+++ b/src/input/ControllerInput.h
@@ -34,6 +34,7 @@ public:
   [[nodiscard]] QString toolbarGlyph() const;
   [[nodiscard]] bool focusNavigation() const;
   void setFocusNavigation(bool enabled);
+  void setInputEnabled(bool enabled);
   void start();
 
 signals:
@@ -72,4 +73,5 @@ private:
   int m_repeatKey = 0;
   bool m_sdlReady = false;
   bool m_focusNavigation = false;
+  bool m_inputEnabled = true;
 };

--- a/src/input/ControllerInput.h
+++ b/src/input/ControllerInput.h
@@ -2,6 +2,7 @@
 
 #include <QFutureWatcher>
 #include <QHash>
+#include <QList>
 #include <QObject>
 #include <QString>
 #include <QTimer>
@@ -52,9 +53,12 @@ private:
   void pollEvents();
   void openAvailableControllers();
   void closeController(SDL_JoystickID id);
-  void handleButton(int button);
+  void handleButtonPressed(int button);
+  void handleButtonReleased(int button);
+  void setDpadPressed(int key, bool pressed);
   void emitDirection(int key);
   void updateAxisKey();
+  void updateRepeatKey();
   [[nodiscard]] QString buttonLabel(SDL_GamepadButton button, const QString& fallback) const;
 
   QHash<SDL_JoystickID, SDL_Gamepad*> m_controllers;
@@ -64,6 +68,8 @@ private:
   int m_axisX = 0;
   int m_axisY = 0;
   int m_axisKey = 0;
+  QList<int> m_dpadKeys;
+  int m_repeatKey = 0;
   bool m_sdlReady = false;
   bool m_focusNavigation = false;
 };

--- a/src/input/CouchCursorManager.cpp
+++ b/src/input/CouchCursorManager.cpp
@@ -1,0 +1,98 @@
+#include "input/CouchCursorManager.h"
+
+#include <QCursor>
+#include <QEvent>
+#include <QGuiApplication>
+#include <QMouseEvent>
+#include <QWindow>
+
+CouchCursorManager::CouchCursorManager(QWindow* window, int idleTimeoutMs, QObject* parent)
+    : QObject(parent), m_window(window) {
+  m_idleTimer.setSingleShot(true);
+  m_idleTimer.setInterval(idleTimeoutMs);
+  connect(&m_idleTimer, &QTimer::timeout, this, [this] {
+    if (m_couchMode) {
+      setCursorHidden(true);
+    }
+  });
+  qGuiApp->installEventFilter(this);
+  syncCouchMode();
+}
+
+CouchCursorManager::~CouchCursorManager() {
+  qGuiApp->removeEventFilter(this);
+  setCursorHidden(false);
+}
+
+bool CouchCursorManager::cursorHidden() const { return m_cursorHidden; }
+
+void CouchCursorManager::syncCouchMode() {
+  const bool couchMode = m_window != nullptr && m_window->property("couchMode").toBool();
+  if (m_couchMode == couchMode) {
+    return;
+  }
+
+  m_couchMode = couchMode;
+  m_idleTimer.stop();
+  setCursorHidden(false);
+  if (m_couchMode) {
+    m_idleTimer.start();
+  }
+}
+
+void CouchCursorManager::navigationActivity() {
+  if (!m_couchMode) {
+    return;
+  }
+  m_idleTimer.stop();
+  setCursorHidden(true);
+}
+
+bool CouchCursorManager::eventFilter(QObject* watched, QEvent* event) {
+  if (m_couchMode) {
+    switch (event->type()) {
+    case QEvent::KeyPress:
+      navigationActivity();
+      break;
+    case QEvent::MouseMove: {
+      const auto* mouseEvent = static_cast<QMouseEvent*>(event);
+      const QPointF position = mouseEvent->globalPosition();
+      if (!m_haveMousePosition || position != m_lastMousePosition) {
+        m_lastMousePosition = position;
+        m_haveMousePosition = true;
+        pointerActivity();
+      }
+      break;
+    }
+    case QEvent::MouseButtonPress:
+    case QEvent::MouseButtonRelease:
+    case QEvent::Wheel:
+      pointerActivity();
+      break;
+    default:
+      break;
+    }
+  }
+  return QObject::eventFilter(watched, event);
+}
+
+void CouchCursorManager::pointerActivity() {
+  if (!m_couchMode) {
+    return;
+  }
+  setCursorHidden(false);
+  m_idleTimer.start();
+}
+
+void CouchCursorManager::setCursorHidden(bool hidden) {
+  if (m_cursorHidden == hidden) {
+    return;
+  }
+  m_cursorHidden = hidden;
+  if (m_cursorHidden) {
+    QGuiApplication::setOverrideCursor(QCursor(Qt::BlankCursor));
+  } else {
+    QGuiApplication::restoreOverrideCursor();
+  }
+  emit cursorHiddenChanged();
+}

--- a/src/input/CouchCursorManager.h
+++ b/src/input/CouchCursorManager.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QObject>
+#include <QPointF>
+#include <QTimer>
+
+class QEvent;
+class QWindow;
+
+class CouchCursorManager final : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(bool cursorHidden READ cursorHidden NOTIFY cursorHiddenChanged)
+
+public:
+  explicit CouchCursorManager(QWindow* window, int idleTimeoutMs = 1600, QObject* parent = nullptr);
+  ~CouchCursorManager() override;
+
+  [[nodiscard]] bool cursorHidden() const;
+
+public slots:
+  void syncCouchMode();
+  void navigationActivity();
+
+signals:
+  void cursorHiddenChanged();
+
+protected:
+  bool eventFilter(QObject* watched, QEvent* event) override;
+
+private:
+  void pointerActivity();
+  void setCursorHidden(bool hidden);
+
+  QWindow* m_window = nullptr;
+  QTimer m_idleTimer;
+  QPointF m_lastMousePosition;
+  bool m_haveMousePosition = false;
+  bool m_couchMode = false;
+  bool m_cursorHidden = false;
+};

--- a/src/launch/GameLauncher.cpp
+++ b/src/launch/GameLauncher.cpp
@@ -3,6 +3,7 @@
 #include "launch/SteamLauncher.h"
 #include "sources/FlatpakInstall.h"
 #include "sources/battlenet/BattleNetScanner.h"
+#include "sources/heroic/HeroicScanner.h"
 
 #include <QDesktopServices>
 #include <QDir>
@@ -50,6 +51,11 @@ bool validHeroicTarget(const QString& id, const QString& runner) {
   return appId.match(id).hasMatch() &&
          (runner == QStringLiteral("legendary") || runner == QStringLiteral("gog") ||
           runner == QStringLiteral("nile") || runner == QStringLiteral("sideload"));
+}
+
+bool validGogId(const QString& id) {
+  static const QRegularExpression appId(QStringLiteral("^[0-9]{1,20}$"));
+  return appId.match(id).hasMatch();
 }
 
 bool validFaugusId(const QString& id) {
@@ -250,11 +256,40 @@ LaunchCommand GameLauncher::battleNetCommand(const QString& id, const QString& p
                                     QStringLiteral("-e"), exe, QStringLiteral("--"), execArg}};
   }
   if (runner == QStringLiteral("proton")) {
-    return {QStringLiteral("env"),
-            {QStringLiteral("WINEPREFIX=%1").arg(prefix), QStringLiteral("umu-run"), exe,
-             execArg}};
+    QStringList arguments{QStringLiteral("WINEPREFIX=%1").arg(prefix)};
+    if (QFileInfo(prefix + QStringLiteral("/version")).isFile()) {
+      arguments.append({QStringLiteral("GAMEID=umu-battlenet"),
+                        QStringLiteral("STORE=battlenet"), QStringLiteral("PROTONPATH=GE-Proton"),
+                        QStringLiteral("PROTON_VERB=run")});
+    }
+    arguments.append({QStringLiteral("umu-run"), exe, execArg});
+    return {QStringLiteral("env"), arguments};
   }
   return {QStringLiteral("wine"), {exe, execArg}};
+}
+
+LaunchCommand GameLauncher::gogCommand(const QString& id, const QString& installPath,
+                                       const QString& winePrefix) {
+  if (!validGogId(id)) {
+    return {};
+  }
+  const std::optional<GogLaunchTask> task = HeroicScanner::gogLaunchTask(installPath, id);
+  if (!task.has_value()) {
+    return {};
+  }
+  if (!task->windows) {
+    return {task->executablePath, task->arguments};
+  }
+  const QString prefix =
+      winePrefix.isEmpty()
+          ? QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) +
+                QStringLiteral("/omakade/gog-prefixes/") + id
+          : winePrefix;
+  QStringList arguments{QStringLiteral("WINEPREFIX=%1").arg(prefix),
+                        QStringLiteral("GAMEID=umu-default"), QStringLiteral("STORE=gog"),
+                        QStringLiteral("umu-run"), task->executablePath};
+  arguments.append(task->arguments);
+  return {QStringLiteral("env"), arguments};
 }
 
 bool GameLauncher::launch(const QString& source, const QString& id, bool flatpak,
@@ -285,6 +320,9 @@ bool GameLauncher::launch(const QString& source, const QString& id, bool flatpak
   }
   if (source.compare(QStringLiteral("Heroic"), Qt::CaseInsensitive) == 0) {
     return launchHeroic(id, runner, flatpak, false);
+  }
+  if (source.compare(QStringLiteral("GOG"), Qt::CaseInsensitive) == 0) {
+    return launchGog(id, installPath, false);
   }
   if (source.compare(QStringLiteral("Faugus"), Qt::CaseInsensitive) == 0) {
     return launchFaugus(id, flatpak, false);
@@ -325,6 +363,9 @@ bool GameLauncher::manage(const QString& source, const QString& id, bool flatpak
   }
   if (source.compare(QStringLiteral("Heroic"), Qt::CaseInsensitive) == 0) {
     return launchHeroic(id, runner, flatpak, true);
+  }
+  if (source.compare(QStringLiteral("GOG"), Qt::CaseInsensitive) == 0) {
+    return launchGog(id, {}, true);
   }
   if (source.compare(QStringLiteral("Faugus"), Qt::CaseInsensitive) == 0) {
     return launchFaugus(id, flatpak, true);
@@ -432,6 +473,42 @@ bool GameLauncher::launchHeroic(const QString& id, const QString& runner, bool f
   }
   if (!QProcess::startDetached(command.program, command.arguments)) {
     setError(QStringLiteral("Heroic could not be started. Open Heroic and try again."));
+    return false;
+  }
+  setError({});
+  return true;
+}
+
+bool GameLauncher::launchGog(const QString& id, const QString& installPath, bool manageOnly) {
+  if (manageOnly) {
+    if (!QDesktopServices::openUrl(QUrl(QStringLiteral("https://www.gog.com/account")))) {
+      setError(QStringLiteral("GOG could not open your library."));
+      return false;
+    }
+    setError({});
+    return true;
+  }
+  const LaunchCommand command = gogCommand(id, installPath);
+  if (!command.isValid()) {
+    setError(QStringLiteral("This GOG installation does not provide a safe launch task."));
+    return false;
+  }
+  if (command.program == QStringLiteral("env") &&
+      QStandardPaths::findExecutable(QStringLiteral("umu-run")).isEmpty()) {
+    setError(QStringLiteral("Install umu-launcher to run this Windows GOG game."));
+    return false;
+  }
+  if (command.program == QStringLiteral("env")) {
+    const QString prefix = command.arguments.constFirst().mid(QStringLiteral("WINEPREFIX=").size());
+    if (!QDir().mkpath(prefix)) {
+      setError(QStringLiteral("Omakade could not create the GOG Wine prefix."));
+      return false;
+    }
+  }
+  const std::optional<GogLaunchTask> task = HeroicScanner::gogLaunchTask(installPath, id);
+  if (!task.has_value() ||
+      !QProcess::startDetached(command.program, command.arguments, task->workingDirectory)) {
+    setError(QStringLiteral("GOG could not start this game."));
     return false;
   }
   setError({});
@@ -657,9 +734,14 @@ bool GameLauncher::launchBattleNet(const QString& id, const QString& prefix, con
   QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
   environment.insert(QStringLiteral("WINEPREFIX"), QDir::cleanPath(prefix));
   if (protonRunner) {
-    environment.insert(QStringLiteral("GAMEID"), QStringLiteral("0"));
-    environment.insert(QStringLiteral("STEAM_COMPAT_DATA_PATH"),
-                       QFileInfo(prefix + QStringLiteral("/..")).absoluteFilePath());
+    const bool omarchyStyleProton = QFileInfo(prefix + QStringLiteral("/version")).isFile();
+    environment.insert(QStringLiteral("GAMEID"), omarchyStyleProton
+                                                       ? QStringLiteral("umu-battlenet")
+                                                       : QStringLiteral("0"));
+    if (!omarchyStyleProton) {
+      environment.insert(QStringLiteral("STEAM_COMPAT_DATA_PATH"),
+                         QFileInfo(prefix + QStringLiteral("/..")).absoluteFilePath());
+    }
   }
   process.setProcessEnvironment(environment);
   if (!process.startDetached()) {

--- a/src/launch/GameLauncher.h
+++ b/src/launch/GameLauncher.h
@@ -30,6 +30,8 @@ public:
                                                         QStringLiteral("io.github.ryubing.Ryujinx"));
   [[nodiscard]] static LaunchCommand battleNetCommand(const QString& id, const QString& prefix,
                                                       const QString& runner, bool flatpak);
+  [[nodiscard]] static LaunchCommand gogCommand(const QString& id, const QString& installPath,
+                                                const QString& winePrefix = {});
   Q_INVOKABLE bool launch(const QString& source, const QString& id, bool flatpak = false,
                           const QString& runner = {}, const QString& installPath = {},
                           const QString& launchTarget = {});
@@ -51,6 +53,7 @@ private:
                      bool manageOnly);
   bool launchBattleNet(const QString& id, const QString& prefix, const QString& runner,
                        bool flatpak, bool manageOnly);
+  bool launchGog(const QString& id, const QString& installPath, bool manageOnly);
   [[nodiscard]] QString flatpakError(const QString& appId, const QString& launcherName) const;
   void setError(const QString& error);
   QString m_lastError;

--- a/src/launch/PlayRequest.h
+++ b/src/launch/PlayRequest.h
@@ -8,7 +8,7 @@ class GameLauncher;
 class UnifiedGameModel;
 
 // Identifies one installation of a game the way Omakade stores it: the source name, the
-// Heroic or Lutris runner (often empty), and the source's own game id. The text form
+// source-specific runner (often empty), and the source's own game id. The text form
 // "Source:runner:id" is what `omakade --play` and Sunshine app entries carry. The id is
 // everything after the second colon, so RetroArch content paths survive unchanged.
 struct LaunchKey {

--- a/src/library/HeroicGameModel.cpp
+++ b/src/library/HeroicGameModel.cpp
@@ -274,11 +274,18 @@ void HeroicGameModel::loadSourceState() {
 }
 
 void HeroicGameModel::applyScan(const HeroicScanResult& result) {
-  const bool missingRoots = result.roots.isEmpty() && !m_games.isEmpty();
-  const bool heroicIncomplete = result.incomplete || missingRoots;
-  const bool gogIncomplete = result.gogIncomplete || missingRoots;
+  const bool missingHeroicRoots = result.roots.isEmpty() &&
+      std::any_of(m_games.cbegin(), m_games.cend(), [](const Game& game) {
+        return game.heroic.runner != QStringLiteral("gog-direct");
+      });
+  const bool missingGogRoots = result.gogRoots.isEmpty() &&
+      std::any_of(m_games.cbegin(), m_games.cend(), [](const Game& game) {
+        return game.heroic.runner == QStringLiteral("gog-direct");
+      });
+  const bool heroicIncomplete = result.incomplete || missingHeroicRoots;
+  const bool gogIncomplete = result.gogIncomplete || missingGogRoots;
   if (heroicIncomplete && gogIncomplete) {
-    setStatus(QStringLiteral("Heroic scan interrupted; kept the cached library"),
+    setStatus(QStringLiteral("Heroic/GOG scan interrupted; kept cached results"),
               result.warnings.join(QLatin1Char('\n')));
     return;
   }

--- a/src/library/HeroicGameModel.cpp
+++ b/src/library/HeroicGameModel.cpp
@@ -6,10 +6,14 @@
 #include <QDateTime>
 #include <QDir>
 #include <QFileInfo>
+#include <QSet>
 #include <QSqlError>
 #include <QSqlQuery>
 #include <QUrl>
 #include <QtConcurrent>
+
+#include <algorithm>
+#include <utility>
 
 namespace {
 QColor colorFor(const QString& key, int offset) {
@@ -101,6 +105,7 @@ QHash<int, QByteArray> HeroicGameModel::roleNames() const {
 }
 
 bool HeroicGameModel::heroicDetected() const { return m_heroicDetected; }
+bool HeroicGameModel::gogDetected() const { return m_gogDetected; }
 QString HeroicGameModel::statusText() const { return m_statusText; }
 QString HeroicGameModel::errorText() const { return m_errorText; }
 QStringList HeroicGameModel::detectedPaths() const { return m_detectedPaths; }
@@ -148,7 +153,7 @@ void HeroicGameModel::refresh() {
   }
   m_scanning = true;
   const QStringList roots = HeroicScanner::discoverRoots();
-  setStatus(QStringLiteral("Scanning Heroic library"));
+  setStatus(QStringLiteral("Scanning Heroic and GOG libraries"));
   m_scanWatcher.setFuture(QtConcurrent::run([roots] { return HeroicScanner::scan(roots); }));
 }
 void HeroicGameModel::refreshFromRoots(const QStringList& roots) {
@@ -235,6 +240,12 @@ void HeroicGameModel::loadDatabase() {
   beginResetModel();
   m_games = loaded;
   endResetModel();
+  m_gogDetected = std::any_of(m_games.cbegin(), m_games.cend(), [](const Game& game) {
+    return game.heroic.runner == QStringLiteral("gog-direct");
+  });
+  m_heroicDetected = std::any_of(m_games.cbegin(), m_games.cend(), [](const Game& game) {
+    return game.heroic.runner != QStringLiteral("gog-direct");
+  });
 }
 
 void HeroicGameModel::loadSourceState() {
@@ -247,15 +258,26 @@ void HeroicGameModel::loadSourceState() {
   m_lastScan = query.value(0).toLongLong();
   m_errorText = query.value(1).toString();
   m_detectedPaths = query.value(2).toString().split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-  m_heroicDetected = !m_detectedPaths.isEmpty();
+  m_heroicDetected = std::any_of(m_games.cbegin(), m_games.cend(), [](const Game& game) {
+    return game.heroic.runner != QStringLiteral("gog-direct");
+  });
+  if (!m_heroicDetected) {
+    m_heroicDetected = std::any_of(
+        m_detectedPaths.cbegin(), m_detectedPaths.cend(), [](const QString& path) {
+          return path.endsWith(QStringLiteral("/heroic")) ||
+                 path.contains(QStringLiteral("com.heroicgameslauncher.hgl"));
+        });
+  }
   if (m_lastScan > 0) {
     m_statusText = QStringLiteral("Loaded cached Heroic library");
   }
 }
 
 void HeroicGameModel::applyScan(const HeroicScanResult& result) {
-  m_heroicDetected = !result.roots.isEmpty();
-  if (result.incomplete || (result.roots.isEmpty() && !m_games.isEmpty())) {
+  const bool missingRoots = result.roots.isEmpty() && !m_games.isEmpty();
+  const bool heroicIncomplete = result.incomplete || missingRoots;
+  const bool gogIncomplete = result.gogIncomplete || missingRoots;
+  if (heroicIncomplete && gogIncomplete) {
     setStatus(QStringLiteral("Heroic scan interrupted; kept the cached library"),
               result.warnings.join(QLatin1Char('\n')));
     return;
@@ -266,8 +288,32 @@ void HeroicGameModel::applyScan(const HeroicScanResult& result) {
   }
   const qint64 scanTimestamp = QDateTime::currentSecsSinceEpoch();
   QSqlQuery query(m_database);
-  bool okay = query.exec(QStringLiteral("UPDATE heroic_games SET observed_at = 0"));
+  bool okay = true;
+  if (!heroicIncomplete) {
+    okay = query.exec(QStringLiteral(
+        "UPDATE heroic_games SET observed_at = 0 WHERE runner != 'gog-direct'"));
+  }
+  if (!gogIncomplete) {
+    okay = okay && query.exec(QStringLiteral(
+                         "UPDATE heroic_games SET observed_at = 0 WHERE runner = 'gog-direct'"));
+  }
+  QSet<QString> cachedManagedGogPaths;
+  if (result.managedGogIncomplete) {
+    for (const Game& cached : std::as_const(m_games)) {
+      if (cached.heroic.runner == QStringLiteral("gog")) {
+        cachedManagedGogPaths.insert(QDir::cleanPath(cached.heroic.installPath));
+      }
+    }
+  }
   for (const HeroicGameRecord& game : result.games) {
+    const bool directGog = game.runner == QStringLiteral("gog-direct");
+    if (directGog ? gogIncomplete : heroicIncomplete) {
+      continue;
+    }
+    if (directGog &&
+        cachedManagedGogPaths.contains(QDir::cleanPath(game.installPath))) {
+      continue;
+    }
     query.prepare(QStringLiteral(
         "INSERT INTO heroic_games(game_key, app_id, runner, name, directory, cover_path, "
         "hero_path, flatpak, playtime_minutes, last_played, observed_at) VALUES(?, ?, ?, ?, ?, ?, "
@@ -305,8 +351,12 @@ void HeroicGameModel::applyScan(const HeroicScanResult& result) {
   loadDatabase();
   m_detectedPaths = result.roots;
   m_lastScan = scanTimestamp;
-  setStatus(m_heroicDetected ? QStringLiteral("Imported %1 Heroic game(s)").arg(result.games.size())
-                             : QStringLiteral("Heroic was not found"),
+  setStatus(heroicIncomplete || gogIncomplete
+                ? QStringLiteral("Imported available Heroic/GOG games; kept cached results for "
+                                 "the interrupted source")
+            : !result.roots.isEmpty()
+                ? QStringLiteral("Imported %1 Heroic/GOG game(s)").arg(result.games.size())
+                : QStringLiteral("Heroic or GOG was not found"),
             result.warnings.join(QLatin1Char('\n')));
 }
 
@@ -315,9 +365,13 @@ QVariant HeroicGameModel::valueForRole(const Game& game, int role) const {
   case GameRoles::Title:
     return game.heroic.title;
   case GameRoles::Subtitle:
-    return QStringLiteral("Heroic · %1").arg(storeName(game.heroic.runner));
+    return game.heroic.runner == QStringLiteral("gog-direct")
+               ? QStringLiteral("GOG · Direct")
+               : QStringLiteral("Heroic · %1").arg(storeName(game.heroic.runner));
   case GameRoles::Description:
-    return game.heroic.runner == QStringLiteral("sideload")
+    return game.heroic.runner == QStringLiteral("gog-direct")
+               ? QStringLiteral("Installed GOG game.")
+           : game.heroic.runner == QStringLiteral("sideload")
                ? QStringLiteral("Added manually to Heroic.")
                : QStringLiteral("Installed locally through Heroic.");
   case GameRoles::Hours:
@@ -350,7 +404,8 @@ QVariant HeroicGameModel::valueForRole(const Game& game, int role) const {
   case GameRoles::InstallPath:
     return game.heroic.installPath;
   case GameRoles::Source:
-    return QStringLiteral("Heroic");
+    return game.heroic.runner == QStringLiteral("gog-direct") ? QStringLiteral("GOG")
+                                                               : QStringLiteral("Heroic");
   case GameRoles::Runner:
     return game.heroic.runner;
   case GameRoles::Flatpak:

--- a/src/library/HeroicGameModel.h
+++ b/src/library/HeroicGameModel.h
@@ -10,6 +10,7 @@
 class HeroicGameModel final : public QAbstractListModel {
   Q_OBJECT
   Q_PROPERTY(bool heroicDetected READ heroicDetected NOTIFY statusChanged)
+  Q_PROPERTY(bool gogDetected READ gogDetected NOTIFY statusChanged)
   Q_PROPERTY(QString statusText READ statusText NOTIFY statusChanged)
   Q_PROPERTY(QString errorText READ errorText NOTIFY statusChanged)
   Q_PROPERTY(QStringList detectedPaths READ detectedPaths NOTIFY statusChanged)
@@ -24,6 +25,7 @@ public:
   [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
   [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
   [[nodiscard]] bool heroicDetected() const;
+  [[nodiscard]] bool gogDetected() const;
   [[nodiscard]] QString statusText() const;
   [[nodiscard]] QString errorText() const;
   [[nodiscard]] QStringList detectedPaths() const;
@@ -61,6 +63,7 @@ private:
   QFutureWatcher<HeroicScanResult> m_scanWatcher;
   bool m_scanning = false;
   bool m_heroicDetected = false;
+  bool m_gogDetected = false;
   QString m_statusText;
   QString m_errorText;
   QStringList m_detectedPaths;

--- a/src/sources/battlenet/BattleNetScanner.cpp
+++ b/src/sources/battlenet/BattleNetScanner.cpp
@@ -371,8 +371,11 @@ QString detectRunner(const QString& prefix) {
     return QStringLiteral("bottles");
   }
   const QFileInfo info(prefix);
-  if (info.fileName() == QStringLiteral("pfx") &&
-      QFileInfo(info.dir().absoluteFilePath(QStringLiteral("version"))).isFile()) {
+  const bool steamStyleProton =
+      info.fileName() == QStringLiteral("pfx") &&
+      QFileInfo(info.dir().absoluteFilePath(QStringLiteral("version"))).isFile();
+  const bool omarchyStyleProton = QFileInfo(prefix + QStringLiteral("/version")).isFile();
+  if (steamStyleProton || omarchyStyleProton) {
     return QStringLiteral("proton");
   }
   return QStringLiteral("wine");

--- a/src/sources/heroic/HeroicScanner.cpp
+++ b/src/sources/heroic/HeroicScanner.cpp
@@ -8,10 +8,99 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QProcess>
+#include <QRegularExpression>
 #include <QStandardPaths>
+
+#include <utility>
 
 namespace {
 constexpr qint64 kMaximumJsonBytes = 32 * 1024 * 1024;
+constexpr qint64 kMaximumGogInfoBytes = 2 * 1024 * 1024;
+
+bool validGogId(const QString& appId) {
+  static const QRegularExpression valid(QStringLiteral("^[0-9]{1,20}$"));
+  return valid.match(appId).hasMatch();
+}
+
+QString confinedPath(const QString& root, QString relative) {
+  relative.replace(QLatin1Char('\\'), QLatin1Char('/'));
+  if (relative.isEmpty() || QDir::isAbsolutePath(relative) ||
+      QRegularExpression(QStringLiteral("^[A-Za-z]:")).match(relative).hasMatch()) {
+    return {};
+  }
+  const QString cleanRelative = QDir::cleanPath(relative);
+  if (cleanRelative == QStringLiteral("..") || cleanRelative.startsWith(QStringLiteral("../"))) {
+    return {};
+  }
+  const QString cleanRoot = QDir::cleanPath(QFileInfo(root).absoluteFilePath());
+  const QString resolved = QDir::cleanPath(QDir(cleanRoot).absoluteFilePath(cleanRelative));
+  if (resolved != cleanRoot && !resolved.startsWith(cleanRoot + QLatin1Char('/'))) {
+    return {};
+  }
+  const QString canonicalRoot = QFileInfo(cleanRoot).canonicalFilePath();
+  const QString canonicalResolved = QFileInfo(resolved).canonicalFilePath();
+  if (!canonicalResolved.isEmpty() &&
+      (canonicalRoot.isEmpty() ||
+       (canonicalResolved != canonicalRoot &&
+        !canonicalResolved.startsWith(canonicalRoot + QLatin1Char('/'))))) {
+    return {};
+  }
+  return resolved;
+}
+
+std::optional<GogLaunchTask> readGogLaunchTask(const QString& installPath,
+                                               const QString& appId) {
+  if (!validGogId(appId)) {
+    return std::nullopt;
+  }
+  QFile file(QDir(installPath).filePath(QStringLiteral("goggame-%1.info").arg(appId)));
+  if (!file.open(QIODevice::ReadOnly) || file.size() <= 0 || file.size() > kMaximumGogInfoBytes) {
+    return std::nullopt;
+  }
+  QJsonParseError error;
+  const QJsonDocument document = QJsonDocument::fromJson(file.readAll(), &error);
+  if (error.error != QJsonParseError::NoError || !document.isObject()) {
+    return std::nullopt;
+  }
+  const QJsonArray tasks = document.object().value(QStringLiteral("playTasks")).toArray();
+  QJsonObject selected;
+  for (const QJsonValue& value : tasks) {
+    const QJsonObject task = value.toObject();
+    if (task.value(QStringLiteral("type")).toString() != QStringLiteral("FileTask")) {
+      continue;
+    }
+    if (selected.isEmpty() || task.value(QStringLiteral("isPrimary")).toBool()) {
+      selected = task;
+    }
+    if (task.value(QStringLiteral("isPrimary")).toBool()) {
+      break;
+    }
+  }
+  const QString executable =
+      confinedPath(installPath, selected.value(QStringLiteral("path")).toString());
+  if (executable.isEmpty() || !QFileInfo(executable).isFile()) {
+    return std::nullopt;
+  }
+  QString workingDirectory = installPath;
+  const QString configuredWorkingDirectory =
+      selected.value(QStringLiteral("workingDir")).toString();
+  if (!configuredWorkingDirectory.isEmpty()) {
+    workingDirectory = confinedPath(installPath, configuredWorkingDirectory);
+    if (workingDirectory.isEmpty() || !QFileInfo(workingDirectory).isDir()) {
+      return std::nullopt;
+    }
+  }
+  const QString suffix = QFileInfo(executable).suffix().toLower();
+  return GogLaunchTask{.executablePath = executable,
+                       .arguments = QProcess::splitCommand(
+                           selected.value(QStringLiteral("arguments")).toString()),
+                       .workingDirectory = workingDirectory,
+                       .windows = suffix == QStringLiteral("exe") ||
+                                  suffix == QStringLiteral("com") ||
+                                  suffix == QStringLiteral("bat") ||
+                                  suffix == QStringLiteral("lnk")};
+}
 
 struct Metadata {
   QString title;
@@ -24,7 +113,8 @@ struct Activity {
   qint64 lastPlayed = 0;
 };
 
-QJsonDocument readJson(const QString& path, HeroicScanResult* result, bool required = true) {
+QJsonDocument readJson(const QString& path, HeroicScanResult* result, bool required = true,
+                       bool managedGogInventory = false) {
   QFile file(path);
   if (!file.exists()) {
     return {};
@@ -32,6 +122,7 @@ QJsonDocument readJson(const QString& path, HeroicScanResult* result, bool requi
   if (!file.open(QIODevice::ReadOnly) || file.size() > kMaximumJsonBytes) {
     if (required) {
       result->incomplete = true;
+      result->managedGogIncomplete = result->managedGogIncomplete || managedGogInventory;
     }
     result->warnings.append(QStringLiteral("Could not read %1").arg(path));
     return {};
@@ -41,6 +132,7 @@ QJsonDocument readJson(const QString& path, HeroicScanResult* result, bool requi
   if (error.error != QJsonParseError::NoError) {
     if (required) {
       result->incomplete = true;
+      result->managedGogIncomplete = result->managedGogIncomplete || managedGogInventory;
     }
     result->warnings.append(
         QStringLiteral("Could not parse %1: %2").arg(path, error.errorString()));
@@ -170,8 +262,10 @@ void scanGog(const QString& root, bool flatpak, const QHash<QString, Activity>& 
   }
   const auto metadata =
       readMetadata(root, QStringLiteral("gog_library.json"), QStringLiteral("games"), result);
-  const QJsonArray games =
-      readJson(path, result).object().value(QStringLiteral("installed")).toArray();
+  const QJsonArray games = readJson(path, result, true, true)
+                               .object()
+                               .value(QStringLiteral("installed"))
+                               .toArray();
   for (const QJsonValue& value : games) {
     const QJsonObject game = value.toObject();
     if (game.value(QStringLiteral("is_dlc")).toBool()) {
@@ -254,6 +348,68 @@ void scanSideload(const QString& root, bool flatpak, const QHash<QString, Activi
                activity.value(appId), flatpak);
   }
 }
+
+bool scanLooseGog(const QString& root, HeroicScanResult* result, QSet<QString>* keys,
+                  const QSet<QString>& managedInstallPaths) {
+  bool foundManifest = false;
+  QStringList directories{root};
+  const QDir rootDirectory(root);
+  for (const QFileInfo& child :
+       rootDirectory.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot | QDir::Readable)) {
+    directories.append(child.absoluteFilePath());
+  }
+  for (const QString& directory : directories) {
+    if (managedInstallPaths.contains(QDir::cleanPath(directory))) {
+      continue;
+    }
+    const QDir gameDirectory(directory);
+    const QFileInfoList manifests = gameDirectory.entryInfoList(
+        {QStringLiteral("goggame-*.info")}, QDir::Files | QDir::Readable, QDir::Name);
+    foundManifest = foundManifest || !manifests.isEmpty();
+    for (const QFileInfo& manifest : manifests) {
+      static const QRegularExpression idPattern(QStringLiteral("^goggame-([0-9]{1,20})\\.info$"));
+      const QRegularExpressionMatch match = idPattern.match(manifest.fileName());
+      if (!match.hasMatch()) {
+        continue;
+      }
+      const QString appId = match.captured(1);
+      const QString key = QStringLiteral("gog-direct:") + appId;
+      if (keys->contains(key)) {
+        continue;
+      }
+      QFile file(manifest.absoluteFilePath());
+      if (!file.open(QIODevice::ReadOnly) || file.size() <= 0 ||
+          file.size() > kMaximumGogInfoBytes) {
+        result->gogIncomplete = true;
+        result->warnings.append(QStringLiteral("Could not read %1").arg(manifest.absoluteFilePath()));
+        continue;
+      }
+      QJsonParseError error;
+      const QJsonDocument document = QJsonDocument::fromJson(file.readAll(), &error);
+      const QString title = document.object().value(QStringLiteral("name")).toString().trimmed();
+      if (error.error != QJsonParseError::NoError || !document.isObject()) {
+        result->gogIncomplete = true;
+        result->warnings.append(
+            QStringLiteral("Could not parse GOG manifest %1").arg(manifest.absoluteFilePath()));
+        continue;
+      }
+      if (title.isEmpty() || !readGogLaunchTask(directory, appId).has_value()) {
+        result->warnings.append(
+            QStringLiteral("Could not use GOG manifest %1").arg(manifest.absoluteFilePath()));
+        continue;
+      }
+      result->games.append({.key = key,
+                            .appId = appId,
+                            .runner = QStringLiteral("gog-direct"),
+                            .title = title,
+                            .installPath = directory,
+                            .coverPath = {},
+                            .heroPath = {}});
+      keys->insert(key);
+    }
+  }
+  return foundManifest;
+}
 } // namespace
 
 QStringList HeroicScanner::discoverRoots() {
@@ -261,7 +417,13 @@ QStringList HeroicScanner::discoverRoots() {
   const QString home = QDir::homePath();
   QStringList candidates = {
       config + QStringLiteral("/heroic"),
-      home + QStringLiteral("/.var/app/com.heroicgameslauncher.hgl/config/heroic")};
+      home + QStringLiteral("/.var/app/com.heroicgameslauncher.hgl/config/heroic"),
+      home + QStringLiteral("/GOG Games"), home + QStringLiteral("/Games/GOG"),
+      home + QStringLiteral("/Games/Heroic"), home + QStringLiteral("/Games")};
+  const QString configured = qEnvironmentVariable("OMAKADE_GOG_LIBRARY_PATHS");
+  for (const QString& path : configured.split(QDir::listSeparator(), Qt::SkipEmptyParts)) {
+    candidates.append(QDir::cleanPath(path));
+  }
   candidates.removeDuplicates();
   QStringList roots;
   for (const QString& root : candidates) {
@@ -275,10 +437,12 @@ QStringList HeroicScanner::discoverRoots() {
 HeroicScanResult HeroicScanner::scan(const QStringList& roots) {
   HeroicScanResult result;
   QSet<QString> keys;
+  QStringList validRoots;
   for (const QString& root : roots) {
     if (!QFileInfo(root).isDir()) {
       continue;
     }
+    validRoots.append(root);
     const bool flatpak = root.contains(QStringLiteral("/.var/app/com.heroicgameslauncher.hgl/"));
     const int before = result.games.size();
     const QHash<QString, Activity> activity = readActivity(root, &result);
@@ -296,5 +460,24 @@ HeroicScanResult HeroicScanner::scan(const QStringList& roots) {
       result.roots.append(root);
     }
   }
+  QSet<QString> managedGogInstallPaths;
+  for (const HeroicGameRecord& game : std::as_const(result.games)) {
+    if (game.runner == QStringLiteral("gog")) {
+      managedGogInstallPaths.insert(QDir::cleanPath(game.installPath));
+    }
+  }
+  for (const QString& root : std::as_const(validRoots)) {
+    const int before = result.games.size();
+    const bool foundManifest =
+        scanLooseGog(root, &result, &keys, managedGogInstallPaths);
+    if ((foundManifest || result.games.size() > before) && !result.roots.contains(root)) {
+      result.roots.append(root);
+    }
+  }
   return result;
+}
+
+std::optional<GogLaunchTask> HeroicScanner::gogLaunchTask(const QString& installPath,
+                                                          const QString& appId) {
+  return readGogLaunchTask(installPath, appId);
 }

--- a/src/sources/heroic/HeroicScanner.cpp
+++ b/src/sources/heroic/HeroicScanner.cpp
@@ -466,7 +466,19 @@ HeroicScanResult HeroicScanner::scan(const QStringList& roots) {
       managedGogInstallPaths.insert(QDir::cleanPath(game.installPath));
     }
   }
+  // Without the managed inventory, ownership of loose manifests is unknown.
+  if (result.managedGogIncomplete) {
+    result.gogIncomplete = true;
+    return result;
+  }
   for (const QString& root : std::as_const(validRoots)) {
+    if (!QDir(root).isReadable()) {
+      result.gogIncomplete = true;
+      result.warnings.append(QStringLiteral("Could not read GOG library %1").arg(root));
+      continue;
+    }
+    // An existing empty directory is a completed scan, including after uninstall.
+    result.gogRoots.append(root);
     const int before = result.games.size();
     const bool foundManifest =
         scanLooseGog(root, &result, &keys, managedGogInstallPaths);

--- a/src/sources/heroic/HeroicScanner.h
+++ b/src/sources/heroic/HeroicScanner.h
@@ -4,6 +4,15 @@
 #include <QStringList>
 #include <QVector>
 
+#include <optional>
+
+struct GogLaunchTask {
+  QString executablePath;
+  QStringList arguments;
+  QString workingDirectory;
+  bool windows = false;
+};
+
 struct HeroicGameRecord {
   QString key;
   QString appId;
@@ -22,10 +31,14 @@ struct HeroicScanResult {
   QStringList roots;
   QStringList warnings;
   bool incomplete = false;
+  bool gogIncomplete = false;
+  bool managedGogIncomplete = false;
 };
 
 class HeroicScanner final {
 public:
   [[nodiscard]] static QStringList discoverRoots();
   [[nodiscard]] static HeroicScanResult scan(const QStringList& roots);
+  [[nodiscard]] static std::optional<GogLaunchTask> gogLaunchTask(const QString& installPath,
+                                                                  const QString& appId);
 };

--- a/src/sources/heroic/HeroicScanner.h
+++ b/src/sources/heroic/HeroicScanner.h
@@ -29,6 +29,7 @@ struct HeroicGameRecord {
 struct HeroicScanResult {
   QVector<HeroicGameRecord> games;
   QStringList roots;
+  QStringList gogRoots;
   QStringList warnings;
   bool incomplete = false;
   bool gogIncomplete = false;

--- a/src/theme/OmarchyTheme.cpp
+++ b/src/theme/OmarchyTheme.cpp
@@ -47,6 +47,20 @@ OmarchyTheme::OmarchyTheme(QString stateHome, QString configHome, QObject* paren
   reload();
 }
 
+OmarchyTheme::~OmarchyTheme() {
+  for (QProcess* process : findChildren<QProcess*>()) {
+    if (process->state() == QProcess::NotRunning) {
+      continue;
+    }
+    process->disconnect(this);
+    process->terminate();
+    if (!process->waitForFinished(50)) {
+      process->kill();
+      process->waitForFinished(50);
+    }
+  }
+}
+
 bool OmarchyTheme::omarchyAvailable() const { return m_omarchyAvailable; }
 QString OmarchyTheme::themeName() const { return m_themeName; }
 QString OmarchyTheme::mode() const { return m_mode; }

--- a/src/theme/OmarchyTheme.h
+++ b/src/theme/OmarchyTheme.h
@@ -36,6 +36,7 @@ class OmarchyTheme final : public QObject {
 public:
   explicit OmarchyTheme(QObject* parent = nullptr);
   OmarchyTheme(QString stateHome, QString configHome, QObject* parent = nullptr);
+  ~OmarchyTheme() override;
 
   [[nodiscard]] bool omarchyAvailable() const;
   [[nodiscard]] QString themeName() const;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,7 +46,7 @@ add_test(NAME omakade_couch_navigation
   COMMAND omakade --couch --couch-navigation-test --render-size=1920x1080
 )
 set_tests_properties(omakade_couch_navigation PROPERTIES
-  ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1"
+  ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1;XDG_CONFIG_HOME=${CMAKE_CURRENT_BINARY_DIR}/config-couch-navigation"
   TIMEOUT 30
 )
 
@@ -97,7 +97,7 @@ add_test(NAME omakade_couch_thousand_game_navigation
   COMMAND omakade --couch --stress-test --couch-navigation-test --render-size=1920x1080
 )
 set_tests_properties(omakade_couch_thousand_game_navigation PROPERTIES
-  ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1;HYPRLAND_INSTANCE_SIGNATURE="
+  ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1;HYPRLAND_INSTANCE_SIGNATURE=;XDG_CONFIG_HOME=${CMAKE_CURRENT_BINARY_DIR}/config-thousand-navigation"
   TIMEOUT 10
 )
 
@@ -106,7 +106,7 @@ add_test(NAME omakade_couch_owned_navigation
           --uninstalled-layout-test --render-size=1920x1080
 )
 set_tests_properties(omakade_couch_owned_navigation PROPERTIES
-  ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1;HYPRLAND_INSTANCE_SIGNATURE="
+  ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1;HYPRLAND_INSTANCE_SIGNATURE=;XDG_CONFIG_HOME=${CMAKE_CURRENT_BINARY_DIR}/config-owned-navigation"
   TIMEOUT 10
 )
 set_tests_properties(omakade_controller_navigation_wide PROPERTIES
@@ -165,6 +165,26 @@ foreach(couch_case IN ITEMS 720p 1440p ultrawide 4k)
             --render-size=${couch_size}
   )
   set_tests_properties(omakade_couch_render_${couch_case} PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1"
+    TIMEOUT 30
+  )
+endforeach()
+
+foreach(grid_size IN ITEMS 720p 1080p 4k)
+  if(grid_size STREQUAL "720p")
+    set(grid_dimensions 1280x720)
+  elseif(grid_size STREQUAL "1080p")
+    set(grid_dimensions 1920x1080)
+  else()
+    set(grid_dimensions 3840x2160)
+  endif()
+  add_test(NAME omakade_couch_grid_${grid_size}_render
+    COMMAND omakade --couch --owned-layout-test
+            --render-overlay=couch-grid
+            --render-screenshot=${CMAKE_CURRENT_BINARY_DIR}/omakade-couch-grid-${grid_size}.png
+            --render-size=${grid_dimensions}
+  )
+  set_tests_properties(omakade_couch_grid_${grid_size}_render PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1"
     TIMEOUT 30
   )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ add_test(NAME omakade_couch_thousand_game_startup
 )
 set_tests_properties(omakade_couch_thousand_game_startup PROPERTIES
   ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1;HYPRLAND_INSTANCE_SIGNATURE="
+  RUN_SERIAL TRUE
   TIMEOUT 5
 )
 

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -3483,7 +3483,10 @@ void CoreTests::virtualControllerConnectsAndMapsPrimaryButton() {
   description.naxes = SDL_GAMEPAD_AXIS_COUNT;
   description.nbuttons = SDL_GAMEPAD_BUTTON_COUNT;
   description.button_mask = (1U << SDL_GAMEPAD_BUTTON_SOUTH) | (1U << SDL_GAMEPAD_BUTTON_WEST) |
-                            (1U << SDL_GAMEPAD_BUTTON_NORTH);
+                            (1U << SDL_GAMEPAD_BUTTON_NORTH) | (1U << SDL_GAMEPAD_BUTTON_DPAD_UP) |
+                            (1U << SDL_GAMEPAD_BUTTON_DPAD_DOWN) |
+                            (1U << SDL_GAMEPAD_BUTTON_DPAD_LEFT) |
+                            (1U << SDL_GAMEPAD_BUTTON_DPAD_RIGHT);
   description.axis_mask = (1U << SDL_GAMEPAD_AXIS_LEFTX) | (1U << SDL_GAMEPAD_AXIS_LEFTY);
   description.name = "Omakade test controller";
   const SDL_JoystickID id = SDL_AttachVirtualJoystick(&description);
@@ -3548,6 +3551,44 @@ void CoreTests::virtualControllerConnectsAndMapsPrimaryButton() {
   SDL_UpdateJoysticks();
   QTRY_VERIFY_WITH_TIMEOUT(!focusDirections.isEmpty(), 1000);
   QCOMPARE(focusDirections.first().at(0).toInt(), static_cast<int>(Qt::Key_Down));
+
+  QVERIFY(SDL_SetJoystickVirtualAxis(joystick, SDL_GAMEPAD_AXIS_LEFTY, 0));
+  SDL_UpdateJoysticks();
+  QTest::qWait(30);
+  focusDirections.clear();
+  SDL_Event dpadDown{};
+  dpadDown.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+  dpadDown.gbutton.which = id;
+  dpadDown.gbutton.button = SDL_GAMEPAD_BUTTON_DPAD_RIGHT;
+  QVERIFY(SDL_PushEvent(&dpadDown));
+  QTRY_VERIFY_WITH_TIMEOUT(focusDirections.size() >= 3, 700);
+  for (const QList<QVariant>& direction : std::as_const(focusDirections)) {
+    QCOMPARE(direction.at(0).toInt(), static_cast<int>(Qt::Key_Right));
+  }
+
+  SDL_Event dpadUp{};
+  dpadUp.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
+  dpadUp.gbutton.which = id;
+  dpadUp.gbutton.button = SDL_GAMEPAD_BUTTON_DPAD_RIGHT;
+  QVERIFY(SDL_PushEvent(&dpadUp));
+  QTest::qWait(50);
+  const qsizetype directionsAfterRelease = focusDirections.size();
+  QTest::qWait(300);
+  QCOMPARE(focusDirections.size(), directionsAfterRelease);
+
+  focusDirections.clear();
+  dpadDown.gbutton.button = SDL_GAMEPAD_BUTTON_DPAD_LEFT;
+  QVERIFY(SDL_PushEvent(&dpadDown));
+  QTRY_VERIFY_WITH_TIMEOUT(focusDirections.size() >= 3, 700);
+  for (const QList<QVariant>& direction : std::as_const(focusDirections)) {
+    QCOMPARE(direction.at(0).toInt(), static_cast<int>(Qt::Key_Left));
+  }
+  dpadUp.gbutton.button = SDL_GAMEPAD_BUTTON_DPAD_LEFT;
+  QVERIFY(SDL_PushEvent(&dpadUp));
+  QTest::qWait(50);
+  const qsizetype leftDirectionsAfterRelease = focusDirections.size();
+  QTest::qWait(300);
+  QCOMPARE(focusDirections.size(), leftDirectionsAfterRelease);
 
   SDL_CloseJoystick(joystick);
   SDL_Event removed{};

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -3076,6 +3076,7 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
     AppSettings settings(path);
     QVERIFY(!settings.closeAfterLaunch());
     QVERIFY(!settings.couchModeEnabled());
+    QCOMPARE(settings.couchLibraryView(), QStringLiteral("detail"));
     settings.setReducedMotion(true);
     settings.setArtworkCacheLimitMb(512);
     settings.setSteamId(QStringLiteral("76561198000000000"));
@@ -3091,6 +3092,7 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
     settings.setBattleNetEnabled(false);
     settings.setCloseAfterLaunch(true);
     settings.setCouchModeEnabled(true);
+    settings.setCouchLibraryView(QStringLiteral("grid"));
   }
   AppSettings reloaded(path);
   QVERIFY(reloaded.reducedMotion());
@@ -3109,6 +3111,7 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
   QVERIFY(!reloaded.battleNetEnabled());
   QVERIFY(reloaded.closeAfterLaunch());
   QVERIFY(reloaded.couchModeEnabled());
+  QCOMPARE(reloaded.couchLibraryView(), QStringLiteral("grid"));
 
   // A config without emulator keys keeps auto-detection pending and the keys absent
   // even after unrelated settings change.

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -63,6 +63,7 @@
 #include <SDL3/SDL.h>
 
 #include <algorithm>
+#include <atomic>
 
 namespace {
 // A launcher-style source that, like Lutris or Heroic, has no Installed role at all.
@@ -3536,6 +3537,21 @@ void CoreTests::virtualControllerConnectsAndMapsPrimaryButton() {
   const SDL_JoystickID id = SDL_AttachVirtualJoystick(&description);
   QVERIFY2(id != 0, SDL_GetError());
 
+  // A real controller may be in use while the offscreen suite runs.
+  std::atomic<SDL_JoystickID> testControllerId{id};
+  SDL_SetEventFilter([](void* context, SDL_Event* event) {
+    const auto allowed = static_cast<std::atomic<SDL_JoystickID>*>(context)->load();
+    if (event->type == SDL_EVENT_GAMEPAD_BUTTON_DOWN ||
+        event->type == SDL_EVENT_GAMEPAD_BUTTON_UP) {
+      return event->gbutton.which == allowed;
+    }
+    if (event->type == SDL_EVENT_GAMEPAD_AXIS_MOTION) {
+      return event->gaxis.which == allowed;
+    }
+    return true;
+  }, &testControllerId);
+  const auto clearEventFilter = qScopeGuard([] { SDL_SetEventFilter(nullptr, nullptr); });
+
   ControllerInput controller;
   controller.start();
   QTRY_VERIFY_WITH_TIMEOUT(controller.connected(), 1000);
@@ -3634,6 +3650,42 @@ void CoreTests::virtualControllerConnectsAndMapsPrimaryButton() {
   QTest::qWait(300);
   QCOMPARE(focusDirections.size(), leftDirectionsAfterRelease);
 
+  // Losing focus must cancel held navigation and suppress every controller action.
+  QVERIFY(SDL_PushEvent(&dpadDown));
+  QTRY_VERIFY_WITH_TIMEOUT(focusDirections.size() > leftDirectionsAfterRelease, 700);
+  controller.setInputEnabled(false);
+  keys.clear();
+  focusDirections.clear();
+  favorites.clear();
+  toolbar.clear();
+  for (int button : {SDL_GAMEPAD_BUTTON_SOUTH, SDL_GAMEPAD_BUTTON_EAST,
+                     SDL_GAMEPAD_BUTTON_START, SDL_GAMEPAD_BUTTON_WEST,
+                     SDL_GAMEPAD_BUTTON_NORTH, SDL_GAMEPAD_BUTTON_DPAD_RIGHT}) {
+    SDL_Event backgroundButton{};
+    backgroundButton.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    backgroundButton.gbutton.which = id;
+    backgroundButton.gbutton.button = button;
+    QVERIFY(SDL_PushEvent(&backgroundButton));
+  }
+  QVERIFY(SDL_SetJoystickVirtualAxis(joystick, SDL_GAMEPAD_AXIS_LEFTX, 20000));
+  SDL_UpdateJoysticks();
+  QTest::qWait(400);
+  QVERIFY(keys.isEmpty());
+  QVERIFY(focusDirections.isEmpty());
+  QVERIFY(favorites.isEmpty());
+  QVERIFY(toolbar.isEmpty());
+
+  // Input already queued on return must not be replayed, nor may an old hold resume.
+  QVERIFY(SDL_PushEvent(&favorite));
+  controller.setInputEnabled(true);
+  QTest::qWait(350);
+  QVERIFY(keys.isEmpty());
+  QVERIFY(focusDirections.isEmpty());
+  QVERIFY(favorites.isEmpty());
+  QVERIFY(toolbar.isEmpty());
+  QVERIFY(SDL_PushEvent(&favorite));
+  QTRY_COMPARE_WITH_TIMEOUT(favorites.size(), 1, 1000);
+
   SDL_CloseJoystick(joystick);
   SDL_Event removed{};
   removed.type = SDL_EVENT_GAMEPAD_REMOVED;
@@ -3647,6 +3699,7 @@ void CoreTests::virtualControllerConnectsAndMapsPrimaryButton() {
 
   const SDL_JoystickID reconnectedId = SDL_AttachVirtualJoystick(&description);
   QVERIFY2(reconnectedId != 0, SDL_GetError());
+  testControllerId.store(reconnectedId);
   QTRY_COMPARE_WITH_TIMEOUT(controller.controllerCount(), connectedCount, 1000);
   SDL_Joystick* reconnectedJoystick = SDL_OpenJoystick(reconnectedId);
   QVERIFY(reconnectedJoystick != nullptr);

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -8,6 +8,7 @@
 #include "app/AppSettings.h"
 #include "app/SingleInstance.h"
 #include "input/ControllerInput.h"
+#include "input/CouchCursorManager.h"
 #include "launch/GameLauncher.h"
 #include "launch/PlayRequest.h"
 #include "launch/SteamLauncher.h"
@@ -47,6 +48,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QMouseEvent>
 #include <QScopeGuard>
 #include <QSignalSpy>
 #include <QSqlDatabase>
@@ -56,6 +58,7 @@
 #include <QTimer>
 #include <QUrl>
 #include <QUuid>
+#include <QWindow>
 
 #include <SDL3/SDL.h>
 
@@ -566,6 +569,7 @@ private slots:
   void singleInstanceForwardsPlayAndQuitCommands();
   void sunshineIntegrationWritesOnlyItsOwnEntries();
   void secondInstanceRequestsActivation();
+  void couchCursorFollowsInputMode();
   void virtualControllerConnectsAndMapsPrimaryButton();
   void thousandGameSearchStaysResponsive();
 };
@@ -3473,6 +3477,46 @@ void CoreTests::secondInstanceRequestsActivation() {
   SingleInstance secondary(name);
   QVERIFY(!secondary.claimOrNotify());
   QTRY_COMPARE_WITH_TIMEOUT(activation.size(), 1, 1000);
+}
+
+void CoreTests::couchCursorFollowsInputMode() {
+  QWindow window;
+  window.setProperty("couchMode", false);
+  CouchCursorManager cursor(&window, 30);
+
+  QVERIFY(!cursor.cursorHidden());
+  window.setProperty("couchMode", true);
+  cursor.syncCouchMode();
+  QVERIFY(!cursor.cursorHidden());
+  QTRY_VERIFY_WITH_TIMEOUT(cursor.cursorHidden(), 250);
+
+  QMouseEvent move(QEvent::MouseMove, QPointF(20, 20), QPointF(20, 20), Qt::NoButton, Qt::NoButton,
+                   Qt::NoModifier);
+  QCoreApplication::sendEvent(&window, &move);
+  QVERIFY(!cursor.cursorHidden());
+
+  cursor.navigationActivity();
+  QVERIFY(cursor.cursorHidden());
+
+  QMouseEvent stationaryMove(QEvent::MouseMove, QPointF(20, 20), QPointF(20, 20), Qt::NoButton,
+                             Qt::NoButton, Qt::NoModifier);
+  QCoreApplication::sendEvent(&window, &stationaryMove);
+  QVERIFY(cursor.cursorHidden());
+
+  QMouseEvent secondMove(QEvent::MouseMove, QPointF(24, 20), QPointF(24, 20), Qt::NoButton,
+                         Qt::NoButton, Qt::NoModifier);
+  QCoreApplication::sendEvent(&window, &secondMove);
+  QVERIFY(!cursor.cursorHidden());
+
+  QKeyEvent keyPress(QEvent::KeyPress, Qt::Key_Right, Qt::NoModifier);
+  QCoreApplication::sendEvent(&window, &keyPress);
+  QVERIFY(cursor.cursorHidden());
+
+  window.setProperty("couchMode", false);
+  cursor.syncCouchMode();
+  QVERIFY(!cursor.cursorHidden());
+  QTest::qWait(60);
+  QVERIFY(!cursor.cursorHidden());
 }
 
 void CoreTests::virtualControllerConnectsAndMapsPrimaryButton() {

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -317,7 +317,9 @@ void createHeroicFixture(const QString& root) {
   writeFile(root + QStringLiteral("/gog_store/installed.json"),
             R"({"installed":[{"appName":"12345","install_path":")" +
                 (root + QStringLiteral("/gog-game")).toUtf8() + R"(","is_dlc":false}]})");
-  writeFile(root + QStringLiteral("/gog-game/goggame-12345.info"), R"({"name":"GOG Quest"})");
+  writeFile(root + QStringLiteral("/gog-game/goggame-12345.info"),
+            R"({"name":"GOG Quest","playTasks":[{"isPrimary":true,"type":"FileTask","path":"start.sh","arguments":"--profile \"couch mode\"","workingDir":""}]})");
+  writeFile(root + QStringLiteral("/gog-game/start.sh"), "#!/bin/sh\n");
   writeFile(root + QStringLiteral("/store_cache/gog_library.json"),
             R"({"games":[{"app_name":"12345","title":"GOG Quest","art_square":""}]})");
 
@@ -514,9 +516,12 @@ private slots:
   void organizationPersistsAndFilters();
   void lutrisLauncherBuildsSafeCommands();
   void heroicScannerImportsEpicGogAndAmazon();
+  void gogScannerImportsLooseInstallsAndConfinesLaunchTasks();
   void heroicModelIsRepeatableAndPreservesLocalState();
   void malformedHeroicDataDoesNotReplaceCachedGames();
+  void heroicAndGogScanFailuresAreIsolated();
   void heroicLauncherBuildsSafeCommands();
+  void gogLauncherBuildsSafeCommands();
   void faugusScannerImportsLaunchableGamesAndArtwork();
   void faugusModelIsRepeatableAndPreservesLocalState();
   void malformedFaugusDataDoesNotReplaceCachedGames();
@@ -1797,6 +1802,12 @@ void CoreTests::heroicScannerImportsEpicGogAndAmazon() {
   QCOMPARE(result.games.at(1).runner, QStringLiteral("gog"));
   QCOMPARE(result.games.at(1).title, QStringLiteral("GOG Quest"));
   QCOMPARE(result.games.at(1).playtimeMinutes, 0);
+  const std::optional<GogLaunchTask> launchTask =
+      HeroicScanner::gogLaunchTask(result.games.at(1).installPath, result.games.at(1).appId);
+  QVERIFY(launchTask.has_value());
+  QVERIFY(launchTask->executablePath.endsWith(QStringLiteral("/gog-game/start.sh")));
+  QCOMPARE(launchTask->arguments,
+           QStringList({QStringLiteral("--profile"), QStringLiteral("couch mode")}));
   QCOMPARE(result.games.at(2).runner, QStringLiteral("nile"));
   QCOMPARE(result.games.at(2).title, QStringLiteral("Amazon Trail"));
   // Sideloaded games come from sideload_apps/library.json; uninstalled entries stay out.
@@ -1818,6 +1829,36 @@ void CoreTests::heroicScannerImportsEpicGogAndAmazon() {
   QCOMPARE(sideload.games.at(0).installPath, QStringLiteral("/games/only"));
 }
 
+void CoreTests::gogScannerImportsLooseInstallsAndConfinesLaunchTasks() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/GOG Games");
+  const QString game = root + QStringLiteral("/Signal Hill");
+  writeFile(game + QStringLiteral("/goggame-98765.info"),
+            R"({"name":"Signal Hill","playTasks":[{"type":"FileTask","isPrimary":true,"path":"bin\\game.exe","workingDir":"bin","arguments":"--safe \"two words\""}]})");
+  writeFile(game + QStringLiteral("/bin/game.exe"), "game");
+
+  const HeroicScanResult result = HeroicScanner::scan({root});
+  QVERIFY(!result.incomplete);
+  QCOMPARE(result.roots, QStringList({root}));
+  QCOMPARE(result.games.size(), 1);
+  QCOMPARE(result.games.at(0).appId, QStringLiteral("98765"));
+  QCOMPARE(result.games.at(0).runner, QStringLiteral("gog-direct"));
+  QCOMPARE(result.games.at(0).title, QStringLiteral("Signal Hill"));
+
+  const QString outside = directory.path() + QStringLiteral("/outside.exe");
+  writeFile(outside, "outside");
+  QVERIFY(QFile::link(outside, game + QStringLiteral("/bin/linked.exe")));
+  writeFile(game + QStringLiteral("/goggame-98765.info"),
+            R"({"name":"Signal Hill","playTasks":[{"type":"FileTask","isPrimary":true,"path":"bin/linked.exe"}]})");
+  QVERIFY(!HeroicScanner::gogLaunchTask(game, QStringLiteral("98765")).has_value());
+
+  writeFile(game + QStringLiteral("/goggame-98765.info"),
+            R"({"name":"Signal Hill","playTasks":[{"type":"FileTask","isPrimary":true,"path":"../escape.exe"}]})");
+  QVERIFY(!HeroicScanner::gogLaunchTask(game, QStringLiteral("98765")).has_value());
+  QVERIFY(!HeroicScanner::gogLaunchTask(game, QStringLiteral("98765;touch")).has_value());
+}
+
 void CoreTests::heroicModelIsRepeatableAndPreservesLocalState() {
   QTemporaryDir directory;
   QVERIFY(directory.isValid());
@@ -1828,6 +1869,9 @@ void CoreTests::heroicModelIsRepeatableAndPreservesLocalState() {
   QCOMPARE(model.rowCount(), 4);
   QCOMPARE(model.detectedPaths(), QStringList({root}));
   QVERIFY(model.lastScan() > 0);
+  QVERIFY(model.heroicDetected());
+  QVERIFY(!model.gogDetected());
+  QCOMPARE(model.data(model.index(2), GameRoles::Source).toString(), QStringLiteral("Heroic"));
   QCOMPARE(model.data(model.index(1), GameRoles::AppId).toString(), QStringLiteral("EpicApp"));
   QCOMPARE(model.data(model.index(1), GameRoles::Hours).toInt(), 2);
   QVERIFY(model.data(model.index(1), GameRoles::Recent).toBool());
@@ -1854,7 +1898,43 @@ void CoreTests::malformedHeroicDataDoesNotReplaceCachedGames() {
   writeFile(root + QStringLiteral("/legendaryConfig/legendary/installed.json"), "not json");
   model.refreshFromRoots({root});
   QCOMPARE(model.rowCount(), 4);
-  QVERIFY(model.statusText().startsWith(QStringLiteral("Heroic scan interrupted")));
+  QVERIFY(model.statusText().contains(QStringLiteral("kept cached results")));
+}
+
+void CoreTests::heroicAndGogScanFailuresAreIsolated() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString heroicRoot = directory.path() + QStringLiteral("/heroic");
+  const QString gogRoot = directory.path() + QStringLiteral("/GOG Games");
+  const QString directGame = gogRoot + QStringLiteral("/Direct Quest");
+  createHeroicFixture(heroicRoot);
+  writeFile(directGame + QStringLiteral("/goggame-98765.info"),
+            R"({"name":"Direct Quest","playTasks":[{"type":"FileTask","isPrimary":true,"path":"start.sh"}]})");
+  writeFile(directGame + QStringLiteral("/start.sh"), "#!/bin/sh\n");
+
+  HeroicGameModel model(directory.path() + QStringLiteral("/omakade.sqlite3"));
+  model.refreshFromRoots({heroicRoot, gogRoot});
+  QCOMPARE(model.rowCount(), 5);
+  QVERIFY(model.heroicDetected());
+  QVERIFY(model.gogDetected());
+
+  writeFile(heroicRoot + QStringLiteral("/legendaryConfig/legendary/installed.json"),
+            "not json");
+  model.refreshFromRoots({heroicRoot, gogRoot});
+  QCOMPARE(model.rowCount(), 5);
+  QVERIFY(model.statusText().contains(QStringLiteral("kept cached results")));
+
+  createHeroicFixture(heroicRoot);
+  writeFile(heroicRoot + QStringLiteral("/gog_store/installed.json"), "not json");
+  model.refreshFromRoots({heroicRoot, gogRoot});
+  QCOMPARE(model.rowCount(), 5);
+  QVERIFY(model.statusText().contains(QStringLiteral("kept cached results")));
+
+  createHeroicFixture(heroicRoot);
+  writeFile(directGame + QStringLiteral("/goggame-98765.info"), "not json");
+  model.refreshFromRoots({heroicRoot, gogRoot});
+  QCOMPARE(model.rowCount(), 5);
+  QVERIFY(model.statusText().contains(QStringLiteral("kept cached results")));
 }
 
 void CoreTests::heroicLauncherBuildsSafeCommands() {
@@ -1876,6 +1956,36 @@ void CoreTests::heroicLauncherBuildsSafeCommands() {
       QStringLiteral("j661Z9rpxqYRZSp45Jh92i"), QStringLiteral("sideload"), false);
   QVERIFY(sideload.isValid());
   QVERIFY(sideload.arguments.constLast().contains(QStringLiteral("runner=sideload")));
+}
+
+void CoreTests::gogLauncherBuildsSafeCommands() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString nativeGame = directory.path() + QStringLiteral("/native");
+  writeFile(nativeGame + QStringLiteral("/goggame-123.info"),
+            R"({"playTasks":[{"type":"FileTask","isPrimary":true,"path":"start.sh","arguments":"--profile \"living room\""}]})");
+  writeFile(nativeGame + QStringLiteral("/start.sh"), "#!/bin/sh\n");
+  const LaunchCommand native =
+      GameLauncher::gogCommand(QStringLiteral("123"), nativeGame);
+  QVERIFY(native.program.endsWith(QStringLiteral("/native/start.sh")));
+  QCOMPARE(native.arguments,
+           QStringList({QStringLiteral("--profile"), QStringLiteral("living room")}));
+
+  const QString windowsGame = directory.path() + QStringLiteral("/windows");
+  writeFile(windowsGame + QStringLiteral("/goggame-456.info"),
+            R"({"playTasks":[{"type":"FileTask","isPrimary":true,"path":"game.exe","arguments":"-windowed"}]})");
+  writeFile(windowsGame + QStringLiteral("/game.exe"), "game");
+  const QString prefix = directory.path() + QStringLiteral("/prefix");
+  const LaunchCommand windows =
+      GameLauncher::gogCommand(QStringLiteral("456"), windowsGame, prefix);
+  QCOMPARE(windows.program, QStringLiteral("env"));
+  QCOMPARE(windows.arguments.at(0), QStringLiteral("WINEPREFIX=%1").arg(prefix));
+  QCOMPARE(windows.arguments.at(1), QStringLiteral("GAMEID=umu-default"));
+  QCOMPARE(windows.arguments.at(2), QStringLiteral("STORE=gog"));
+  QCOMPARE(windows.arguments.at(3), QStringLiteral("umu-run"));
+  QVERIFY(windows.arguments.at(4).endsWith(QStringLiteral("/windows/game.exe")));
+  QCOMPARE(windows.arguments.at(5), QStringLiteral("-windowed"));
+  QVERIFY(!GameLauncher::gogCommand(QStringLiteral("456;touch"), windowsGame).isValid());
 }
 
 void CoreTests::faugusScannerImportsLaunchableGamesAndArtwork() {
@@ -2019,7 +2129,7 @@ void CoreTests::launcherRefreshesRunAsynchronously() {
   faugus.refresh();
   battlenet.refresh();
   QCOMPARE(lutris.statusText(), QStringLiteral("Scanning Lutris library"));
-  QCOMPARE(heroic.statusText(), QStringLiteral("Scanning Heroic library"));
+  QCOMPARE(heroic.statusText(), QStringLiteral("Scanning Heroic and GOG libraries"));
   QCOMPARE(faugus.statusText(), QStringLiteral("Scanning Faugus library"));
   QCOMPARE(battlenet.statusText(), QStringLiteral("Scanning Battle.net library"));
   QVERIFY(battlenet.scanning());
@@ -2325,6 +2435,7 @@ void CoreTests::battleNetScannerDiscoversKnownPrefixes() {
   createBattleNetFixture(data + QStringLiteral("/bottles/bottles/Wow"));
   writeFile(data + QStringLiteral("/bottles/bottles/Wow/bottle.yml"), "Name: Wow\n");
   createBattleNetFixture(home + QStringLiteral("/Games/battlenet"));
+  writeFile(home + QStringLiteral("/Games/battlenet/version"), "GE-Proton11-6\n");
   const QString steamRoot = home + QStringLiteral("/.local/share/Steam");
   createBattleNetFixture(steamRoot + QStringLiteral("/steamapps/compatdata/4242/pfx"));
   writeFile(steamRoot + QStringLiteral("/steamapps/compatdata/4242/version"), "9.0\n");
@@ -2345,6 +2456,9 @@ void CoreTests::battleNetScannerDiscoversKnownPrefixes() {
   const BattleNetScanResult proton =
       BattleNetScanner::scan({steamRoot + QStringLiteral("/steamapps/compatdata/4242/pfx")});
   QCOMPARE(proton.games.at(0).runner, QStringLiteral("proton"));
+  const BattleNetScanResult omarchy =
+      BattleNetScanner::scan({home + QStringLiteral("/Games/battlenet")});
+  QCOMPARE(omarchy.games.at(0).runner, QStringLiteral("proton"));
 }
 
 void CoreTests::battleNetScannerKeepsInstallsFromSeparatePrefixes() {
@@ -2524,6 +2638,18 @@ void CoreTests::battleNetLauncherBuildsSafeCommands() {
   QCOMPARE(proton.arguments.at(1), QStringLiteral("umu-run"));
   QVERIFY(proton.arguments.at(2).contains(QStringLiteral("Battle.net.exe")));
   QCOMPARE(proton.arguments.constLast(), QStringLiteral("--exec=launch S2"));
+  QTemporaryDir omarchyPrefixDir;
+  QVERIFY(omarchyPrefixDir.isValid());
+  const QString omarchyPrefix = omarchyPrefixDir.path() + QStringLiteral("/battlenet");
+  createBattleNetFixture(omarchyPrefix);
+  writeFile(omarchyPrefix + QStringLiteral("/version"), "GE-Proton11-6\n");
+  const LaunchCommand omarchy = GameLauncher::battleNetCommand(
+      QStringLiteral("wow"), omarchyPrefix, QStringLiteral("proton"), false);
+  QCOMPARE(omarchy.program, QStringLiteral("env"));
+  QVERIFY(omarchy.arguments.contains(QStringLiteral("GAMEID=umu-battlenet")));
+  QVERIFY(omarchy.arguments.contains(QStringLiteral("STORE=battlenet")));
+  QVERIFY(omarchy.arguments.contains(QStringLiteral("PROTONPATH=GE-Proton")));
+  QVERIFY(omarchy.arguments.contains(QStringLiteral("PROTON_VERB=run")));
   QVERIFY(!GameLauncher::battleNetCommand(QStringLiteral("bad;id"), prefix, QStringLiteral("wine"),
                                           false)
                .isValid());
@@ -3083,6 +3209,7 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
     settings.setIgdbClientId(QStringLiteral("publicclient123"));
     settings.setSteamEnabled(false);
     settings.setLutrisEnabled(false);
+    settings.setGogEnabled(false);
     settings.setFaugusEnabled(false);
     settings.setRetroArchEnabled(false);
     QVERIFY(settings.pcsx2AutoEnabled());
@@ -3102,6 +3229,7 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
   QVERIFY(!reloaded.steamEnabled());
   QVERIFY(!reloaded.lutrisEnabled());
   QVERIFY(reloaded.heroicEnabled());
+  QVERIFY(!reloaded.gogEnabled());
   QVERIFY(!reloaded.faugusEnabled());
   QVERIFY(!reloaded.retroArchEnabled());
   QVERIFY(!reloaded.pcsx2Enabled());

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -524,6 +524,8 @@ private slots:
   void heroicModelIsRepeatableAndPreservesLocalState();
   void malformedHeroicDataDoesNotReplaceCachedGames();
   void heroicAndGogScanFailuresAreIsolated();
+  void coldManagedGogFailureDoesNotImportDirectGames();
+  void removingLastDirectGogGameClearsCache();
   void heroicLauncherBuildsSafeCommands();
   void gogLauncherBuildsSafeCommands();
   void faugusScannerImportsLaunchableGamesAndArtwork();
@@ -1940,6 +1942,49 @@ void CoreTests::heroicAndGogScanFailuresAreIsolated() {
   model.refreshFromRoots({heroicRoot, gogRoot});
   QCOMPARE(model.rowCount(), 5);
   QVERIFY(model.statusText().contains(QStringLiteral("kept cached results")));
+}
+
+void CoreTests::coldManagedGogFailureDoesNotImportDirectGames() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/heroic");
+  createHeroicFixture(root);
+  writeFile(root + QStringLiteral("/gog_store/installed.json"), "not json");
+  const HeroicScanResult result = HeroicScanner::scan({root});
+  QVERIFY(result.managedGogIncomplete);
+  for (const HeroicGameRecord& game : result.games) {
+    QVERIFY(game.runner != QStringLiteral("gog-direct"));
+  }
+  HeroicGameModel model(directory.path() + QStringLiteral("/library.sqlite3"));
+  model.refreshFromRoots({root});
+  QVERIFY(!model.gogDetected());
+  createHeroicFixture(root);
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 4);
+  QVERIFY(model.heroicDetected());
+  QVERIFY(!model.gogDetected());
+}
+
+void CoreTests::removingLastDirectGogGameClearsCache() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/GOG Games");
+  const QString game = root + QStringLiteral("/Direct Quest");
+  writeFile(game + QStringLiteral("/goggame-98765.info"),
+            R"({"name":"Direct Quest","playTasks":[{"type":"FileTask","isPrimary":true,"path":"start.sh"}]})");
+  writeFile(game + QStringLiteral("/start.sh"), "#!/bin/sh\n");
+  const QString database = directory.path() + QStringLiteral("/library.sqlite3");
+  HeroicGameModel model(database);
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 1);
+  model.refreshFromRoots({directory.path() + QStringLiteral("/missing")});
+  QCOMPARE(model.rowCount(), 1);
+  QVERIFY(QFile::remove(game + QStringLiteral("/goggame-98765.info")));
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 0);
+  QVERIFY(!model.gogDetected());
+  HeroicGameModel reloaded(database);
+  QCOMPARE(reloaded.rowCount(), 0);
 }
 
 void CoreTests::heroicLauncherBuildsSafeCommands() {


### PR DESCRIPTION
Adds controller-first Couch Mode with Detail and Grid views, direct GOG support, and the Omarchy Battle.net Proton fix. Launched games keep controller focus. GOG rescans handle broken Heroic inventories and removal of the last installed game.

Validation:
- Candidate c91b14e: 41/41 release tests, metadata, release-tooling, and staged-install checks pass.
- Maintainer tested the installed candidate and approved publication.
- x86_64 and aarch64 builds, package lifecycle checks, scans, and artifact checksums pass: [package validation](https://github.com/btsouth/omakade/actions/runs/33938436079).

ARM64 hardware testing and broader real-library reports remain open. Published assets and signed provenance are verified; main is updated.

Released as [Omakade 1.6.0](https://github.com/btsouth/omakade/releases/tag/v1.6.0).
