### PR TITLE
Share QML role names across game models

### DIFF
--- a/src/library/BattleNetGameModel.cpp
+++ b/src/library/BattleNetGameModel.cpp
@@ -148,31 +148,10 @@ QVariant BattleNetGameModel::data(const QModelIndex& index, int role) const {
 }
 
 QHash<int, QByteArray> BattleNetGameModel::roleNames() const {
-  return {{GameRoles::Title, "title"},
-          {GameRoles::Subtitle, "subtitle"},
-          {GameRoles::Description, "description"},
-          {GameRoles::Hours, "hours"},
-          {GameRoles::Progress, "progress"},
-          {GameRoles::AchievementsUnlocked, "achievementsUnlocked"},
-          {GameRoles::AchievementsTotal, "achievementsTotal"},
-          {GameRoles::Favorite, "favorite"},
-          {GameRoles::Recent, "recent"},
-          {GameRoles::LastPlayed, "lastPlayed"},
-          {GameRoles::AccentStart, "accentStart"},
-          {GameRoles::AccentEnd, "accentEnd"},
-          {GameRoles::CoverMark, "coverMark"},
-          {GameRoles::Year, "year"},
-          {GameRoles::AppId, "appId"},
-          {GameRoles::CoverPath, "coverPath"},
-          {GameRoles::HeroPath, "heroPath"},
-          {GameRoles::LogoPath, "logoPath"},
-          {GameRoles::InstallPath, "installPath"},
-          {GameRoles::Source, "source"},
-          {GameRoles::Runner, "runner"},
-          {GameRoles::Flatpak, "flatpak"},
-          {GameRoles::Hidden, "hidden"},
-          {GameRoles::LaunchTarget, "launchTarget"},
-          {GameRoles::Installed, "installed"}};
+  auto roles = GameRoles::names();
+  roles.insert(GameRoles::LaunchTarget, "launchTarget");
+  roles.insert(GameRoles::Installed, "installed");
+  return roles;
 }
 
 bool BattleNetGameModel::battleNetDetected() const { return m_battleNetDetected; }

--- a/src/library/FaugusGameModel.cpp
+++ b/src/library/FaugusGameModel.cpp
@@ -59,29 +59,7 @@ QVariant FaugusGameModel::data(const QModelIndex& index, int role) const {
 }
 
 QHash<int, QByteArray> FaugusGameModel::roleNames() const {
-  return {{GameRoles::Title, "title"},
-          {GameRoles::Subtitle, "subtitle"},
-          {GameRoles::Description, "description"},
-          {GameRoles::Hours, "hours"},
-          {GameRoles::Progress, "progress"},
-          {GameRoles::AchievementsUnlocked, "achievementsUnlocked"},
-          {GameRoles::AchievementsTotal, "achievementsTotal"},
-          {GameRoles::Favorite, "favorite"},
-          {GameRoles::Recent, "recent"},
-          {GameRoles::LastPlayed, "lastPlayed"},
-          {GameRoles::AccentStart, "accentStart"},
-          {GameRoles::AccentEnd, "accentEnd"},
-          {GameRoles::CoverMark, "coverMark"},
-          {GameRoles::Year, "year"},
-          {GameRoles::AppId, "appId"},
-          {GameRoles::CoverPath, "coverPath"},
-          {GameRoles::HeroPath, "heroPath"},
-          {GameRoles::LogoPath, "logoPath"},
-          {GameRoles::InstallPath, "installPath"},
-          {GameRoles::Source, "source"},
-          {GameRoles::Runner, "runner"},
-          {GameRoles::Flatpak, "flatpak"},
-          {GameRoles::Hidden, "hidden"}};
+  return GameRoles::names();
 }
 
 bool FaugusGameModel::faugusDetected() const { return m_faugusDetected; }

--- a/src/library/GameRoles.h
+++ b/src/library/GameRoles.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QByteArray>
+#include <QHash>
 #include <Qt>
 
 namespace GameRoles {
@@ -36,4 +38,32 @@ enum Role {
   LaunchTarget,
   Installed,
 };
+
+inline QHash<int, QByteArray> names() {
+  return {
+      {Title, "title"},
+      {Subtitle, "subtitle"},
+      {Description, "description"},
+      {Hours, "hours"},
+      {Progress, "progress"},
+      {AchievementsUnlocked, "achievementsUnlocked"},
+      {AchievementsTotal, "achievementsTotal"},
+      {Favorite, "favorite"},
+      {Recent, "recent"},
+      {LastPlayed, "lastPlayed"},
+      {AccentStart, "accentStart"},
+      {AccentEnd, "accentEnd"},
+      {CoverMark, "coverMark"},
+      {Year, "year"},
+      {AppId, "appId"},
+      {CoverPath, "coverPath"},
+      {HeroPath, "heroPath"},
+      {LogoPath, "logoPath"},
+      {InstallPath, "installPath"},
+      {Source, "source"},
+      {Runner, "runner"},
+      {Flatpak, "flatpak"},
+      {Hidden, "hidden"},
+  };
 }
+} // namespace GameRoles

