### PR TITLE
Launch Steam through the client and prepare 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## 1.6.1
 
-- Launch, manage, and install Steam games through the Steam client itself
-  instead of the desktop `steam://` URL handler. Steam packages that register
-  no handler sent Play to the web browser. Thanks @radiohost-cloud for the
-  report and the Apple Silicon test.
+- Launch, manage, and install Steam games through the Steam client itself,
+  native first and then Flatpak, and only fall back to the desktop `steam://`
+  URL handler when neither is available. Steam packages that register no
+  handler sent Play to the web browser. Thanks @radiohost-cloud for the report
+  and the Apple Silicon test.
 - Stop matching the Omakade desktop entry when searching for "Steam" or
   "RetroArch" in the app launcher. Thanks @gmickel for the report.
 - Remember the library sort order between launches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
-## Unreleased
+## 1.6.1
 
-- Share QML role-name definitions across nine game models without changing
-  their role IDs, names, or behavior.
+- Launch, manage, and install Steam games through the Steam client itself
+  instead of the desktop `steam://` URL handler. Steam packages that register
+  no handler sent Play to the web browser. Thanks @radiohost-cloud for the
+  report and the Apple Silicon test.
+- Stop matching the Omakade desktop entry when searching for "Steam" or
+  "RetroArch" in the app launcher. Thanks @gmickel for the report.
 - Remember the library sort order between launches.
 - Show every game's cover at the same compact size on the details screen
   instead of letting portrait covers render larger than landscape ones.
+- Share QML role-name definitions across nine game models without changing
+  their role IDs, names, or behavior.
 
 ## 1.6.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-project(Omakade VERSION 1.6.0 LANGUAGES CXX)
