### PR TITLE
Bundle a TV gaming agent skill and optional Gamescope launcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,5 +56,8 @@ jobs:
           test -x stage/usr/bin/omakade
           test -f stage/usr/share/applications/io.github.tsouth89.Omakade.desktop
           test -f stage/usr/share/metainfo/io.github.tsouth89.Omakade.metainfo.xml
+          test -f stage/usr/share/omakade/skills/omakade-tv-gaming/SKILL.md
+          test -f stage/usr/share/omakade/skills/omakade-tv-gaming/references/session.md
+          python stage/usr/share/omakade/skills/omakade-tv-gaming/scripts/omakade-tv-game.py --help
           desktop-file-validate stage/usr/share/applications/io.github.tsouth89.Omakade.desktop
           appstreamcli validate stage/usr/share/metainfo/io.github.tsouth89.Omakade.metainfo.xml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,11 @@ install(FILES LICENSE COPYRIGHT
 install(FILES README.md PRIVACY.md SUPPORT.md CHANGELOG.md docs/COMPATIBILITY.md
   DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/omakade
 )
+install(DIRECTORY skills/omakade-tv-gaming
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/omakade/skills
+  FILES_MATCHING PATTERN "*.md" PATTERN "*.py"
+  PATTERN "__pycache__" EXCLUDE
+)
 
 include(CTest)
 if(BUILD_TESTING)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,33 @@ omakade --couch                     # Start directly in Couch Mode
 omakade --quit
 ```
 
+### Use a dedicated TV alongside agent work
+
+The optional [TV gaming skill](skills/omakade-tv-gaming/SKILL.md) guides coding
+agents through reserving a TV workspace, preserving work displays and input,
+routing game audio, and verifying session shutdown. It includes a configurable
+Gamescope launcher that checks the TV and audio sink before opening a game.
+It is a setup guide and helper, not a built-in TV session manager.
+
+Packages install it under `/usr/share/omakade/skills/omakade-tv-gaming`. Add a
+symlink in the skill directory your agent discovers, or copy the folder if you
+want to customize it independently of package updates. For Codex, for example:
+
+```sh
+mkdir -p ~/.codex/skills
+ln -s /usr/share/omakade/skills/omakade-tv-gaming ~/.codex/skills/omakade-tv-gaming
+```
+
+From a source checkout, use the absolute path to `skills/omakade-tv-gaming`
+instead. For agents using a shared skill hub, link it there and add a pointer
+to that agent's local instructions: when setting up, starting or ending a TV
+gaming session, or performing desktop input during a game, read this skill.
+Installing Omakade does not automatically modify agent configuration.
+
+The helper's optional dependencies and machine setup are described in the
+[session guide](skills/omakade-tv-gaming/references/session.md). Workspaces
+separate windows; CPU, RAM and GPU resources remain shared with desktop work.
+
 ## Build
 
 Requirements:
@@ -155,6 +182,7 @@ Requirements:
 - CMake 3.24 or newer
 - Ninja
 - C++20 compiler
+- Python 3 for the test suite
 - Qt 6.8 or newer with Concurrent, Core, Gui, Network, Qml, Quick, Quick
   Controls, SQL, and Test, plus the SVG and image format plugins
 - SDL 3

--- a/skills/omakade-tv-gaming/SKILL.md
+++ b/skills/omakade-tv-gaming/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: omakade-tv-gaming
+description: Set up or operate Omakade Couch Mode on a dedicated TV while preserving desktop work, and adapt agent activity when the user starts or finishes gaming.
+---
+
+# Omakade on a shared workstation
+
+Omakade runs on the PC and delegates games to their owning launchers. A TV
+workspace separates windows; it does not partition GPU, CPU, memory, or input.
+The skill provides instructions, not a background service or an input sandbox.
+
+## Set up the local session
+
+Read [the session guide](references/session.md) when configuring a machine.
+Discover its compositor version, TV connector, workspaces and audio sinks.
+Keep machine identifiers and any TV pairing credentials in local configuration.
+Reserve a user-chosen workspace for games, including when the TV is off, and
+exclude it from any agent desktop allocator. Workspace 10 is an example.
+
+Reuse existing local start/stop/status commands when available. Otherwise,
+configure a session controller for that compositor using the guide's lifecycle
+and verification checklist. Record the chosen commands and identifiers in the
+user's local agent instructions. Do not assume that another machine has a
+`tv-gaming` command, a Samsung TV, or a particular GPU.
+
+## Start gaming
+
+1. Read the local session status and preserve the work monitors' layout and
+   active workspaces. Enable only the configured TV output.
+2. Verify the TV's audio sink before launching audio. Keep the desktop default
+   sink unchanged and route the game to the TV. An unavailable TV sink is a
+   reason to stop the launch, not to fall back to the user's headset.
+3. Open `omakade --couch` on the reserved workspace. Check the resulting window
+   and controller navigation; enumerating a controller alone is not an input
+   test. Omakade normally relinquishes controller input after launching a game.
+4. Verify the launched game's output, audio and focus. Treat a measured result
+   and a prepared graphics configuration as different outcomes.
+
+The optional [Gamescope launcher](scripts/omakade-tv-game.py) checks the live TV
+workspace and sink before starting a game. See the session guide for its scope,
+dependencies and Steam launch options. It does not configure workspace rules,
+power the TV, or supervise an entire gaming session.
+
+## Work alongside the player
+
+Continue file, terminal and API work without taking the player's focus. Use
+targeted browser automation or an isolated agent desktop when UI work would
+otherwise inject global input. Keep agent windows and notifications on work
+displays; capture only the work display or isolated desktop needed for the task.
+
+Respect ongoing jobs and the user's performance preference. Local GPU inference
+and memory allocations can compete with games even in other workspaces. Check
+actual utilization before proposing changes; a workspace is not a resource cap.
+
+Run game benchmarks in a session the user has agreed to observe. If an explicitly
+requested test uses an invisible display, establish isolated audio before
+starting it and report where it runs. Turning off the TV is not authorization
+to start an invisible game with sound on the desktop headset.
+
+## Finish gaming
+
+Use the local stop command and inspect the result. Let the user save or close
+an active game normally; preserve unsaved state if the TV disappears mid-game.
+Close the session-owned Omakade instance and disable only the TV output.
+Restore any audio configuration the session changed. Verify remaining game and
+Gamescope processes as well as the output: an invisible or parked game can still
+use resources. Report retained games instead of claiming everything is off.
+
+Confirm that work displays and workspaces remain as they were. The gaming
+workspace stays reserved for the next session, and idle session monitoring
+should stop when it is no longer needed.

--- a/skills/omakade-tv-gaming/references/session.md
+++ b/skills/omakade-tv-gaming/references/session.md
@@ -1,0 +1,110 @@
+# Dedicated TV session guide
+
+## Discover before configuring
+
+For Hyprland, inspect `hyprctl version`, `hyprctl -j monitors all`,
+`hyprctl -j workspaces` and `hyprctl -j clients`. Inspect PipeWire's PulseAudio
+compatibility sinks with `pactl -f json list sinks`. Match the TV by its display
+description and audio port, not by assuming connector numbering is stable.
+
+Record the connector, reserved workspace, game sink, supported display mode,
+and existing work monitor layout in local configuration. Configure the actual
+monitor mode, not just the game's render resolution. An EDID advertisement is
+not proof that the current cable/driver/output path accepts that mode.
+
+Hyprland configuration syntax varies by version. Newer Omarchy installations
+use Lua; older installations use hyprlang. Use that version's monitor and
+window-rule APIs rather than copying a configuration from another release.
+Keep changes in user configuration and validate reload errors. Back up the
+files being edited; do not replace unrelated monitor or keybinding settings.
+
+## Local controller lifecycle
+
+A session controller should own a runtime state file and expose start, stop and
+status operations. A user service is one way to supervise it. Its state machine
+should implement:
+
+| Event | Expected behavior |
+| --- | --- |
+| Start | Enable the TV output, bind the reserved workspace, install session rules, verify audio, open Couch Mode. Repeated starts reuse the session. |
+| Game launch | Put the game on the TV and route only its audio there. Keep desktop audio on its previous sink. |
+| Normal stop | Refuse to discard an active game; close the owned library and disable the TV once the game exits. Remove temporary rules and stop polling. |
+| Confirmed standby or unplug | Disable the output and preserve game state. Mute or isolate any retained game's audio before removing its sink so it cannot migrate to the headset. Report that retained games still consume resources. |
+| TV network timeout | Treat power state as unknown. Network failure alone does not establish that the TV is off. |
+| Restart or failure | Reconcile runtime state with live processes and outputs. Clean up only owned state, leaving work monitors and applications intact. |
+
+Reserve the workspace even outside gaming sessions. Add the reservation to
+agent workspace allocation, not just a window rule. Route Omakade and games
+only while that local session is active. Revalidate window identity by address
+and PID before moving or closing it. A broad permanent `gamescope` rule can
+also capture an unrelated agent's test window.
+
+`omakade --quit` addresses the existing Omakade instance; it is appropriate
+only when that instance belongs to the gaming session. Owning the Couch Mode
+process in a user service makes cleanup explicit. Keep Omakade open after
+launch if it should remain available when the game closes.
+
+TV remote pairing, standby detection and Wake-on-LAN are vendor-specific
+extensions. HDMI screenshots show the PC image, not the TV's internal picture
+menus. Use direct user feedback for those menus. A generic skill should not
+ship private network addresses, MAC addresses or pairing tokens.
+
+## Optional Gamescope launcher
+
+`scripts/omakade-tv-game.py` is an opt-in wrapper for a **configured Hyprland TV
+session**. It requires Python 3, `hyprctl`, `pactl` and Gamescope with the Wayland
+backend. `--fps` additionally requires MangoHud's `mangoapp` executable.
+Omakade's normal launch behavior and package dependencies remain unchanged.
+
+Use `pactl -f json list sinks` and `hyprctl -j monitors` to choose the local
+identifiers. Replace the example connector and sink below with those values:
+
+```sh
+python3 /usr/share/omakade/skills/omakade-tv-gaming/scripts/omakade-tv-game.py \
+  --output HDMI-A-2 --workspace 10 --sink YOUR_TV_SINK --check
+```
+
+Use the same arguments followed by `--dry-run -- COMMAND ARGUMENTS` to inspect
+the launch plan. In Steam's per-game launch options, use an absolute installed
+path and `%command%`:
+
+```text
+python3 /usr/share/omakade/skills/omakade-tv-gaming/scripts/omakade-tv-game.py --output HDMI-A-2 --workspace 10 --sink YOUR_TV_SINK --fps -- %command%
+```
+
+The wrapper refuses to launch if the TV is disabled, displays a different
+workspace, or lacks the requested sink. It does not enable outputs, install
+window rules, or change the default audio device. Set up the session's window
+placement first and focus Couch Mode on the TV before launching. The check is
+a launch precondition, not ongoing hotplug or audio supervision; the local
+session controller must handle the lifecycle above.
+
+The default size and refresh come from the active TV mode. Optional `--width`,
+`--height` and `--refresh` arguments select the Gamescope canvas; they do not
+change the physical display mode. HDR is opt-in with `--hdr` after verifying
+the compositor, display and in-game HDR settings. An HDR-capable output alone
+does not enable HDR rendering inside a game.
+
+The FPS option shows a small counter using MangoApp, without enabling Steam's
+interactive overlay. A counter can include generated frames. Distinguish base
+rendering FPS from displayed FPS when evaluating frame generation or latency.
+Game resolution, DLSS/FSR, ray tracing and quality presets remain game settings;
+the wrapper does not overwrite them or install drivers.
+
+## Verify on the user's machine
+
+1. Compare work monitor modes, positions and active workspaces before and after
+   a start/stop cycle. Confirm the reservation is excluded from agent allocation.
+2. Test real controller buttons in Couch Mode and in a game. If the device uses
+   the wrong protocol, consult its exact model's manual before changing drivers.
+3. Play game audio to the TV alongside desktop audio on the user's usual sink.
+   Test the unavailable-sink path before relying on automatic shutdown.
+4. Confirm game resolution, image quality and FPS in actual gameplay or an
+   agreed visible benchmark. Record HDR and refresh support separately.
+5. Stop normally and verify the TV is disabled and session-owned processes have
+   exited. Test unplug/standby recovery without risking an unsaved game.
+
+The underlying approach was exercised on one Omarchy/Hyprland workstation
+with three work monitors, a TV and a controller. The portable wrapper has
+automated preflight/argument tests; other hardware and full physical hotplug
+lifecycles still require local verification.

--- a/skills/omakade-tv-gaming/scripts/omakade-tv-game.py
+++ b/skills/omakade-tv-gaming/scripts/omakade-tv-game.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Launch a game in an already configured Hyprland TV session."""
+
+import argparse
+import json
+import math
+import os
+import shutil
+import subprocess
+import sys
+
+
+def positive_int(value):
+    number = int(value)
+    if number <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return number
+
+
+def read_state(*command):
+    result = subprocess.run(command, check=True, capture_output=True, text=True, timeout=5)
+    return json.loads(result.stdout)
+
+
+def launch_plan(args):
+    for tool in ("hyprctl", "pactl", "gamescope") + (("mangoapp",) if args.fps else ()):
+        if not shutil.which(tool):
+            raise ValueError(f"Required command not found: {tool}")
+
+    monitors = read_state("hyprctl", "-j", "monitors")
+    monitor = next((item for item in monitors if item["name"] == args.output), None)
+    if monitor is None or monitor.get("disabled") or monitor.get("dpmsStatus") is False:
+        raise ValueError("TV output is unavailable; start the local TV session first.")
+    if monitor.get("activeWorkspace", {}).get("id") != args.workspace:
+        raise ValueError("TV is not displaying the reserved workspace; check the local session.")
+
+    sinks = read_state("pactl", "-f", "json", "list", "sinks")
+    if not any(sink["name"] == args.sink for sink in sinks):
+        raise ValueError("TV audio sink is unavailable; refusing to use the desktop audio sink.")
+
+    width = args.width or int(monitor["width"])
+    height = args.height or int(monitor["height"])
+    refresh = args.refresh or round(float(monitor["refreshRate"]))
+    if any(not math.isfinite(value) or value <= 0 for value in (width, height, refresh)):
+        raise ValueError("TV reported an invalid display mode.")
+
+    command = ["gamescope", "--backend", "wayland", "-W", str(width), "-H", str(height),
+               "-w", str(width), "-h", str(height), "-r", str(refresh), "-o", str(refresh), "-f"]
+    environment = {"PULSE_SINK": args.sink, "SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS": "1"}
+    if args.hdr:
+        command.append("--hdr-enabled")
+        environment["DXVK_HDR"] = "1"
+    if args.fps:
+        command.append("--mangoapp")
+        environment["MANGOHUD_CONFIG"] = "fps_only,position=top-left,font_size=32,background_alpha=0.25"
+    command += ["--", *args.game]
+    return command, environment
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, help="active Hyprland TV connector")
+    parser.add_argument("--workspace", type=positive_int, required=True, help="reserved TV workspace")
+    parser.add_argument("--sink", required=True, help="TV sink name from pactl list sinks")
+    parser.add_argument("--width", type=positive_int)
+    parser.add_argument("--height", type=positive_int)
+    parser.add_argument("--refresh", type=positive_int)
+    parser.add_argument("--hdr", action="store_true")
+    parser.add_argument("--fps", action="store_true")
+    inspection = parser.add_mutually_exclusive_group()
+    inspection.add_argument("--check", action="store_true", help="check preconditions without launching")
+    inspection.add_argument("--dry-run", action="store_true", help="print the checked launch plan")
+    parser.add_argument("game", nargs=argparse.REMAINDER, help="-- COMMAND [ARGUMENTS...]")
+    args = parser.parse_args()
+    if args.game[:1] == ["--"]:
+        args.game = args.game[1:]
+    if not args.game and not args.check:
+        parser.error("a game command after -- is required")
+
+    try:
+        command, changes = launch_plan(args)
+        if args.check:
+            print("TV workspace and audio sink are available. Window placement is owned by the local session.")
+        elif args.dry_run:
+            print(json.dumps({"command": command, "environment": changes}, indent=2))
+        else:
+            environment = dict(os.environ)
+            if args.fps:
+                environment.pop("MANGOHUD_CONFIGFILE", None)
+            environment.update(changes)
+            os.execvpe(command[0], command, environment)
+        return 0
+    except (OSError, ValueError, KeyError, TypeError, subprocess.SubprocessError) as error:
+        print(f"Omakade TV launch: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,8 @@
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+add_test(NAME omakade_tv_game_launcher
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/TvGameLauncherTests.py
+)
+
 qt_add_executable(omakade_core_tests
   CoreTests.cpp
 )

--- a/tests/TvGameLauncherTests.py
+++ b/tests/TvGameLauncherTests.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Exercise the launcher CLI with isolated stand-ins for desktop commands."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+LAUNCHER = Path(__file__).resolve().parents[1] / "skills/omakade-tv-gaming/scripts/omakade-tv-game.py"
+
+
+class TvGameLauncherTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.environment = {
+            **os.environ,
+            "PATH": str(self.root),
+            "TEST_ROOT": str(self.root),
+            "PULSE_SINK": "desktop-headset",
+        }
+        stand_in = "#!" + sys.executable + "\n" + '''
+import json, os, pathlib, sys
+root = pathlib.Path(os.environ["TEST_ROOT"])
+name = pathlib.Path(sys.argv[0]).name
+if name == "hyprctl":
+    assert sys.argv[1:] == ["-j", "monitors"]
+    print((root / "monitors.json").read_text())
+elif name == "pactl":
+    assert sys.argv[1:] == ["-f", "json", "list", "sinks"]
+    print((root / "sinks.json").read_text())
+elif name == "gamescope":
+    keys = ["PULSE_SINK", "SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS", "DXVK_HDR", "MANGOHUD_CONFIG"]
+    (root / "launched.json").write_text(json.dumps({
+        "arguments": sys.argv[1:], "environment": {k: os.environ.get(k) for k in keys}}))
+else:
+    raise AssertionError("unexpected command execution")
+'''
+        for tool in ("hyprctl", "pactl", "gamescope", "mangoapp"):
+            path = self.root / tool
+            path.write_text(stand_in)
+            path.chmod(0o700)
+        self.monitor = {"name": "TV-EXAMPLE", "width": 3840, "height": 2160,
+                        "refreshRate": 59.94, "activeWorkspace": {"id": 12}, "dpmsStatus": True}
+        self.write_state()
+
+    def write_state(self):
+        (self.root / "monitors.json").write_text(json.dumps([self.monitor]))
+        (self.root / "sinks.json").write_text(json.dumps([{"name": "tv-audio"}]))
+
+    def invoke(self, *arguments):
+        return subprocess.run(
+            [sys.executable, str(LAUNCHER), "--output", "TV-EXAMPLE", "--workspace", "12",
+             "--sink", "tv-audio", *arguments],
+            env=self.environment, capture_output=True, text=True, timeout=10,
+        )
+
+    def assert_not_launched(self, result):
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertFalse((self.root / "launched.json").exists())
+
+    def test_disabled_tv_never_starts_game(self):
+        (self.root / "monitors.json").write_text("[]")
+        result = self.invoke("--", "game")
+        self.assert_not_launched(result)
+        self.assertIn("TV output is unavailable", result.stderr)
+
+    def test_dpms_off_and_disabled_output_never_start_game(self):
+        for field, value in (("dpmsStatus", False), ("disabled", True)):
+            with self.subTest(field=field):
+                self.monitor[field] = value
+                self.write_state()
+                self.assert_not_launched(self.invoke("--", "game"))
+                self.monitor.pop(field)
+
+    def test_other_workspace_is_not_a_gaming_session(self):
+        self.monitor["activeWorkspace"]["id"] = 3
+        self.write_state()
+        self.assert_not_launched(self.invoke("--", "game"))
+
+    def test_missing_tv_sink_never_falls_back_to_headset(self):
+        (self.root / "sinks.json").write_text('[{"name":"desktop-headset"}]')
+        result = self.invoke("--", "game")
+        self.assert_not_launched(result)
+        self.assertIn("refusing to use the desktop audio sink", result.stderr)
+
+    def test_missing_optional_dependency_is_actionable(self):
+        (self.root / "mangoapp").unlink()
+        result = self.invoke("--fps", "--", "game")
+        self.assert_not_launched(result)
+        self.assertIn("mangoapp", result.stderr)
+
+    def test_check_and_dry_run_do_not_launch(self):
+        self.assertEqual(self.invoke("--check").returncode, 0)
+        result = self.invoke("--dry-run", "--", "game")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["environment"]["PULSE_SINK"], "tv-audio")
+        self.assertFalse((self.root / "launched.json").exists())
+
+    def test_launch_keeps_arguments_literal_and_routes_only_child_audio(self):
+        game = ["/a game/launch", "argument with spaces", "$(touch unwanted)", ";", "--flag"]
+        result = self.invoke("--hdr", "--fps", "--", *game)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        launched = json.loads((self.root / "launched.json").read_text())
+        arguments = launched["arguments"]
+        self.assertEqual(arguments[arguments.index("--") + 1:], game)
+        self.assertEqual(arguments[arguments.index("-W") + 1], "3840")
+        self.assertEqual(arguments[arguments.index("-r") + 1], "60")
+        self.assertIn("--hdr-enabled", arguments)
+        self.assertIn("--mangoapp", arguments)
+        self.assertEqual(launched["environment"]["PULSE_SINK"], "tv-audio")
+        self.assertEqual(self.environment["PULSE_SINK"], "desktop-headset")
+
+    def test_overrides_and_optional_features(self):
+        result = self.invoke("--width", "2560", "--height", "1440", "--refresh", "120", "--", "game")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        args = json.loads((self.root / "launched.json").read_text())["arguments"]
+        self.assertEqual(args[args.index("-w") + 1], "2560")
+        self.assertEqual(args[args.index("-h") + 1], "1440")
+        self.assertEqual(args[args.index("-r") + 1], "120")
+        self.assertNotIn("--hdr-enabled", args)
+        self.assertNotIn("--mangoapp", args)
+
+    def test_invalid_input_and_malformed_desktop_state(self):
+        self.assert_not_launched(self.invoke("--width", "0", "--", "game"))
+        (self.root / "monitors.json").write_text("not json")
+        self.assert_not_launched(self.invoke("--", "game"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A TV gaming session on a shared workstation needs rules for display ownership, game audio and agent input. This adds an opt-in Omakade skill that teaches agents how to configure and operate that session, plus a Gamescope launcher adapted from a working local setup.

The contribution includes:

- A portable `omakade-tv-gaming` skill and a session guide covering workspace reservation, start/stop behavior, controller verification, audio routing and coexistence with agent work.
- A Python launcher that checks the active TV workspace and named audio sink before starting Gamescope, preserves command arguments without shell evaluation, and offers optional HDR and an FPS-only MangoApp display.
- Package installation under `/usr/share/omakade/skills/omakade-tv-gaming`, opt-in agent discovery instructions, nine launcher tests in CTest, and staged-install checks in CI.

The session guide describes how to implement a compositor-specific controller. This PR does not introduce a built-in monitor/power manager, change default launching, or automatically alter agent configuration. The helper checks launch preconditions; a local session controller remains responsible for window placement and handling audio/output loss after launch. All machine identifiers are local configuration or examples, with no TV credentials or personal paths included.

Validation on x86_64 at commit `ccb0aae8a0feaeb8b81559d6b149485b94374d5e`:

- Release configure/build and all 42 CTest cases passed.
- Nine launcher CLI tests, including missing/off TV, wrong workspace, missing TV audio, dry-run behavior and literal argument preservation.
- Existing SBOM tooling tests and desktop/AppStream metadata validation.
- Staged installation with the skill, its reference and the launcher's `--help` entry point.
- A read-only check against the actual disabled TV correctly refused to launch. No game was opened for this contribution.

The original local setup was used with three work monitors, a separate TV and a controller, including real Couch Mode/game input and TV shutdown. The generalized helper's successful-launch path is covered using isolated command stand-ins; cross-hardware behavior and a complete physical hotplug lifecycle still need local validation. No game-FPS or hardware-isolation guarantees are made.

@btsouth, this grew out of using Omakade for TV gaming while coding agents continue working on the same PC. I would appreciate your feedback on shipping the skill and optional helper with Omakade. A useful manual review would be to install the staged skill, configure a spare TV workspace/sink, inspect `--check` and `--dry-run`, and then try a visible session and normal shutdown with those local rules in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional TV gaming skill for operating Omakade Couch Mode on a dedicated TV.
  * Added a launcher that validates TV session requirements and supports optional HDR and FPS overlays.
  * Installed launcher scripts are executable.

* **Documentation**
  * Added setup, usage, session lifecycle, troubleshooting, and verification guidance.
  * Documented Python 3 as a build prerequisite.

* **Tests**
  * Added automated coverage for launcher scenarios, display validation, overrides, and command-line behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->