--- a/src/library/HeroicGameModel.cpp
+++ b/src/library/HeroicGameModel.cpp
@@ -75,29 +75,7 @@ QVariant HeroicGameModel::data(const QModelIndex& index, int role) const {
 }
 
 QHash<int, QByteArray> HeroicGameModel::roleNames() const {
-  return {{GameRoles::Title, "title"},
-          {GameRoles::Subtitle, "subtitle"},
-          {GameRoles::Description, "description"},
-          {GameRoles::Hours, "hours"},
-          {GameRoles::Progress, "progress"},
-          {GameRoles::AchievementsUnlocked, "achievementsUnlocked"},
-          {GameRoles::AchievementsTotal, "achievementsTotal"},
-          {GameRoles::Favorite, "favorite"},
-          {GameRoles::Recent, "recent"},
-          {GameRoles::LastPlayed, "lastPlayed"},
-          {GameRoles::AccentStart, "accentStart"},
-          {GameRoles::AccentEnd, "accentEnd"},
-          {GameRoles::CoverMark, "coverMark"},
-          {GameRoles::Year, "year"},
-          {GameRoles::AppId, "appId"},
-          {GameRoles::CoverPath, "coverPath"},
-          {GameRoles::HeroPath, "heroPath"},
-          {GameRoles::LogoPath, "logoPath"},
-          {GameRoles::InstallPath, "installPath"},
-          {GameRoles::Source, "source"},
-          {GameRoles::Runner, "runner"},
-          {GameRoles::Flatpak, "flatpak"},
-          {GameRoles::Hidden, "hidden"}};
+  return GameRoles::names();
 }
 
 bool HeroicGameModel::heroicDetected() const { return m_heroicDetected; }

--- a/src/library/LutrisGameModel.cpp
+++ b/src/library/LutrisGameModel.cpp
@@ -59,29 +59,7 @@ QVariant LutrisGameModel::data(const QModelIndex& index, int role) const {
 }
 
 QHash<int, QByteArray> LutrisGameModel::roleNames() const {
-  return {{GameRoles::Title, "title"},
-          {GameRoles::Subtitle, "subtitle"},
-          {GameRoles::Description, "description"},
-          {GameRoles::Hours, "hours"},
-          {GameRoles::Progress, "progress"},
-          {GameRoles::AchievementsUnlocked, "achievementsUnlocked"},
-          {GameRoles::AchievementsTotal, "achievementsTotal"},
-          {GameRoles::Favorite, "favorite"},
-          {GameRoles::Recent, "recent"},
-          {GameRoles::LastPlayed, "lastPlayed"},
-          {GameRoles::AccentStart, "accentStart"},
-          {GameRoles::AccentEnd, "accentEnd"},
-          {GameRoles::CoverMark, "coverMark"},
-          {GameRoles::Year, "year"},
-          {GameRoles::AppId, "appId"},
-          {GameRoles::CoverPath, "coverPath"},
-          {GameRoles::HeroPath, "heroPath"},
-          {GameRoles::LogoPath, "logoPath"},
-          {GameRoles::InstallPath, "installPath"},
-          {GameRoles::Source, "source"},
-          {GameRoles::Runner, "runner"},
-          {GameRoles::Flatpak, "flatpak"},
-          {GameRoles::Hidden, "hidden"}};
+  return GameRoles::names();
 }
 
 bool LutrisGameModel::lutrisDetected() const { return m_lutrisDetected; }