+project(Omakade VERSION 1.6.1 LANGUAGES CXX)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(SDL3 REQUIRED IMPORTED_TARGET sdl3)
@@ -64,6 +64,7 @@ add_library(omakade_core STATIC
   src/library/UnifiedGameModel.h
   src/launch/GameLauncher.cpp
   src/launch/GameLauncher.h
+  src/launch/LaunchCommand.h
   src/launch/PlayRequest.cpp
   src/launch/PlayRequest.h
   src/launch/SteamLauncher.cpp

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ into one quiet, cover-focused home that follows the active Omarchy theme.
 
 ## Features
 
-Omakade 1.6.0 includes:
+Omakade 1.6.1 includes:
 
 - Native and Flatpak Steam, Lutris, Heroic, Faugus, RetroArch, PCSX2, and
   Ryujinx discovery, plus direct GOG installation discovery,
@@ -62,6 +62,11 @@ GOG games installed through Heroic continue to launch through Heroic.
 
 ARM64 packages pass automated build and lifecycle checks; testing on an Omarchy
 ARM64 device is still open in [issue #13](https://github.com/btsouth/omakade/issues/13).
+On Apple Silicon with Asahi Linux, Omakade installs and discovers Steam games,
+but the `fex-steam` wrapper that provides `/usr/bin/steam` can fail to start
+games from any `steam://` request, including Steam's own client. That is a
+wrapper limitation, not something Omakade can work around; see issue #13 for
+the details and workarounds reported so far.
 
 ## Install on Omarchy or Arch
 
@@ -85,23 +90,23 @@ verify the package, and install it. If Omakade is already installed, `pacman -U`
 upgrades it in place without removing your settings or library data:
 
 ```bash
-curl -fLO https://github.com/btsouth/omakade/releases/download/v1.6.0/omakade-1.6.0-1-x86_64.pkg.tar.zst
-curl -fLO https://github.com/btsouth/omakade/releases/download/v1.6.0/SHA256SUMS
+curl -fLO https://github.com/btsouth/omakade/releases/download/v1.6.1/omakade-1.6.1-1-x86_64.pkg.tar.zst
+curl -fLO https://github.com/btsouth/omakade/releases/download/v1.6.1/SHA256SUMS
 sha256sum -c SHA256SUMS --ignore-missing
-sudo pacman -U ./omakade-1.6.0-1-x86_64.pkg.tar.zst
+sudo pacman -U ./omakade-1.6.1-1-x86_64.pkg.tar.zst
 ```
 
 ### Install or upgrade from a browser download
 
 1. Open the [latest release](https://github.com/btsouth/omakade/releases/latest).
-2. Under **Assets**, download `omakade-1.6.0-1-x86_64.pkg.tar.zst` (or
-   `omakade-1.6.0-1-aarch64.pkg.tar.zst` for ARM64) and `SHA256SUMS` into the same folder.
+2. Under **Assets**, download `omakade-1.6.1-1-x86_64.pkg.tar.zst` (or
+   `omakade-1.6.1-1-aarch64.pkg.tar.zst` for ARM64) and `SHA256SUMS` into the same folder.
 3. Open a terminal in that folder and run the commands below. On ARM64,
    replace `x86_64` with `aarch64` in the package filename:
 
 ```bash
 sha256sum -c SHA256SUMS --ignore-missing
-sudo pacman -U ./omakade-1.6.0-1-x86_64.pkg.tar.zst
+sudo pacman -U ./omakade-1.6.1-1-x86_64.pkg.tar.zst
 ```
 
 Launch Omakade from the application launcher or run `omakade` in a terminal.

--- a/packaging/io.github.tsouth89.Omakade.desktop
+++ b/packaging/io.github.tsouth89.Omakade.desktop
@@ -6,6 +6,6 @@ Exec=omakade
 Icon=io.github.tsouth89.Omakade
 Terminal=false
 Categories=Game;
-Keywords=Games;Launcher;Steam;RetroArch;Library;
+Keywords=Games;Launcher;Library;
 StartupNotify=true
 StartupWMClass=io.github.tsouth89.Omakade

--- a/packaging/io.github.tsouth89.Omakade.metainfo.xml
+++ b/packaging/io.github.tsouth89.Omakade.metainfo.xml
@@ -26,6 +26,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.6.1" date="2026-09-05" />
     <release version="1.6.0" date="2026-09-04" />
     <release version="1.5.0" date="2026-09-04" />
     <release version="1.4.0" date="2026-09-02" />

--- a/src/launch/GameLauncher.cpp
+++ b/src/launch/GameLauncher.cpp
@@ -308,7 +308,7 @@ bool GameLauncher::launch(const QString& source, const QString& id, bool flatpak
       setError(QStringLiteral("This game has an invalid Steam App ID."));
       return false;
     }
-    if (!QDesktopServices::openUrl(url)) {
+    if (!SteamLauncher::openUrl(url)) {
       setError(QStringLiteral("Steam could not open the game. Check that Steam is installed."));
       return false;
     }
@@ -351,7 +351,7 @@ bool GameLauncher::manage(const QString& source, const QString& id, bool flatpak
                           const QString& runner, const QString& launchTarget) {
   if (source.compare(QStringLiteral("Steam"), Qt::CaseInsensitive) == 0) {
     const QUrl url = SteamLauncher::manageUrl(id);
-    if (!url.isValid() || url.isEmpty() || !QDesktopServices::openUrl(url)) {
+    if (!url.isValid() || url.isEmpty() || !SteamLauncher::openUrl(url)) {
       setError(QStringLiteral("Steam could not open the game details."));
       return false;
     }
@@ -396,7 +396,7 @@ bool GameLauncher::install(const QString& source, const QString& id) {
     setError(QStringLiteral("This game has an invalid Steam App ID."));
     return false;
   }
-  if (!QDesktopServices::openUrl(url)) {
+  if (!SteamLauncher::openUrl(url)) {
     setError(QStringLiteral("Steam could not start the installation."));
     return false;
   }

--- a/src/launch/GameLauncher.h
+++ b/src/launch/GameLauncher.h
@@ -1,13 +1,9 @@
 #pragma once
 
+#include "launch/LaunchCommand.h"
+
 #include <QObject>
 #include <QStringList>
-
-struct LaunchCommand {
-  QString program;
-  QStringList arguments;
-  [[nodiscard]] bool isValid() const { return !program.isEmpty(); }
-};
 
 class GameLauncher final : public QObject {
   Q_OBJECT

--- a/src/launch/LaunchCommand.h
+++ b/src/launch/LaunchCommand.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+
+struct LaunchCommand {
+  QString program;
+  QStringList arguments;
+  [[nodiscard]] bool isValid() const { return !program.isEmpty(); }
+};

--- a/src/launch/SteamLauncher.cpp
+++ b/src/launch/SteamLauncher.cpp
@@ -49,32 +49,35 @@ QUrl SteamLauncher::installUrl(const QString& appId) {
   return validAppId(appId) ? QUrl(QStringLiteral("steam://install/%1").arg(appId)) : QUrl{};
 }
 
-LaunchCommand SteamLauncher::steamCommand(const QUrl& url, const QString& steamExecutable,
-                                          bool flatpakSteamInstalled) {
+QList<LaunchCommand> SteamLauncher::steamCommands(const QUrl& url, const QString& steamExecutable,
+                                                  bool flatpakSteamInstalled) {
   if (!url.isValid() || url.isEmpty() || url.scheme() != QStringLiteral("steam")) {
     return {};
   }
   const QString target = url.toString(QUrl::FullyEncoded);
+  QList<LaunchCommand> commands;
   if (!steamExecutable.isEmpty()) {
-    return LaunchCommand{steamExecutable, {target}};
+    commands.append(LaunchCommand{steamExecutable, {target}});
   }
   if (flatpakSteamInstalled) {
-    return LaunchCommand{
-        QStringLiteral("flatpak"),
-        {QStringLiteral("run"), QStringLiteral("com.valvesoftware.Steam"), target}};
+    commands.append(
+        LaunchCommand{QStringLiteral("flatpak"),
+                      {QStringLiteral("run"), QStringLiteral("com.valvesoftware.Steam"), target}});
   }
-  return {};
+  return commands;
 }
 
 bool SteamLauncher::openUrl(const QUrl& url) {
   if (!url.isValid() || url.isEmpty()) {
     return false;
   }
-  const LaunchCommand command =
-      steamCommand(url, QStandardPaths::findExecutable(QStringLiteral("steam")),
-                   flatpakAppInstalled(QStringLiteral("com.valvesoftware.Steam")));
-  if (command.isValid() && QProcess::startDetached(command.program, command.arguments)) {
-    return true;
+  const QList<LaunchCommand> commands =
+      steamCommands(url, QStandardPaths::findExecutable(QStringLiteral("steam")),
+                    flatpakAppInstalled(QStringLiteral("com.valvesoftware.Steam")));
+  for (const LaunchCommand& command : commands) {
+    if (QProcess::startDetached(command.program, command.arguments)) {
+      return true;
+    }
   }
   return QDesktopServices::openUrl(url);
 }

--- a/src/launch/SteamLauncher.cpp
+++ b/src/launch/SteamLauncher.cpp
@@ -1,7 +1,11 @@
 #include "launch/SteamLauncher.h"
 
 #include <QDesktopServices>
+#include <QProcess>
 #include <QRegularExpression>
+#include <QStandardPaths>
+
+#include "sources/FlatpakInstall.h"
 
 namespace {
 bool validAppId(const QString& appId) {
@@ -45,6 +49,36 @@ QUrl SteamLauncher::installUrl(const QString& appId) {
   return validAppId(appId) ? QUrl(QStringLiteral("steam://install/%1").arg(appId)) : QUrl{};
 }
 
+LaunchCommand SteamLauncher::steamCommand(const QUrl& url, const QString& steamExecutable,
+                                          bool flatpakSteamInstalled) {
+  if (!url.isValid() || url.isEmpty() || url.scheme() != QStringLiteral("steam")) {
+    return {};
+  }
+  const QString target = url.toString(QUrl::FullyEncoded);
+  if (!steamExecutable.isEmpty()) {
+    return LaunchCommand{steamExecutable, {target}};
+  }
+  if (flatpakSteamInstalled) {
+    return LaunchCommand{
+        QStringLiteral("flatpak"),
+        {QStringLiteral("run"), QStringLiteral("com.valvesoftware.Steam"), target}};
+  }
+  return {};
+}
+
+bool SteamLauncher::openUrl(const QUrl& url) {
+  if (!url.isValid() || url.isEmpty()) {
+    return false;
+  }
+  const LaunchCommand command =
+      steamCommand(url, QStandardPaths::findExecutable(QStringLiteral("steam")),
+                   flatpakAppInstalled(QStringLiteral("com.valvesoftware.Steam")));
+  if (command.isValid() && QProcess::startDetached(command.program, command.arguments)) {
+    return true;
+  }
+  return QDesktopServices::openUrl(url);
+}
+
 bool SteamLauncher::launch(const QString& appId) { return open(launchUrl(appId)); }
 
 bool SteamLauncher::manage(const QString& appId) { return open(manageUrl(appId)); }
@@ -55,7 +89,7 @@ bool SteamLauncher::open(const QUrl& url) {
   QString error;
   if (!url.isValid() || url.isEmpty()) {
     error = QStringLiteral("This game has an invalid Steam App ID.");
-  } else if (!QDesktopServices::openUrl(url)) {
+  } else if (!openUrl(url)) {
     error = QStringLiteral("Steam could not open the game. Check that Steam is installed.");
   }
   if (m_lastError != error) {

--- a/src/launch/SteamLauncher.h
+++ b/src/launch/SteamLauncher.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QList>
 #include <QObject>
 #include <QUrl>
 
@@ -16,10 +17,11 @@ public:
   [[nodiscard]] static QUrl launchUrl(const QString& appId);
   [[nodiscard]] static QUrl manageUrl(const QString& appId);
   [[nodiscard]] static QUrl installUrl(const QString& appId);
-  // Command that hands a steam:// URL to the Steam client directly. Prefers the
-  // native executable, then Flatpak Steam; invalid when neither is available.
-  [[nodiscard]] static LaunchCommand steamCommand(const QUrl& url, const QString& steamExecutable,
-                                                  bool flatpakSteamInstalled);
+  // Commands that hand a steam:// URL to the Steam client directly, in the order
+  // they should be tried: the native executable, then Flatpak Steam. Empty when
+  // neither is available.
+  [[nodiscard]] static QList<LaunchCommand>
+  steamCommands(const QUrl& url, const QString& steamExecutable, bool flatpakSteamInstalled);
   // Opens a steam:// URL through the Steam client, falling back to the desktop URL
   // handler. Some Steam packages register no x-scheme-handler, in which case the
   // handler fallback alone would open a web browser instead of Steam.

--- a/src/launch/SteamLauncher.h
+++ b/src/launch/SteamLauncher.h
@@ -3,6 +3,8 @@
 #include <QObject>
 #include <QUrl>
 
+#include "launch/LaunchCommand.h"
+
 class SteamLauncher final : public QObject {
   Q_OBJECT
   Q_PROPERTY(QString lastError READ lastError NOTIFY lastErrorChanged)
@@ -14,6 +16,14 @@ public:
   [[nodiscard]] static QUrl launchUrl(const QString& appId);
   [[nodiscard]] static QUrl manageUrl(const QString& appId);
   [[nodiscard]] static QUrl installUrl(const QString& appId);
+  // Command that hands a steam:// URL to the Steam client directly. Prefers the
+  // native executable, then Flatpak Steam; invalid when neither is available.
+  [[nodiscard]] static LaunchCommand steamCommand(const QUrl& url, const QString& steamExecutable,
+                                                  bool flatpakSteamInstalled);
+  // Opens a steam:// URL through the Steam client, falling back to the desktop URL
+  // handler. Some Steam packages register no x-scheme-handler, in which case the
+  // handler fallback alone would open a web browser instead of Steam.
+  [[nodiscard]] static bool openUrl(const QUrl& url);
 
   Q_INVOKABLE bool launch(const QString& appId);
   Q_INVOKABLE bool manage(const QString& appId);

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -1461,6 +1461,24 @@ void CoreTests::steamLauncherBuildsSafeUrls() {
            QUrl(QStringLiteral("steam://rungameid/13899108412974694400")));
   QVERIFY(SteamLauncher::launchUrl(QStringLiteral("440;touch /tmp/nope")).isEmpty());
   QVERIFY(SteamLauncher::installUrl(QStringLiteral("440;touch /tmp/nope")).isEmpty());
+
+  // Launches go to the Steam client itself, not the desktop URL handler: some Steam
+  // packages register no steam:// handler and xdg-open would fall back to a browser.
+  const QUrl launch = SteamLauncher::launchUrl(QStringLiteral("440"));
+  const LaunchCommand native =
+      SteamLauncher::steamCommand(launch, QStringLiteral("/usr/bin/steam"), true);
+  QCOMPARE(native.program, QStringLiteral("/usr/bin/steam"));
+  QCOMPARE(native.arguments, QStringList{QStringLiteral("steam://rungameid/440")});
+  const LaunchCommand flatpak = SteamLauncher::steamCommand(launch, QString{}, true);
+  QCOMPARE(flatpak.program, QStringLiteral("flatpak"));
+  QCOMPARE(flatpak.arguments,
+           (QStringList{QStringLiteral("run"), QStringLiteral("com.valvesoftware.Steam"),
+                        QStringLiteral("steam://rungameid/440")}));
+  QVERIFY(!SteamLauncher::steamCommand(launch, QString{}, false).isValid());
+  QVERIFY(!SteamLauncher::steamCommand(QUrl(QStringLiteral("https://example.com")),
+                                       QStringLiteral("/usr/bin/steam"), true)
+               .isValid());
+  QVERIFY(!SteamLauncher::steamCommand(QUrl{}, QStringLiteral("/usr/bin/steam"), true).isValid());
 }
 
 void CoreTests::lutrisScannerImportsOnlyLaunchableGames() {

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -1464,21 +1464,30 @@ void CoreTests::steamLauncherBuildsSafeUrls() {
 
   // Launches go to the Steam client itself, not the desktop URL handler: some Steam
   // packages register no steam:// handler and xdg-open would fall back to a browser.
+  // Native Steam is tried first, then Flatpak Steam, so a stale native binary still
+  // reaches an installed Flatpak client.
   const QUrl launch = SteamLauncher::launchUrl(QStringLiteral("440"));
-  const LaunchCommand native =
-      SteamLauncher::steamCommand(launch, QStringLiteral("/usr/bin/steam"), true);
-  QCOMPARE(native.program, QStringLiteral("/usr/bin/steam"));
-  QCOMPARE(native.arguments, QStringList{QStringLiteral("steam://rungameid/440")});
-  const LaunchCommand flatpak = SteamLauncher::steamCommand(launch, QString{}, true);
-  QCOMPARE(flatpak.program, QStringLiteral("flatpak"));
-  QCOMPARE(flatpak.arguments,
+  const QList<LaunchCommand> both =
+      SteamLauncher::steamCommands(launch, QStringLiteral("/usr/bin/steam"), true);
+  QCOMPARE(both.size(), 2);
+  QCOMPARE(both.at(0).program, QStringLiteral("/usr/bin/steam"));
+  QCOMPARE(both.at(0).arguments, QStringList{QStringLiteral("steam://rungameid/440")});
+  QCOMPARE(both.at(1).program, QStringLiteral("flatpak"));
+  QCOMPARE(both.at(1).arguments,
            (QStringList{QStringLiteral("run"), QStringLiteral("com.valvesoftware.Steam"),
                         QStringLiteral("steam://rungameid/440")}));
-  QVERIFY(!SteamLauncher::steamCommand(launch, QString{}, false).isValid());
-  QVERIFY(!SteamLauncher::steamCommand(QUrl(QStringLiteral("https://example.com")),
+  const QList<LaunchCommand> nativeOnly =
+      SteamLauncher::steamCommands(launch, QStringLiteral("/usr/bin/steam"), false);
+  QCOMPARE(nativeOnly.size(), 1);
+  QCOMPARE(nativeOnly.at(0).program, QStringLiteral("/usr/bin/steam"));
+  const QList<LaunchCommand> flatpakOnly = SteamLauncher::steamCommands(launch, QString{}, true);
+  QCOMPARE(flatpakOnly.size(), 1);
+  QCOMPARE(flatpakOnly.at(0).program, QStringLiteral("flatpak"));
+  QVERIFY(SteamLauncher::steamCommands(launch, QString{}, false).isEmpty());
+  QVERIFY(SteamLauncher::steamCommands(QUrl(QStringLiteral("https://example.com")),
                                        QStringLiteral("/usr/bin/steam"), true)
-               .isValid());
-  QVERIFY(!SteamLauncher::steamCommand(QUrl{}, QStringLiteral("/usr/bin/steam"), true).isValid());
+              .isEmpty());
+  QVERIFY(SteamLauncher::steamCommands(QUrl{}, QStringLiteral("/usr/bin/steam"), true).isEmpty());
 }
 
 void CoreTests::lutrisScannerImportsOnlyLaunchableGames() {


### PR DESCRIPTION
Patch release candidate for 1.6.1. Not to be tagged until the maintainer has tested it locally.

Fixes #29. Addresses the Omakade regression in #13.

Steam launch, manage, and install requests now go to the Steam client directly, preferring the native steam executable and falling back to Flatpak Steam, with the desktop URL handler kept as the last resort. Steam packages that ship no x-scheme-handler for steam:// made xdg-open hand Play to the web browser (reported on Asahi in #13). SteamLauncher::steamCommand is pure and unit tested; GameLauncher's three Steam sites share the same openUrl path. LaunchCommand moved to its own header so both launchers can use it.

The desktop entry no longer lists Steam or RetroArch in Keywords, so searching for those apps in the Omarchy launcher does not surface Omakade (#29).

Release prep: version 1.6.1 in CMake and AppStream, changelog section covering these two fixes plus the already merged sort persistence, cover sizing, and role cleanup, README package commands and a short aarch64 known-issue note pointing at #13.

Checks: dev build and full ctest matrix 41/41, desktop-file-validate and appstreamcli validate pass, git diff --check clean, clang-format clean on the touched SteamLauncher files.

Not verified here: an actual Play against a Steam game, since this machine has no installed Steam titles. The x86_64 and Asahi confirmation belongs in the maintainer checklist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Steam games can now be launched, managed, and installed directly through the Steam client, with improved support for native and Flatpak installations.
  * Added fallback handling for systems that do not provide a Steam URL handler.
* **Bug Fixes**
  * Omakade no longer appears in app-launcher searches for “Steam” or “RetroArch.”
* **Documentation**
  * Updated release information, installation instructions, and Apple Silicon/Asahi Linux guidance for version 1.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->