### PR TITLE
Share personal-data rules with the backup validator and tolerate missing artwork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(omakade_core STATIC
   src/library/RyujinxGameModel.h
   src/library/ManualGameModel.cpp
   src/library/ManualGameModel.h
+  src/library/PersonalDataRules.h
   src/library/MockGameModel.cpp
   src/library/MockGameModel.h
   src/library/SteamGameModel.cpp

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -395,10 +395,16 @@ int main(int argc, char* argv[]) {
           ? QDir::tempPath() +
                 QStringLiteral("/omakade-test-%1.toml").arg(QCoreApplication::applicationPid())
           : QString{};
-  const BackupRecovery::Paths backupPaths{
-      QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/omakade/library.sqlite3",
-      QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + "/omakade/config.toml",
-      QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/omakade/restore-recovery"};
+  // Recovery insists on canonical paths. Qt passes XDG_DATA_HOME and
+  // XDG_CONFIG_HOME through untouched, so a trailing slash there must be
+  // cleaned here rather than rejected at restore time.
+  const QString dataRoot =
+      QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation));
+  const QString configRoot =
+      QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation));
+  const BackupRecovery::Paths backupPaths{dataRoot + "/omakade/library.sqlite3",
+                                          configRoot + "/omakade/config.toml",
+                                          dataRoot + "/omakade/restore-recovery"};
   // All synthetic libraries skip recovery entirely. The normal path owns the
   // SingleInstance claim above before any source database or service is opened.
   if (!demoMode && !stressMode && !navigationTest &&

--- a/src/backup/BackupArchive.cpp
+++ b/src/backup/BackupArchive.cpp
@@ -1,5 +1,7 @@
 #include "backup/BackupArchive.h"
 
+#include "library/PersonalDataRules.h"
+
 #include <QBuffer>
 #include <QCryptographicHash>
 #include <QDateTime>
@@ -28,12 +30,7 @@ QJsonObject manifestFor(const BackupPayload& payload) {
           {"createdAt", payload.createdAt}, {"library", payload.library},
           {"settings", payload.settings},   {"artwork", artworks}};
 }