--- a/src/library/MockGameModel.cpp
+++ b/src/library/MockGameModel.cpp
@@ -93,32 +93,9 @@ QVariant MockGameModel::data(const QModelIndex& index, int role) const {
 }
 
 QHash<int, QByteArray> MockGameModel::roleNames() const {
-  return {
-      {GameRoles::Title, "title"},
-      {GameRoles::Subtitle, "subtitle"},
-      {GameRoles::Description, "description"},
-      {GameRoles::Hours, "hours"},
-      {GameRoles::Progress, "progress"},
-      {GameRoles::AchievementsUnlocked, "achievementsUnlocked"},
-      {GameRoles::AchievementsTotal, "achievementsTotal"},
-      {GameRoles::Favorite, "favorite"},
-      {GameRoles::Recent, "recent"},
-      {GameRoles::LastPlayed, "lastPlayed"},
-      {GameRoles::AccentStart, "accentStart"},
-      {GameRoles::AccentEnd, "accentEnd"},
-      {GameRoles::CoverMark, "coverMark"},
-      {GameRoles::Year, "year"},
-      {GameRoles::AppId, "appId"},
-      {GameRoles::CoverPath, "coverPath"},
-      {GameRoles::HeroPath, "heroPath"},
-      {GameRoles::LogoPath, "logoPath"},
-      {GameRoles::InstallPath, "installPath"},
-      {GameRoles::Source, "source"},
-      {GameRoles::Runner, "runner"},
-      {GameRoles::Flatpak, "flatpak"},
-      {GameRoles::Hidden, "hidden"},
-      {GameRoles::Installed, "installed"},
-  };
+  auto roles = GameRoles::names();
+  roles.insert(GameRoles::Installed, "installed");
+  return roles;
 }
 
 QVariantMap MockGameModel::get(int row) const {

--- a/src/library/Pcsx2GameModel.cpp
+++ b/src/library/Pcsx2GameModel.cpp
@@ -59,30 +59,9 @@ QVariant Pcsx2GameModel::data(const QModelIndex& index, int role) const {
 }
 
 QHash<int, QByteArray> Pcsx2GameModel::roleNames() const {
-  return {{GameRoles::Title, "title"},
-          {GameRoles::Subtitle, "subtitle"},
-          {GameRoles::Description, "description"},
-          {GameRoles::Hours, "hours"},
-          {GameRoles::Progress, "progress"},
-          {GameRoles::AchievementsUnlocked, "achievementsUnlocked"},
-          {GameRoles::AchievementsTotal, "achievementsTotal"},
-          {GameRoles::Favorite, "favorite"},
-          {GameRoles::Recent, "recent"},
-          {GameRoles::LastPlayed, "lastPlayed"},
-          {GameRoles::AccentStart, "accentStart"},
-          {GameRoles::AccentEnd, "accentEnd"},
-          {GameRoles::CoverMark, "coverMark"},
-          {GameRoles::Year, "year"},
-          {GameRoles::AppId, "appId"},
-          {GameRoles::CoverPath, "coverPath"},
-          {GameRoles::HeroPath, "heroPath"},
-          {GameRoles::LogoPath, "logoPath"},
-          {GameRoles::InstallPath, "installPath"},
-          {GameRoles::Source, "source"},
-          {GameRoles::Runner, "runner"},
-          {GameRoles::Flatpak, "flatpak"},
-          {GameRoles::Hidden, "hidden"},
-          {GameRoles::LaunchTarget, "launchTarget"}};
+  auto roles = GameRoles::names();
+  roles.insert(GameRoles::LaunchTarget, "launchTarget");
+  return roles;
 }
 
 bool Pcsx2GameModel::pcsx2Detected() const { return m_pcsx2Detected; }

--- a/src/library/RetroArchGameModel.cpp
+++ b/src/library/RetroArchGameModel.cpp
@@ -62,30 +62,9 @@ QVariant RetroArchGameModel::data(const QModelIndex& index, int role) const {
 }
 
 QHash<int, QByteArray> RetroArchGameModel::roleNames() const {
-  return {{GameRoles::Title, "title"},
-          {GameRoles::Subtitle, "subtitle"},
-          {GameRoles::Description, "description"},
-          {GameRoles::Hours, "hours"},
-          {GameRoles::Progress, "progress"},
-          {GameRoles::AchievementsUnlocked, "achievementsUnlocked"},
-          {GameRoles::AchievementsTotal, "achievementsTotal"},
-          {GameRoles::Favorite, "favorite"},
-          {GameRoles::Recent, "recent"},
-          {GameRoles::LastPlayed, "lastPlayed"},
-          {GameRoles::AccentStart, "accentStart"},
-          {GameRoles::AccentEnd, "accentEnd"},
-          {GameRoles::CoverMark, "coverMark"},
-          {GameRoles::Year, "year"},
-          {GameRoles::AppId, "appId"},
-          {GameRoles::CoverPath, "coverPath"},
-          {GameRoles::HeroPath, "heroPath"},
-          {GameRoles::LogoPath, "logoPath"},
-          {GameRoles::InstallPath, "installPath"},
-          {GameRoles::Source, "source"},
-          {GameRoles::Runner, "runner"},
-          {GameRoles::Flatpak, "flatpak"},
-          {GameRoles::Hidden, "hidden"},
-          {GameRoles::LaunchTarget, "launchTarget"}};
+  auto roles = GameRoles::names();
+  roles.insert(GameRoles::LaunchTarget, "launchTarget");
+  return roles;
 }
 
 bool RetroArchGameModel::retroArchDetected() const { return m_retroArchDetected; }

--- a/src/library/RyujinxGameModel.cpp
+++ b/src/library/RyujinxGameModel.cpp
@@ -59,30 +59,9 @@ QVariant RyujinxGameModel::data(const QModelIndex& index, int role) const {
 }
 
 QHash<int, QByteArray> RyujinxGameModel::roleNames() const {
-  return {{GameRoles::Title, "title"},
-          {GameRoles::Subtitle, "subtitle"},
-          {GameRoles::Description, "description"},
-          {GameRoles::Hours, "hours"},
-          {GameRoles::Progress, "progress"},
-          {GameRoles::AchievementsUnlocked, "achievementsUnlocked"},
-          {GameRoles::AchievementsTotal, "achievementsTotal"},
-          {GameRoles::Favorite, "favorite"},
-          {GameRoles::Recent, "recent"},
-          {GameRoles::LastPlayed, "lastPlayed"},
-          {GameRoles::AccentStart, "accentStart"},
-          {GameRoles::AccentEnd, "accentEnd"},
-          {GameRoles::CoverMark, "coverMark"},
-          {GameRoles::Year, "year"},
-          {GameRoles::AppId, "appId"},
-          {GameRoles::CoverPath, "coverPath"},
-          {GameRoles::HeroPath, "heroPath"},
-          {GameRoles::LogoPath, "logoPath"},
-          {GameRoles::InstallPath, "installPath"},
-          {GameRoles::Source, "source"},
-          {GameRoles::Runner, "runner"},
-          {GameRoles::Flatpak, "flatpak"},
-          {GameRoles::Hidden, "hidden"},
-          {GameRoles::LaunchTarget, "launchTarget"}};
+  auto roles = GameRoles::names();
+  roles.insert(GameRoles::LaunchTarget, "launchTarget");
+  return roles;
 }
 
 bool RyujinxGameModel::ryujinxDetected() const { return m_ryujinxDetected; }

--- a/src/library/SteamGameModel.cpp
+++ b/src/library/SteamGameModel.cpp
@@ -122,32 +122,9 @@ QVariant SteamGameModel::data(const QModelIndex& index, int role) const {
 }
 
 QHash<int, QByteArray> SteamGameModel::roleNames() const {
-  return {
-      {GameRoles::Title, "title"},
-      {GameRoles::Subtitle, "subtitle"},
-      {GameRoles::Description, "description"},
-      {GameRoles::Hours, "hours"},
-      {GameRoles::Progress, "progress"},
-      {GameRoles::AchievementsUnlocked, "achievementsUnlocked"},
-      {GameRoles::AchievementsTotal, "achievementsTotal"},
-      {GameRoles::Favorite, "favorite"},
-      {GameRoles::Recent, "recent"},
-      {GameRoles::LastPlayed, "lastPlayed"},
-      {GameRoles::AccentStart, "accentStart"},
-      {GameRoles::AccentEnd, "accentEnd"},
-      {GameRoles::CoverMark, "coverMark"},
-      {GameRoles::Year, "year"},
-      {GameRoles::AppId, "appId"},
-      {GameRoles::CoverPath, "coverPath"},
-      {GameRoles::HeroPath, "heroPath"},
-      {GameRoles::LogoPath, "logoPath"},
-      {GameRoles::InstallPath, "installPath"},
-      {GameRoles::Source, "source"},
-      {GameRoles::Runner, "runner"},
-      {GameRoles::Flatpak, "flatpak"},
-      {GameRoles::Hidden, "hidden"},
-      {GameRoles::Installed, "installed"},
-  };
+  auto roles = GameRoles::names();
+  roles.insert(GameRoles::Installed, "installed");
+  return roles;
 }
 
 bool SteamGameModel::scanning() const { return m_scanning; }


### PR DESCRIPTION
Use one shared table for the 23 QML role names repeated across nine game models. Each model keeps its additional roles.

Validation:
- All role IDs and per-model name mappings are unchanged.
- Clean integration with current main; the 1.6 fixes are preserved.
- Release build and all 41 tests pass on local integration candidate 2de11d5.
- Existing PR CI passes on x86_64 and aarch64.

Maintainer authorized merging this behavior-preserving cleanup based on review and automated validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized game role-name mappings across supported game library integrations.
  * Preserved existing role names and exposed behavior while reducing duplicated mappings.
  * Maintained integration-specific roles such as installation status and launch targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->