### PR TITLE
Persist library sort order and unify details cover size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Share QML role-name definitions across nine game models without changing
   their role IDs, names, or behavior.
+- Remember the library sort order between launches.
+- Show every game's cover at the same compact size on the details screen
+  instead of letting portrait covers render larger than landscape ones.
 
 ## 1.6.0
 

--- a/qml/screens/GameDetails.qml
+++ b/qml/screens/GameDetails.qml
@@ -169,9 +169,12 @@ Item {
             id: coverSidebar
             anchors.top: parent.top
             anchors.left: parent.left
-            width: Math.max(0, Math.min(root.width * (root.couchMode ? 0.24 : 0.28),
+            // Fixed 2:3 frame so every game shows the same cover size; keep it
+            // compact so the description column stays the focus.
+            width: Math.max(0, Math.min(root.couchMode ? 300 * root.uiScale : 240,
+                                        root.width * (root.couchMode ? 0.2 : 0.22),
                                         (detailsArea.height - reservedControlHeight) / 1.5,
-                                        detailsArea.width * 0.44))
+                                        detailsArea.width * 0.4))
             spacing: 8
             readonly property real reservedControlHeight:
                 (coverActions.visible ? coverActions.implicitHeight + spacing : 0)
@@ -195,7 +198,7 @@ Item {
                     source: root.game.coverPath || ""
                     asynchronous: true
                     cache: false
-                    fillMode: Image.PreserveAspectFit
+                    fillMode: Image.PreserveAspectCrop
                     sourceSize.width: Math.ceil(width * Math.max(1, Screen.devicePixelRatio) / 64) * 64
                     sourceSize.height: Math.ceil(height * Math.max(1, Screen.devicePixelRatio) / 64) * 64
                     opacity: status === Image.Ready ? 1 : 0

--- a/src/app/AppSettings.cpp
+++ b/src/app/AppSettings.cpp
@@ -220,6 +220,25 @@ void AppSettings::setCouchLibraryView(const QString& value) {
   emit couchLibraryViewChanged();
 }
 
+namespace {
+const QStringList kSortModeNames = {QStringLiteral("title"), QStringLiteral("recent"),
+                                    QStringLiteral("playtime")};
+}  // namespace
+
+int AppSettings::librarySortMode() const { return m_librarySortMode; }
+
+void AppSettings::setLibrarySortMode(int value) {
+  if (value < 0 || value >= kSortModeNames.size()) {
+    value = 0;
+  }
+  if (m_librarySortMode == value) {
+    return;
+  }
+  m_librarySortMode = value;
+  save();
+  emit librarySortModeChanged();
+}
+
 QString AppSettings::defaultPath() {
   return QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) +
          QStringLiteral("/omakade/config.toml");
@@ -289,6 +308,12 @@ void AppSettings::load() {
   if (couchLibraryViewMatch.hasMatch()) {
     m_couchLibraryView = couchLibraryViewMatch.captured(1);
   }
+  const QRegularExpression sortMode(
+      QStringLiteral("(?m)^library_sort_mode\\s*=\\s*\"(title|recent|playtime)\"\\s*$"));
+  const QRegularExpressionMatch sortModeMatch = sortMode.match(contents);
+  if (sortModeMatch.hasMatch()) {
+    m_librarySortMode = static_cast<int>(kSortModeNames.indexOf(sortModeMatch.captured(1)));
+  }
   m_sunshineOmakadeApp = readEnabled(QStringLiteral("sunshine_omakade_app"), false);
   m_sunshineGameApps = readEnabled(QStringLiteral("sunshine_game_apps"), false);
 }
@@ -353,12 +378,14 @@ void AppSettings::save() const {
   contents += QStringLiteral("close_after_launch = %1\n"
                              "couch_mode_enabled = %2\n"
                              "couch_library_view = \"%3\"\n"
+                             "library_sort_mode = \"%6\"\n"
                              "sunshine_omakade_app = %4\nsunshine_game_apps = %5\n")
                   .arg(m_closeAfterLaunch ? QStringLiteral("true") : QStringLiteral("false"))
                   .arg(m_couchModeEnabled ? QStringLiteral("true") : QStringLiteral("false"))
                   .arg(m_couchLibraryView)
                   .arg(m_sunshineOmakadeApp ? QStringLiteral("true") : QStringLiteral("false"))
-                  .arg(m_sunshineGameApps ? QStringLiteral("true") : QStringLiteral("false"));
+                  .arg(m_sunshineGameApps ? QStringLiteral("true") : QStringLiteral("false"))
+                  .arg(kSortModeNames.value(m_librarySortMode));
   file.write(contents.toUtf8());
   file.commit();
 }

--- a/src/app/AppSettings.h
+++ b/src/app/AppSettings.h
@@ -31,6 +31,8 @@ class AppSettings final : public QObject {
                  couchModeEnabledChanged)
   Q_PROPERTY(QString couchLibraryView READ couchLibraryView WRITE setCouchLibraryView NOTIFY
                  couchLibraryViewChanged)
+  Q_PROPERTY(int librarySortMode READ librarySortMode WRITE setLibrarySortMode NOTIFY
+                 librarySortModeChanged)
   Q_PROPERTY(bool sunshineOmakadeApp READ sunshineOmakadeApp WRITE setSunshineOmakadeApp NOTIFY
                  sunshineChanged)
   Q_PROPERTY(bool sunshineGameApps READ sunshineGameApps WRITE setSunshineGameApps NOTIFY
@@ -79,6 +81,9 @@ public:
   void setCouchModeEnabled(bool value);
   [[nodiscard]] QString couchLibraryView() const;
   void setCouchLibraryView(const QString& value);
+  // Mirrors LibraryFilterModel::SortMode: 0 title, 1 recently played, 2 playtime.
+  [[nodiscard]] int librarySortMode() const;
+  void setLibrarySortMode(int value);
   [[nodiscard]] bool sunshineOmakadeApp() const;
   void setSunshineOmakadeApp(bool value);
   [[nodiscard]] bool sunshineGameApps() const;
@@ -94,6 +99,7 @@ signals:
   void closeAfterLaunchChanged();
   void couchModeEnabledChanged();
   void couchLibraryViewChanged();
+  void librarySortModeChanged();
   void sunshineChanged();
 
 private:
@@ -121,6 +127,7 @@ private:
   bool m_closeAfterLaunch = false;
   bool m_couchModeEnabled = false;
   QString m_couchLibraryView = QStringLiteral("detail");
+  int m_librarySortMode = 0;
   bool m_sunshineOmakadeApp = false;
   bool m_sunshineGameApps = false;
 };

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -375,6 +375,10 @@ int main(int argc, char* argv[]) {
   }
   LibraryFilterModel library;
   library.setSourceModel(&unifiedGames);
+  library.setSortMode(static_cast<LibraryFilterModel::SortMode>(preferences.librarySortMode()));
+  QObject::connect(&library, &LibraryFilterModel::sortModeChanged, &preferences, [&]() {
+    preferences.setLibrarySortMode(static_cast<int>(library.sortMode()));
+  });
   if (uninstalledLayoutTest) {
     library.setAvailability(LibraryFilterModel::Availability::AllGames);
   }

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -3253,6 +3253,7 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
     QVERIFY(!settings.closeAfterLaunch());
     QVERIFY(!settings.couchModeEnabled());
     QCOMPARE(settings.couchLibraryView(), QStringLiteral("detail"));
+    QCOMPARE(settings.librarySortMode(), 0);
     settings.setReducedMotion(true);
     settings.setArtworkCacheLimitMb(512);
     settings.setSteamId(QStringLiteral("76561198000000000"));
@@ -3270,6 +3271,7 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
     settings.setCloseAfterLaunch(true);
     settings.setCouchModeEnabled(true);
     settings.setCouchLibraryView(QStringLiteral("grid"));
+    settings.setLibrarySortMode(1);
   }
   AppSettings reloaded(path);
   QVERIFY(reloaded.reducedMotion());
@@ -3290,6 +3292,9 @@ void CoreTests::settingsPersistReducedMotionAndCacheLimit() {
   QVERIFY(reloaded.closeAfterLaunch());
   QVERIFY(reloaded.couchModeEnabled());
   QCOMPARE(reloaded.couchLibraryView(), QStringLiteral("grid"));
+  QCOMPARE(reloaded.librarySortMode(), 1);
+  reloaded.setLibrarySortMode(7);  // out of range falls back to title
+  QCOMPARE(reloaded.librarySortMode(), 0);
 
   // A config without emulator keys keeps auto-detection pending and the keys absent
   // even after unrelated settings change.


### PR DESCRIPTION
Two requests from a Reddit user.

Sort order now persists between launches. AppSettings gains a librarySortMode property stored in config.toml as library_sort_mode = "title" | "recent" | "playtime". main.cpp applies it to the LibraryFilterModel at startup and writes it back when the SORT button cycles. Unknown values fall back to title.

The details screen cover was drawn with PreserveAspectFit inside a fixed 2:3 frame, so games with real portrait art (Dota 2's 600x900) filled the frame while games falling back to a landscape header rendered letterboxed and small. The cover now uses PreserveAspectCrop like the grid tiles, and the frame is capped at a smaller width (240px desktop, 300px scaled in couch mode), matching the user's preference for the smaller look.

Testing: settings round-trip test extended for the new key, full ctest suite passes (41/41), and the desktop and couch detail render tests were checked visually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Library sort order now persists between launches, including sorting by title, recently played, or playtime.
  * Details screen cover art now displays in a consistent compact 2:3 frame.

* **Bug Fixes**
  * Portrait cover images no longer appear larger than landscape covers; artwork fills the frame consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->