-bool hasControls(const QString& value) {
-  for (const auto ch : value)
-    if (ch.category() == QChar::Other_Control)
-      return true;
-  return false;
-}
+bool hasControls(const QString& value) { return PersonalDataRules::hasControlCharacters(value); }
 bool fail(QString* error, const QString& message) {
   if (error)
     *error = message;
@@ -65,7 +62,7 @@ bool validSavedState(const QJsonObject& state) {
 bool validManual(const QJsonObject& entry, const QString& id) {
   const QSet<QString> fields{"id", "title", "executable", "directory", "arguments"};
   if (entry.size() != fields.size() || entry.value("id").toString() != id ||
-      !text(entry.value("title"), 200, false) || !text(entry.value("executable"), 4096, false) ||
+      !text(entry.value("title"), PersonalDataRules::kMaxManualTitleLength, false) || !text(entry.value("executable"), 4096, false) ||
       !text(entry.value("directory"), 4096, false) || !entry.value("arguments").isArray())
     return false;
   for (auto it = entry.begin(); it != entry.end(); ++it)
@@ -75,7 +72,7 @@ bool validManual(const QJsonObject& entry, const QString& id) {
       !QDir::isAbsolutePath(entry.value("directory").toString()))
     return false;
   const auto args = entry.value("arguments").toArray();
-  if (args.size() > 256)
+  if (args.size() > PersonalDataRules::kMaxManualArguments)
     return false;
   for (const auto& arg : args)
     if (!text(arg, 128 * 1024))
@@ -249,7 +246,8 @@ bool BackupArchive::validate(const BackupPayload& payload, QString* error) {
       if (table.key() == "saved_filters") {
         const auto name = row.value("name").toString();
         const auto key = name.normalized(QString::NormalizationForm_C).toCaseFolded();
-        if (name.trimmed() != name || name.size() > 100 || hasControls(name) ||
+        if (name.trimmed() != name || name.size() > PersonalDataRules::kMaxFilterNameLength ||
+            hasControls(name) ||
             row.value("name_key").toString() != key || savedNames.contains(key))
           return fail(error, "A saved filter name is invalid or duplicated.");
         savedNames.insert(key);

--- a/src/backup/BackupSnapshot.cpp
+++ b/src/backup/BackupSnapshot.cpp
@@ -50,6 +50,7 @@ bool captureDatabase(QSqlDatabase& database, const QJsonObject& settings, Backup
     QString source;
     QString appId;
     QString runner;
+    QString where;
   };
   const QList<LegacySource> sources{
       {"games", "'Steam'", "app_id", "''"},
@@ -61,12 +62,13 @@ bool captureDatabase(QSqlDatabase& database, const QJsonObject& settings, Backup
       {"pcsx2_games", "'PCSX2'", "'path:' || path", "COALESCE(serial, '')"},
       {"ryujinx_games", "'Ryujinx'", "game_id", "COALESCE(flatpak_app_id, '')"},
       {"battlenet_games", "'Battle.net'", "game_id", "COALESCE(runner, '')"},
-      {"manual_games", "'Manual'", "id", "''"}};
+      {"manual_games", "'Manual'", "id", "''", "WHERE active = 1"}};
   for (const auto& source : sources) {
     if (!tables.contains(source.table))
       continue;
-    if (!query.exec(QStringLiteral("SELECT %1, %2, %3, favorite, hidden FROM %4")
-                        .arg(source.source, source.runner, source.appId, source.table)))
+    if (!query.exec(QStringLiteral("SELECT %1, %2, %3, favorite, hidden FROM %4 %5")
+                        .arg(source.source, source.runner, source.appId, source.table,
+                             source.where)))
       return fail("Could not read personal state for " + source.table + ".");
     while (query.next()) {
       QJsonObject row{{"source", query.value(0).toString()},
@@ -102,12 +104,16 @@ bool captureDatabase(QSqlDatabase& database, const QJsonObject& settings, Backup
         else
           return fail("The personal-data schema is unsupported: " + schema.key() + ".");
       }
-      if (!query.exec("SELECT " + expressions.join(", ") + " FROM " + schema.key()))
+      // Removed manual games stay in the table as inactive rows; they are not
+      // personal data worth carrying to another machine.
+      const QString where = schema.key() == "manual_games" ? " WHERE active = 1" : QString();
+      if (!query.exec("SELECT " + expressions.join(", ") + " FROM " + schema.key() + where))
         return fail("Could not read the personal-data table " + schema.key() + ".");
       while (query.next()) {
         if (++recordCount > 100000)
           return fail("The library contains too many personal records for one backup.");
         QJsonObject row;
+        bool danglingArtwork = false;
         for (int index = 0; index < schema.value().size(); ++index) {
           const QString column = schema.value().at(index);
           const auto value = query.value(index);
@@ -127,9 +133,16 @@ bool captureDatabase(QSqlDatabase& database, const QJsonObject& settings, Backup
             }
             if (!assetForPath.contains(path)) {
               QFile image(path);
-              if (!image.open(QIODevice::ReadOnly) || image.size() > BackupArchive::MaxImageBytes)
-                return fail("Custom artwork is missing or too large. Repair or reset it before "
-                            "backing up.");
+              if (!image.open(QIODevice::ReadOnly)) {
+                // The override points at a file that is gone. The library already
+                // falls back to provider artwork for it, so drop it from the backup
+                // instead of blocking every export on a file nobody can repair.
+                danglingArtwork = true;
+                row.insert(column, "");
+                continue;
+              }
+              if (image.size() > BackupArchive::MaxImageBytes)
+                return fail("Custom artwork is too large. Reset it before backing up.");
               const auto bytes = image.read(BackupArchive::MaxImageBytes + 1);
               const auto name = BackupArchive::artworkName(bytes, error);
               if (name.isEmpty())
@@ -151,6 +164,14 @@ bool captureDatabase(QSqlDatabase& database, const QJsonObject& settings, Backup
               return fail("A personal record exceeds the backup size limit.");
             row.insert(column, text);
           }
+        }
+        if (danglingArtwork) {
+          bool anyArtwork = false;
+          for (const QString& column : schema.value())
+            if (column.endsWith("_path") && !row.value(column).toString().isEmpty())
+              anyArtwork = true;
+          if (!anyArtwork)
+            continue;
         }
         if (schema.key() == "user_game_flags") {
           const QString key = keyFor(row);

--- a/src/library/LibraryFilterModel.cpp
+++ b/src/library/LibraryFilterModel.cpp
@@ -1,5 +1,7 @@
 #include "library/LibraryFilterModel.h"
 
+#include "library/PersonalDataRules.h"
+
 #include "library/GameRoles.h"
 #include "library/UnifiedGameModel.h"
 
@@ -149,8 +151,9 @@ QVariantList LibraryFilterModel::savedFilters() const {
 QString LibraryFilterModel::saveCurrentFilter(const QString& value) {
   auto* games = qobject_cast<UnifiedGameModel*>(sourceModel());
   const QString name = value.trimmed().normalized(QString::NormalizationForm_C);
-  if (!games || savedFilters().size() >= 500 || name.isEmpty() || name.size() > 100 ||
-      name.contains(QRegularExpression(QStringLiteral("[\\x00-\\x1f\\x7f]"))) || !validFilterState(filterState())) {
+  if (!games || savedFilters().size() >= PersonalDataRules::kMaxSavedFilters || name.isEmpty() ||
+      name.size() > PersonalDataRules::kMaxFilterNameLength ||
+      PersonalDataRules::hasControlCharacters(name) || !validFilterState(filterState())) {
     setSavedFilterMessage("Use a name of 1 to 100 characters; up to 500 filters can be saved."); return {};
   }
   const QString id = QUuid::createUuid().toString(QUuid::WithoutBraces);
@@ -164,8 +167,8 @@ QString LibraryFilterModel::saveCurrentFilter(const QString& value) {
 bool LibraryFilterModel::renameSavedFilter(const QString& id, const QString& value) {
   auto* games = qobject_cast<UnifiedGameModel*>(sourceModel());
   const QString name = value.trimmed().normalized(QString::NormalizationForm_C);
-  if (games && !name.isEmpty() && name.size() <= 100 &&
-      !name.contains(QRegularExpression(QStringLiteral("[\\x00-\\x1f\\x7f]")))) {
+  if (games && !name.isEmpty() && name.size() <= PersonalDataRules::kMaxFilterNameLength &&
+      !PersonalDataRules::hasControlCharacters(name)) {
     for (const auto& entry : games->savedFilters()) {
       const auto saved = entry.toMap();
       if (saved.value("id").toString() == id && games->saveFilter(id, name, saved.value("state").toMap())) {

--- a/src/library/ManualGameModel.cpp
+++ b/src/library/ManualGameModel.cpp
@@ -1,4 +1,6 @@
 #include "library/ManualGameModel.h"
+
+#include "library/PersonalDataRules.h"
 #include "library/GameRoles.h"
 
 #include <QColor>
@@ -304,7 +306,7 @@ bool ManualGameModel::validateLaunch(const QString& target, const QString& id, Q
       return fail("The argument list is invalid");
     parsed.append(value.toString());
   }
-  if (parsed.size() > 256 || program.contains(QChar::Null) || cwd.contains(QChar::Null))
+  if (parsed.size() > PersonalDataRules::kMaxManualArguments || program.contains(QChar::Null) || cwd.contains(QChar::Null))
     return fail("The manual launch details are invalid");
   if (executable)
     *executable = program;
@@ -324,8 +326,10 @@ QString ManualGameModel::saveEntry(const QVariantMap& input) {
   const QString id =
       existing.isEmpty() ? QUuid::createUuid().toString(QUuid::WithoutBraces) : existing;
   const QString title = input.value("title").toString().trimmed();
-  if (title.isEmpty() || title.size() > 256) {
-    setError("Enter a title up to 256 characters");
+  if (title.isEmpty() || title.size() > PersonalDataRules::kMaxManualTitleLength ||
+      PersonalDataRules::hasControlCharacters(title)) {
+    setError(QStringLiteral("Enter a title up to %1 characters")
+                 .arg(PersonalDataRules::kMaxManualTitleLength));
     return {};
   }
   QVariantMap entry{{"id", id},

--- a/src/library/PersonalDataRules.h
+++ b/src/library/PersonalDataRules.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QChar>
+#include <QString>
+
+// Limits and character rules for personal data the user types in. The models
+// apply them when data is written and BackupArchive applies the same rules when
+// an archive is validated, so a library the app accepted always exports.
+namespace PersonalDataRules {
+constexpr int kMaxManualTitleLength = 200;
+constexpr int kMaxManualArguments = 256;
+constexpr int kMaxFilterNameLength = 100;
+constexpr int kMaxSavedFilters = 500;
+
+inline bool hasControlCharacters(const QString& value) {
+  for (const QChar character : value) {
+    if (character.category() == QChar::Other_Control) {
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace PersonalDataRules

--- a/src/library/UnifiedGameModel.cpp
+++ b/src/library/UnifiedGameModel.cpp
@@ -1,5 +1,7 @@
 #include "library/UnifiedGameModel.h"
 
+#include "library/PersonalDataRules.h"
+
 #include "library/GameRoles.h"
 #include "library/ManualGameModel.h"
 
@@ -65,10 +67,8 @@ QString normalizedCollectionName(const QString& input) {
   if (name.isEmpty() || name.size() > 48) {
     return {};
   }
-  for (const QChar character : name) {
-    if (character.category() == QChar::Other_Control) {
-      return {};
-    }
+  if (PersonalDataRules::hasControlCharacters(name)) {
+    return {};
   }
   return name;
 }
@@ -1014,7 +1014,7 @@ bool UnifiedGameModel::bulkOrganize(const QStringList& identities, const QVarian
     for (const auto& raw : changes.value(field).toString().split(QLatin1Char(','), Qt::SkipEmptyParts)) {
       const QString tag = raw.trimmed().simplified();
       if (tag.size() > 32) return false;
-      for (const auto ch : raw) if (ch.category() == QChar::Other_Control) return false;
+      if (PersonalDataRules::hasControlCharacters(raw)) return false;
       if (!tag.isEmpty() && !unique.contains(tag, Qt::CaseInsensitive)) unique.append(tag);
     }
     if (unique.size() > 20) return false;

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -23,6 +23,7 @@
 #include "library/LutrisGameModel.h"
 #include "library/MockGameModel.h"
 #include "library/ManualGameModel.h"
+#include "library/PersonalDataRules.h"
 #include "library/Pcsx2GameModel.h"
 #include "library/RyujinxGameModel.h"
 #include "library/RetroArchGameModel.h"
@@ -1880,10 +1881,14 @@ void CoreTests::backupSnapshotConsolidatesLegacyPersonalState() {
   QCOMPARE(snapshot.artwork.size(), 1);
   QVERIFY(original.open(QIODevice::ReadOnly)); QCOMPARE(original.readAll(), originalBytes); original.close();
   QVERIFY2(BackupArchive::write(temp.filePath("export.omakade-backup"), snapshot, &error), qPrintable(error));
-  const auto goodLibrary = snapshot.library;
+  // A custom artwork file that has gone missing is dropped from the backup
+  // rather than blocking every export; the library already falls back for it.
   QVERIFY(QFile::remove(cover));
-  QVERIFY(!BackupSnapshot::capture(path, settings.backupSettings(), &snapshot, &error));
-  QCOMPARE(snapshot.library, goodLibrary);
+  BackupPayload withoutCover;
+  QVERIFY2(BackupSnapshot::capture(path, settings.backupSettings(), &withoutCover, &error), qPrintable(error));
+  QVERIFY(withoutCover.library.value("artwork_overrides").toArray().isEmpty());
+  QVERIFY(withoutCover.artwork.isEmpty());
+  QCOMPARE(withoutCover.library.value("user_game_flags").toArray().size(), 9);
 }
 
 void CoreTests::backupArchiveRoundTripsAndRejectsInvalidContent() {
@@ -2190,6 +2195,9 @@ void CoreTests::savedFiltersPersistAndPreserveQueries() {
     QCOMPARE(filter.rowCount(), 1);
     expected = filter.filterState();
     id = filter.saveCurrentFilter(" Weekend picks ");
+  // Names follow the same control-character rule the backup validator applies.
+  QVERIFY(filter.saveCurrentFilter(QStringLiteral("bad\u0085name")).isEmpty());
+  QVERIFY(filter.saveCurrentFilter(QString(PersonalDataRules::kMaxFilterNameLength + 1, QLatin1Char('n'))).isEmpty());
     QVERIFY(!id.isEmpty());
     QVERIFY(filter.saveCurrentFilter("WEEKEND PICKS").isEmpty());
     QVERIFY(filter.saveCurrentFilter(" ").isEmpty());
@@ -4139,6 +4147,19 @@ void CoreTests::manualGamesImportEditLaunchAndRemove() {
   QVERIFY(QFileInfo::exists(executable + QStringLiteral(" moved")));
   ManualGameModel afterRemoval(database);
   QCOMPARE(afterRemoval.rowCount(), 1);
+  // Removed entries are inactive rows; backups carry only what the library shows.
+  BackupPayload snapshot;
+  QString snapshotError;
+  QVERIFY2(BackupSnapshot::capture(database, {}, &snapshot, &snapshotError), qPrintable(snapshotError));
+  QCOMPARE(snapshot.library.value("manual_games").toArray().size(), 1);
+  for (const auto& flag : snapshot.library.value("user_game_flags").toArray())
+    QVERIFY(flag.toObject().value("app_id").toString() != id);
+  // The editor and the backup validator share one title limit.
+  QVariantMap longTitle = afterRemoval.get(afterRemoval.data(afterRemoval.index(0), GameRoles::AppId).toString());
+  longTitle.insert(QStringLiteral("title"), QString(PersonalDataRules::kMaxManualTitleLength + 1, QLatin1Char('x')));
+  QVERIFY(afterRemoval.saveEntry(longTitle).isEmpty());
+  longTitle.insert(QStringLiteral("title"), QStringLiteral("bad\u0085title"));
+  QVERIFY(afterRemoval.saveEntry(longTitle).isEmpty());
 }
 
 void CoreTests::gogFoldersPersistAndHandleDisconnectedRoots() {


### PR DESCRIPTION
Fixes from the review of #30. All six findings sat in the backup path.

- New library/PersonalDataRules.h holds the manual title limit, argument count, saved filter name length and count, and the control-character rule. ManualGameModel, LibraryFilterModel, UnifiedGameModel, and BackupArchive all use it, so the validator accepts exactly what the app can store. Previously the editor allowed 256-character titles the archive rejected at 200, and filter names allowed C1 controls the archive rejected.
- BackupSnapshot drops an artwork override whose file is gone instead of failing the whole export. The library already falls back to provider art for those rows and the reset button is disabled when the file is missing, so there was no in-app remedy. Oversized or invalid files still fail.
- BackupSnapshot exports only active manual games in both the flag pass and the table dump, so removed entries no longer inflate the preview count or come back on a Replace restore.
- main.cpp cleans the XDG data and config roots before building the recovery paths. Qt passes a trailing slash in XDG_DATA_HOME or XDG_CONFIG_HOME through untouched and BackupRecovery rejects any path cleanPath would change, which blocked every restore on such systems.

Tests: artwork test now expects a successful capture with the dangling override dropped, manual game test checks inactive rows are excluded and the shared title limit is enforced, saved filter test checks the shared name rule. Full suite 81/81.