### PR TITLE
Identification, cover loading, and Couch Mode fixes on top of 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,15 @@ and more control over how your library looks.
 
 ### Ratings, covers, and settings
 
-- Identify games with IGDB and sort the library by rating or popularity.
-  Review uncertain matches and correct them from game details.
-- Add optional SteamGridDB portrait covers using the same game identification.
-  Choose another portrait manually and keep downloaded artwork available offline.
+- Identify games with IGDB and sort the library by rating or popularity. Ratings
+  appear on library cards beside the source and the playtime.
+- Match ROM dumps automatically. Region, revision, release and translation tags
+  are understood, so a shelf of tagged dumps identifies itself instead of asking
+  you to confirm every game. What cannot be matched confidently is counted at the
+  end and can be corrected from game details.
+- Add optional SteamGridDB portrait covers using the same game identification,
+  for Switch, Wii U, PS4 and PC games. Retro consoles keep their own box art
+  instead. Choose another portrait manually and keep artwork available offline.
 - Replace the long settings sheet with Sources, Library, Connections,
   Controls & streaming, and About & storage.
 - Adjust cover size, with separate desktop and Couch Mode preferences. Restore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,8 @@ add_library(omakade_core STATIC
   src/artwork/ZArchiveReader.h
   src/artwork/TgaImage.cpp
   src/artwork/TgaImage.h
+  src/artwork/CoverImageProvider.cpp
+  src/artwork/CoverImageProvider.h
   src/sources/heroic/HeroicScanner.cpp
   src/sources/heroic/HeroicScanner.h
   src/sources/faugus/FaugusScanner.cpp
@@ -185,6 +187,7 @@ add_library(omakade_core STATIC
 
 target_include_directories(omakade_core PUBLIC src)
 target_link_libraries(omakade_core PUBLIC
+  Qt6::Quick
   PkgConfig::SDL3
   PkgConfig::LIBSECRET
   PkgConfig::LIBZIP

--- a/docs/releases/1.7.0-notes.md
+++ b/docs/releases/1.7.0-notes.md
@@ -20,10 +20,15 @@ and more control over how your library looks.
 
 ### Ratings, covers, and settings
 
-- Identify games with IGDB and sort the library by rating or popularity.
-  Review uncertain matches and correct them from game details.
-- Add optional SteamGridDB portrait covers using the same game identification.
-  Choose another portrait manually and keep downloaded artwork available offline.
+- Identify games with IGDB and sort the library by rating or popularity. Ratings
+  appear on library cards beside the source and the playtime.
+- Match ROM dumps automatically. Region, revision, release and translation tags
+  are understood, so a shelf of tagged dumps identifies itself instead of asking
+  you to confirm every game. What cannot be matched confidently is counted at the
+  end and can be corrected from game details.
+- Add optional SteamGridDB portrait covers using the same game identification,
+  for Switch, Wii U, PS4 and PC games. Retro consoles keep their own box art
+  instead. Choose another portrait manually and keep artwork available offline.
 - Replace the long settings sheet with Sources, Library, Connections,
   Controls & streaming, and About & storage.
 - Adjust cover size, with separate desktop and Couch Mode preferences. Restore

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -431,13 +431,61 @@ ApplicationWindow {
     function leaveConsole() {
         if (Library.consoleFilter.length > 0) {
             Library.consoleFilter = ""
-            libraryView.currentIndex = Library.rowCount() > 0 ? 0 : -1
+            root.resetLibrarySelection()
+            return true
+        }
+        return false
+    }
+
+    // Both views watch the same library, so a filter change has to settle the selection in
+    // whichever one is on screen.
+    function resetLibrarySelection() {
+        const first = Library.rowCount() > 0 ? 0 : -1
+        libraryView.currentIndex = first
+        couchLibraryView.currentIndex = first
+        couchLibraryView.refreshCurrentGame()
+    }
+
+    // Back walks out of the library the way you walked in: out of a console, then out of a
+    // search, then out of a source, and finally out of anything else still narrowing the view.
+    // Levels that are not active are skipped, so from RetroArch inside Nintendo 64 one press
+    // reaches RetroArch and the next reaches all sources. Returns true when a level was left.
+    function stepBackFilter() {
+        if (root.leaveConsole()) {
+            return true
+        }
+        if (Library.searchText.length > 0) {
+            searchField.text = ""
+            Library.searchText = ""
+            root.resetLibrarySelection()
+            return true
+        }
+        if (Library.sourceFilters.length > 0) {
+            Library.sourceFilters = []
+            root.resetLibrarySelection()
+            return true
+        }
+        // Whatever is left narrowing the view goes together, so back always reaches the whole
+        // library rather than asking for a press per filter.
+        if (Library.completionFilter !== "" || Library.collectionFilter !== ""
+                || Library.tagFilter !== "" || Library.mode !== 0 || Library.availability !== 0) {
+            Library.completionFilter = ""
+            Library.collectionFilter = ""
+            Library.tagFilter = ""
+            Library.mode = 0
+            Library.availability = 0
+            root.resetLibrarySelection()
             return true
         }
         return false
     }
 
     function openGame(index) {
+        // Refuse a row that is not in the library rather than opening an empty page. Every way
+        // in is guarded, so a stale index cannot reach here, and this is the backstop.
+        if (index < 0 || index >= Library.rowCount()) {
+            return
+        }
         root.randomSelection = false
         selectedIndex = index
         selectedGame = Library.get(index)
@@ -970,10 +1018,10 @@ ApplicationWindow {
                 detailsLoader.item.closeCollectionEditor()
             } else if (root.detailOpen) {
                 root.closeDetails()
-            } else if (root.leaveConsole()) {
-            } else if (!root.couchMode && searchField.text.length > 0) {
-                searchField.clear()
-                libraryView.focusGrid()
+            } else if (root.stepBackFilter()) {
+                if (!root.couchMode) {
+                    libraryView.focusGrid()
+                }
             } else if (root.couchMode || !libraryView.gridFocused) {
                 root.focusLibrary()
             }
@@ -1803,6 +1851,7 @@ ApplicationWindow {
                 GlassButton {
                     id: statusFilterButton
                     objectName: "statusFilterButton"
+                    property Item controllerDownTarget: libraryView.focusTarget
                     compact: true
                     text: root.filterLabel("STATUS", Library.completionFilter)
                     selected: Library.completionFilter !== ""
@@ -1812,6 +1861,7 @@ ApplicationWindow {
                 GlassButton {
                     id: collectionFilterButton
                     objectName: "collectionFilterButton"
+                    property Item controllerDownTarget: libraryView.focusTarget
                     compact: true
                     text: root.filterLabel("COLLECTION", Library.collectionFilter,
                                            Library.collectionNames)
@@ -1827,6 +1877,7 @@ ApplicationWindow {
                 GlassButton {
                     id: tagFilterButton
                     objectName: "tagFilterButton"
+                    property Item controllerDownTarget: libraryView.focusTarget
                     compact: true
                     text: root.filterLabel("TAG", Library.tagFilter, Library.tagNames)
                     selected: Library.tagFilter !== ""

--- a/qml/components/CouchLibraryView.qml
+++ b/qml/components/CouchLibraryView.qml
@@ -111,6 +111,23 @@ FocusScope {
         }
     }
 
+    readonly property string sourceLabel: {
+        const chosen = root.libraryModel.sourceFilters
+        if (!chosen || chosen.length === 0)
+            return "ALL"
+        if (chosen.length === 1)
+            return chosen[0].toUpperCase()
+        const grouped = root.libraryModel.sourceFilter
+        if (grouped && grouped.toUpperCase() === "EMULATED")
+            return "EMULATED"
+        return chosen.length + " SOURCES"
+    }
+    readonly property string sortLabel:
+        root.libraryModel.sortMode === 1 ? "RECENT"
+      : root.libraryModel.sortMode === 2 ? "PLAYTIME"
+      : root.libraryModel.sortMode === 3 ? "RATING"
+      : root.libraryModel.sortMode === 4 ? "POPULARITY" : "TITLE"
+
     function selectMode(mode) {
         libraryModel.mode = mode
         currentIndex = libraryModel.rowCount() > 0 ? 0 : -1
@@ -139,7 +156,7 @@ FocusScope {
                        : -1
         refreshCurrentGame()
         Qt.callLater(function() {
-            browseButton.forceActiveFocus(Qt.TabFocusReason)
+            sourceButton.forceActiveFocus(Qt.TabFocusReason)
         })
     }
 
@@ -353,49 +370,63 @@ FocusScope {
                     root.libraryModel.consoleFilter = ""
                     root.currentIndex = root.libraryModel.rowCount() > 0 ? 0 : -1
                 }
-                KeyNavigation.right: allButton
+                KeyNavigation.right: showButton
                 KeyNavigation.down: root.detailView ? viewButton : gameGrid
             }
+            // What the library is showing, and what it is filtered and sorted by, are stated on
+            // the bar rather than hidden inside Browse. Being unable to tell that only one
+            // source was selected is what made the library look broken.
             GlassButton {
-                id: allButton
-                objectName: "couchAllButton"
-                text: "ALL"
+                id: showButton
+                objectName: "couchShowButton"
+                text: "SHOW: " + (root.libraryModel.mode === 1 ? "FAVORITES"
+                                : root.libraryModel.mode === 2 ? "RECENT" : "ALL")
+                Accessible.name: "Showing " + (root.libraryModel.mode === 1 ? "favorites"
+                                             : root.libraryModel.mode === 2 ? "recently played"
+                                                                            : "all games")
                 compact: true
                 displayScale: Math.max(1, root.uiScale * 1.18)
-                selected: root.libraryModel.mode === 0
-                onClicked: root.selectMode(0)
+                selected: root.libraryModel.mode !== 0
+                onClicked: root.selectMode((root.libraryModel.mode + 1) % 3)
                 KeyNavigation.left: consoleButton.visible ? consoleButton : null
-                KeyNavigation.right: favoritesButton
+                KeyNavigation.right: sourceButton
                 KeyNavigation.down: root.detailView ? viewButton : gameGrid
             }
             GlassButton {
-                id: favoritesButton
-                objectName: "couchFavoritesFilterButton"
-                text: "FAVORITES"
+                id: sourceButton
+                objectName: "couchSourceButton"
+                text: "SOURCE: " + root.sourceLabel
+                Accessible.name: "Source filter: " + root.sourceLabel.toLowerCase()
                 compact: true
                 displayScale: Math.max(1, root.uiScale * 1.18)
-                selected: root.libraryModel.mode === 1
-                onClicked: root.selectMode(1)
-                KeyNavigation.left: allButton
-                KeyNavigation.right: recentButton
+                selected: root.libraryModel.sourceFilters.length > 0
+                // Opens Browse on its source list, which is also the way to every other filter.
+                onClicked: root.openBrowse()
+                KeyNavigation.left: showButton
+                KeyNavigation.right: sortButton
                 KeyNavigation.down: root.detailView ? viewButton : gameGrid
             }
             GlassButton {
-                id: recentButton
-                objectName: "couchRecentButton"
-                text: "RECENT"
+                id: sortButton
+                objectName: "couchSortButton"
+                text: "SORT: " + root.sortLabel
+                Accessible.name: "Sorted by " + root.sortLabel.toLowerCase()
                 compact: true
                 displayScale: Math.max(1, root.uiScale * 1.18)
-                selected: root.libraryModel.mode === 2
-                onClicked: root.selectMode(2)
-                KeyNavigation.left: favoritesButton
+                selected: root.libraryModel.sortMode !== 0
+                onClicked: {
+                    root.libraryModel.sortMode = (root.libraryModel.sortMode + 1) % 5
+                    root.currentIndex = root.libraryModel.rowCount() > 0 ? 0 : -1
+                    root.refreshCurrentGame()
+                }
+                KeyNavigation.left: sourceButton
                 KeyNavigation.right: consoleViewButton
                 KeyNavigation.down: root.detailView ? favoriteButton : gameGrid
             }
             GlassButton {
                 id: consoleViewButton
                 objectName: "couchConsoleViewButton"
-                text: root.libraryModel.expandConsoles ? "CONSOLES: GAMES" : "CONSOLES: CARDS"
+                text: "CONSOLES"
                 Accessible.name: "Console view: " + (root.libraryModel.expandConsoles ? "games" : "cards")
                 compact: true
                 displayScale: Math.max(1, root.uiScale * 1.18)
@@ -405,31 +436,20 @@ FocusScope {
                     root.currentIndex = root.libraryModel.rowCount() > 0 ? 0 : -1
                     root.refreshCurrentGame()
                 }
-                KeyNavigation.left: recentButton
+                KeyNavigation.left: sortButton
                 KeyNavigation.right: layoutButton
                 KeyNavigation.down: root.detailView ? favoriteButton : gameGrid
             }
             GlassButton {
                 id: layoutButton
                 objectName: "couchLayoutButton"
-                text: root.detailView ? "VIEW · DETAIL" : "VIEW · GRID"
+                text: root.detailView ? "VIEW: DETAIL" : "VIEW: GRID"
                 iconText: root.detailView ? "▤" : "▦"
                 compact: true
                 displayScale: Math.max(1, root.uiScale * 1.18)
                 selected: true
                 onClicked: root.toggleLibraryView()
                 KeyNavigation.left: consoleViewButton
-                KeyNavigation.right: browseButton
-                KeyNavigation.down: root.detailView ? favoriteButton : gameGrid
-            }
-            GlassButton {
-                id: browseButton
-                objectName: "couchBrowseButton"
-                text: "BROWSE"
-                compact: true
-                displayScale: Math.max(1, root.uiScale * 1.18)
-                onClicked: root.openBrowse()
-                KeyNavigation.left: layoutButton
                 KeyNavigation.right: searchButton
                 KeyNavigation.down: root.detailView ? favoriteButton : gameGrid
             }
@@ -444,7 +464,7 @@ FocusScope {
                 compact: true
                 displayScale: Math.max(1, root.uiScale * 1.18)
                 onClicked: root.openSearch()
-                KeyNavigation.left: browseButton
+                KeyNavigation.left: layoutButton
                 KeyNavigation.right: settingsButton
                 KeyNavigation.down: root.detailView ? favoriteButton : gameGrid
             }
@@ -630,7 +650,7 @@ FocusScope {
                 displayScale: Math.max(1, root.uiScale * 1.2)
                 enabled: root.currentIndex >= 0
                 onClicked: root.gameActivated(root.currentIndex)
-                KeyNavigation.up: allButton
+                KeyNavigation.up: showButton
                 KeyNavigation.right: favoriteButton
                 KeyNavigation.down: gameStrip
             }
@@ -896,7 +916,7 @@ FocusScope {
 
         Keys.onUpPressed: function(event) {
             if (currentIndex >= 0 && currentIndex < columnCount) {
-                allButton.forceActiveFocus(Qt.TabFocusReason)
+                showButton.forceActiveFocus(Qt.TabFocusReason)
                 event.accepted = true
             } else {
                 event.accepted = false
@@ -926,6 +946,8 @@ FocusScope {
             required property string source
             required property string appId
             required property bool favorite
+            required property int rating
+            required property int hours
             required property color accentStart
             required property color accentEnd
             readonly property bool current: gameGrid.currentIndex === index
@@ -1025,6 +1047,33 @@ FocusScope {
                     }
                 }
 
+                // Sitting in a fixed corner lets the eye read a column of ratings down the grid,
+                // which a line of text under the card cannot do at television distance. Games
+                // without a rating simply have no badge.
+                Rectangle {
+                    objectName: "couchCardRating"
+                    visible: gridCard.rating >= 0
+                    anchors.bottom: parent.bottom
+                    anchors.right: parent.right
+                    anchors.rightMargin: 10 * root.uiScale
+                    anchors.bottomMargin: 14 * root.uiScale
+                    width: gridRatingText.implicitWidth + 14 * root.uiScale
+                    height: 26 * root.uiScale
+                    radius: 5 * root.uiScale
+                    color: root.alpha(Theme.darkerBackground, 0.86)
+                    border.color: root.alpha(Theme.brightForeground, 0.24)
+
+                    Text {
+                        id: gridRatingText
+                        anchors.centerIn: parent
+                        text: gridCard.rating + "%"
+                        color: Theme.brightForeground
+                        font.family: Theme.fontFamily
+                        font.pixelSize: 13 * root.uiScale
+                        font.weight: Font.DemiBold
+                    }
+                }
+
                 Rectangle {
                     visible: gridCard.current
                     anchors.left: parent.left
@@ -1072,6 +1121,7 @@ FocusScope {
                 anchors.rightMargin: 11 * root.uiScale
                 anchors.bottomMargin: 8 * root.uiScale
                 text: (gridCard.source || gridCard.subtitle || "LIBRARY").toUpperCase()
+                      + (gridCard.hours > 0 ? " · " + gridCard.hours + "H" : "")
                 textFormat: Text.PlainText
                 color: gridCard.current ? Theme.accent : Theme.mutedText
                 font.family: Theme.fontFamily

--- a/qml/components/CouchLibraryView.qml
+++ b/qml/components/CouchLibraryView.qml
@@ -648,7 +648,7 @@ FocusScope {
                 iconText: "▶"
                 primary: true
                 displayScale: Math.max(1, root.uiScale * 1.2)
-                enabled: root.currentIndex >= 0
+                enabled: root.currentIndex >= 0 && root.currentIndex < root.libraryModel.rowCount()
                 onClicked: root.gameActivated(root.currentIndex)
                 KeyNavigation.up: showButton
                 KeyNavigation.right: favoriteButton
@@ -743,13 +743,13 @@ FocusScope {
             event.accepted = true
         }
         Keys.onReturnPressed: function(event) {
-            if (currentIndex >= 0) {
+            if (currentIndex >= 0 && currentIndex < count) {
                 root.gameActivated(currentIndex)
             }
             event.accepted = true
         }
         Keys.onEnterPressed: function(event) {
-            if (currentIndex >= 0) {
+            if (currentIndex >= 0 && currentIndex < count) {
                 root.gameActivated(currentIndex)
             }
             event.accepted = true
@@ -861,7 +861,7 @@ FocusScope {
                     gameStrip.currentIndex = card.index
                     gameStrip.forceActiveFocus(Qt.MouseFocusReason)
                 }
-                onDoubleClicked: root.gameActivated(card.index)
+                onDoubleClicked: if (card.index >= 0) root.gameActivated(card.index)
             }
 
             opacity: gameStrip.currentIndex === card.index ? 1 : 0.58
@@ -924,13 +924,13 @@ FocusScope {
         }
 
         Keys.onReturnPressed: function(event) {
-            if (currentIndex >= 0) {
+            if (currentIndex >= 0 && currentIndex < count) {
                 root.gameActivated(currentIndex)
             }
             event.accepted = true
         }
         Keys.onEnterPressed: function(event) {
-            if (currentIndex >= 0) {
+            if (currentIndex >= 0 && currentIndex < count) {
                 root.gameActivated(currentIndex)
             }
             event.accepted = true
@@ -1136,10 +1136,10 @@ FocusScope {
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
                 onClicked: {
-                    gameGrid.currentIndex = gridCard.index
+                    if (gridCard.index >= 0) gameGrid.currentIndex = gridCard.index
                     gameGrid.forceActiveFocus(Qt.MouseFocusReason)
                 }
-                onDoubleClicked: root.gameActivated(gridCard.index)
+                onDoubleClicked: if (gridCard.index >= 0) root.gameActivated(gridCard.index)
             }
 
             opacity: gridCard.current ? 1 : 0.72

--- a/qml/components/CoverArtwork.qml
+++ b/qml/components/CoverArtwork.qml
@@ -17,6 +17,22 @@ Item {
     readonly property bool nearFit: ready && shapeRatio >= 0.88 && shapeRatio <= 1.14
     readonly property bool wideArt: ready && shapeRatio >= 1.8
 
+    // Artwork reaches the cover cache as "f/<file path>" or "q/<bundled path>". Marking which
+    // kind it is keeps the identifier a plain path, which survives being carried through a URL
+    // far more predictably than an escaped one.
+    readonly property string cacheId: {
+        const text = root.source.toString()
+        if (text === "")
+            return ""
+        if (text.startsWith("qrc:/"))
+            return "q" + text.substring(4)
+        if (text.startsWith("file://"))
+            return "f" + decodeURIComponent(text.substring(7))
+        if (text.startsWith("/"))
+            return "f" + text
+        return ""
+    }
+
     // Wide box scans sit on a plain dark field rather than the card's accent
     // gradient, so the letterbox does not draw the eye.
     Rectangle {
@@ -30,9 +46,13 @@ Item {
         anchors.fill: parent
         // Wait for the card to have a size before loading. A delegate is created before layout
         // gives it one, so binding straight through decoded every cover twice: once at its full
-        // size while the frame was still zero, then again at the size actually wanted. The
-        // second decode missed the cache, which is what made covers blink on every filter change.
-        source: width > 0 && height > 0 ? root.source : ""
+        // size while the frame was still zero, then again at the size actually wanted.
+        //
+        // Go through Omakade's own cover cache rather than reading the file directly. Qt only
+        // keeps a couple of megabytes of artwork no card is currently showing, about twenty
+        // covers, so a library of any size re-read them from disk on every scroll and filter
+        // change. The provider keeps a decoded cover for as long as the library is open.
+        source: width > 0 && height > 0 && root.cacheId !== "" ? "image://covers/" + root.cacheId : ""
         asynchronous: true
         cache: true
         fillMode: root.nearFit ? Image.Stretch

--- a/qml/components/CoverArtwork.qml
+++ b/qml/components/CoverArtwork.qml
@@ -28,7 +28,11 @@ Item {
     Image {
         id: artwork
         anchors.fill: parent
-        source: root.source
+        // Wait for the card to have a size before loading. A delegate is created before layout
+        // gives it one, so binding straight through decoded every cover twice: once at its full
+        // size while the frame was still zero, then again at the size actually wanted. The
+        // second decode missed the cache, which is what made covers blink on every filter change.
+        source: width > 0 && height > 0 ? root.source : ""
         asynchronous: true
         cache: true
         fillMode: root.nearFit ? Image.Stretch
@@ -39,8 +43,19 @@ Item {
         sourceSize.width: Math.ceil(width * Math.max(1, Screen.devicePixelRatio) / 64) * 64
         sourceSize.height: Math.ceil(height * Math.max(1, Screen.devicePixelRatio) / 64) * 64
         opacity: status === Image.Ready ? 1 : 0
+
+        // A cover already decoded is ready within a frame or two, so fading it in is what makes
+        // a filter change look like the library is reloading. The fade is kept for art that
+        // genuinely has to be read from disk or downloaded.
+        property bool fadeIn: false
+        Timer {
+            id: settleDelay
+            interval: 90
+            onTriggered: if (artwork.status !== Image.Ready) artwork.fadeIn = true
+        }
+        Component.onCompleted: settleDelay.start()
         Behavior on opacity {
-            enabled: !Preferences.reducedMotion
+            enabled: !Preferences.reducedMotion && artwork.fadeIn
             NumberAnimation { duration: 160 }
         }
     }

--- a/qml/components/GameCard.qml
+++ b/qml/components/GameCard.qml
@@ -7,6 +7,9 @@ FocusScope {
     required property string title
     required property string subtitle
     required property int hours
+    // IGDB score out of 100. Below zero means this game has no rating, and the card
+    // then shows nothing rather than a placeholder.
+    required property int rating
     required property int progress
     required property bool favorite
     required property string completionStatus
@@ -26,6 +29,7 @@ FocusScope {
     activeFocusOnTab: true
     Accessible.name: title
     Accessible.description: subtitle + ", " + hours + " hours played"
+                            + (rating >= 0 ? ", rated " + rating + " out of 100" : "")
     Accessible.role: Accessible.ListItem
 
     Keys.onReturnPressed: function(event) {
@@ -249,13 +253,18 @@ FocusScope {
         }
 
         Row {
+            id: metaRow
             width: parent.width
             spacing: 7
+            // The source name gives up whatever room the fixed trailing fields need, so a long
+            // name elides instead of pushing the playtime or the rating off the card.
+            readonly property real trailingWidth:
+                subtitleDot.width + subtitleHours.width + spacing * 2
+                + (subtitleRating.visible
+                   ? subtitleRatingDot.width + subtitleRating.width + spacing * 2 : 0)
 
             Text {
-                width: Math.min(implicitWidth, Math.max(0, parent.width - subtitleDot.width
-                                                            - subtitleHours.width
-                                                            - parent.spacing * 2))
+                width: Math.min(implicitWidth, Math.max(0, parent.width - metaRow.trailingWidth))
                 elide: Text.ElideRight
                 text: root.subtitle
                 color: Theme.mutedText
@@ -274,6 +283,25 @@ FocusScope {
                 color: Theme.mutedText
                 font.family: Theme.fontFamily
                 font.pixelSize: 10
+            }
+            Text {
+                id: subtitleRatingDot
+                visible: subtitleRating.visible
+                text: "·"
+                color: root.alpha(Theme.foreground, 0.32)
+                font.pixelSize: 10
+            }
+            Text {
+                id: subtitleRating
+                objectName: "cardRating"
+                visible: root.rating >= 0
+                text: root.rating + "%"
+                // Brighter than the rest of the line, so a rating-sorted grid can be read
+                // down the column at a glance.
+                color: Theme.foreground
+                font.family: Theme.fontFamily
+                font.pixelSize: 10
+                font.weight: Font.DemiBold
             }
         }
     }

--- a/qml/components/GameMetadataEditor.qml
+++ b/qml/components/GameMetadataEditor.qml
@@ -15,6 +15,10 @@ ColumnLayout {
     readonly property string gameKey: game.metadataKey || ""
     onGameKeyChanged: { editing = false; if (Metadata) Metadata.inspect(game) }
     Component.onCompleted: if (Metadata) Metadata.inspect(game)
+    // Identifying a game by hand takes precedence over the background pass, which would
+    // otherwise hold the service busy and leave every control here disabled.
+    onEditingChanged: if (Metadata) Metadata.setEditing(editing)
+    Component.onDestruction: if (Metadata) Metadata.setEditing(false)
     Connections {
         target: Metadata
         function onPortraitSelected(key) {

--- a/qml/components/LibraryView.qml
+++ b/qml/components/LibraryView.qml
@@ -228,7 +228,11 @@ Item {
                 anchors.topMargin: 7
                 anchors.bottomMargin: 7
                 title: delegateRoot.title
-                subtitle: delegateRoot.subtitle
+                // Inside a console the heading already names the system, so the launcher's
+                // long core name is repetition. Drop it and let the rating and playtime have
+                // the room instead.
+                subtitle: Library.consoleFilter.length > 0 && delegateRoot.source.length > 0
+                          ? delegateRoot.source : delegateRoot.subtitle
                 hours: delegateRoot.hours
                 rating: delegateRoot.rating
                 progress: delegateRoot.progress

--- a/qml/components/LibraryView.qml
+++ b/qml/components/LibraryView.qml
@@ -189,6 +189,7 @@ Item {
             required property string title
             required property string subtitle
             required property int hours
+            required property int rating
             required property int progress
             required property bool favorite
             required property string completionStatus
@@ -229,6 +230,7 @@ Item {
                 title: delegateRoot.title
                 subtitle: delegateRoot.subtitle
                 hours: delegateRoot.hours
+                rating: delegateRoot.rating
                 progress: delegateRoot.progress
                 favorite: delegateRoot.favorite
                 completionStatus: delegateRoot.completionStatus

--- a/qml/components/LibraryView.qml
+++ b/qml/components/LibraryView.qml
@@ -12,6 +12,10 @@ Item {
     readonly property int count: grid.count
     readonly property int columns: grid.columns
     readonly property bool gridFocused: grid.activeFocus
+    // Where focus should land when something above hands it downwards. With no games left the
+    // grid has nothing to select, so the empty state takes it instead.
+    readonly property Item focusTarget: grid.count > 0 ? grid
+                                      : root.filtersActive ? emptyClearButton : emptyRescanButton
     property bool scanning: false
     property bool filtersActive: false
     property string emptyTitle: "No games found"
@@ -137,19 +141,19 @@ Item {
         }
 
         Keys.onReturnPressed: function(event) {
-            if (currentIndex >= 0) {
+            if (currentIndex >= 0 && currentIndex < count) {
                 root.gameActivated(currentIndex)
                 event.accepted = true
             }
         }
         Keys.onEnterPressed: function(event) {
-            if (currentIndex >= 0) {
+            if (currentIndex >= 0 && currentIndex < count) {
                 root.gameActivated(currentIndex)
                 event.accepted = true
             }
         }
         Keys.onSpacePressed: function(event) {
-            if (currentIndex >= 0) {
+            if (currentIndex >= 0 && currentIndex < count) {
                 root.gameActivated(currentIndex)
                 event.accepted = true
             }
@@ -244,14 +248,26 @@ Item {
                 coverPath: delegateRoot.coverPath
                 current: grid.currentIndex === delegateRoot.index
                 focus: current
+                // A recycled delegate keeps its place in the scene but stands for no row, and
+                // carries index -1. Leaving it in the focus chain let a keyboard or controller
+                // move land on a card the person cannot see and open a game that is not there.
+                activeFocusOnTab: delegateRoot.index >= 0
 
                 onActiveFocusChanged: {
-                    if (activeFocus) {
+                    if (activeFocus && delegateRoot.index >= 0) {
                         grid.currentIndex = delegateRoot.index
                     }
                 }
-                onActivated: root.gameActivated(delegateRoot.index)
-                onFavoriteToggled: root.favoriteToggled(delegateRoot.index)
+                onActivated: {
+                    if (delegateRoot.index >= 0) {
+                        root.gameActivated(delegateRoot.index)
+                    }
+                }
+                onFavoriteToggled: {
+                    if (delegateRoot.index >= 0) {
+                        root.favoriteToggled(delegateRoot.index)
+                    }
+                }
             }
         }
 

--- a/qml/components/SettingsPanel.qml
+++ b/qml/components/SettingsPanel.qml
@@ -6,6 +6,17 @@ import QtQuick.Layouts
         id: settingsOverlay
         objectName: "settingsOverlay"
         function reveal(item) { if (host.isWithin(item, settingsScroll)) host.revealInScrollView(settingsScroll, item) }
+        // Every connection row reports the same three states from the service that owns it.
+        // Credentials are stored in the keyring, so "connected" means Omakade holds what the
+        // provider needs, and a provider that answered with a problem says so instead.
+        readonly property var connectionProblems: ["invalid-key", "private", "rate-limited",
+                                                   "unsupported", "error"]
+        function connectionLabel(name, ready, state) {
+            if (!ready) return name + " · NOT CONNECTED"
+            if (state && settingsOverlay.connectionProblems.indexOf(state) >= 0)
+                return name + " · CHECK SETTINGS"
+            return name + " · CONNECTED"
+        }
         // Main.qml owns the GOG folder actions, but the field lives here.
         function focusGogFolderField() {
             settingsOverlay.section = 0
@@ -732,7 +743,7 @@ import QtQuick.Layouts
                 }
                 GlassButton { compact: true; text: "STOP UPDATE"; visible: Metadata && Metadata.busy; onClicked: Metadata.cancel() }
                 Text { Layout.fillWidth: true; wrapMode: Text.Wrap; text: Metadata ? Metadata.status : ""; color: Theme.mutedText; font.family: Theme.fontFamily; font.pixelSize: 10 * settingsPanel.uiScale }
-                GlassButton { Layout.fillWidth: true; compact: true; text: "STEAMGRIDDB PORTRAIT COVERS · " + (Metadata && Metadata.hasGridKey ? "CONNECTED" : "NOT CONNECTED"); selected: settingsOverlay.connection === 3; onClicked: { settingsOverlay.connection = settingsOverlay.connection === 3 ? -1 : 3; settingsOverlay.pageChanged() } }
+                GlassButton { Layout.fillWidth: true; compact: true; text: settingsOverlay.connectionLabel("STEAMGRIDDB PORTRAIT COVERS", Metadata && Metadata.hasGridKey, ""); selected: settingsOverlay.connection === 3; onClicked: { settingsOverlay.connection = settingsOverlay.connection === 3 ? -1 : 3; settingsOverlay.pageChanged() } }
                 ColumnLayout {
                     Layout.fillWidth: true; spacing: 10; visible: settingsOverlay.connection === 3
                     Text { Layout.fillWidth: true; wrapMode: Text.Wrap; text: "Add a SteamGridDB API key for portrait covers. You can choose a different portrait in each game's details."; color: Theme.mutedText; font.family: Theme.fontFamily; font.pixelSize: 11 * settingsPanel.uiScale }
@@ -759,7 +770,7 @@ import QtQuick.Layouts
                         GlassButton { compact: true; text: "GET AN API KEY"; onClicked: Qt.openUrlExternally("https://www.steamgriddb.com/profile/preferences/api") }
                     }
                 }
-                GlassButton { Layout.fillWidth: true; compact: true; text: "STEAM LIBRARY INFORMATION · " + (SteamAccount && SteamAccount.hasApiKey ? "CONNECTED" : "OPTIONAL"); selected: settingsOverlay.connection === 0; onClicked: { settingsOverlay.connection = settingsOverlay.connection === 0 ? -1 : 0; settingsOverlay.pageChanged() } }
+                GlassButton { Layout.fillWidth: true; compact: true; text: settingsOverlay.connectionLabel("STEAM LIBRARY INFORMATION", SteamAccount && SteamAccount.hasApiKey && SteamAccount.steamId.length > 0, SteamAccount ? SteamAccount.state : ""); selected: settingsOverlay.connection === 0; onClicked: { settingsOverlay.connection = settingsOverlay.connection === 0 ? -1 : 0; settingsOverlay.pageChanged() } }
                 ColumnLayout { Layout.fillWidth: true; spacing: 12; visible: settingsOverlay.connection === 0
                 Text {
                     Layout.fillWidth: true
@@ -896,7 +907,7 @@ import QtQuick.Layouts
                     wrapMode: Text.Wrap
                 }
                 }
-                GlassButton { Layout.fillWidth: true; compact: true; text: "RETROACHIEVEMENTS"; selected: settingsOverlay.connection === 1; onClicked: { settingsOverlay.connection = settingsOverlay.connection === 1 ? -1 : 1; settingsOverlay.pageChanged() } }
+                GlassButton { Layout.fillWidth: true; compact: true; text: settingsOverlay.connectionLabel("RETROACHIEVEMENTS", RetroAchievements && RetroAchievements.hasApiKey && RetroAchievements.username.length > 0, RetroAchievements ? RetroAchievements.state : ""); selected: settingsOverlay.connection === 1; onClicked: { settingsOverlay.connection = settingsOverlay.connection === 1 ? -1 : 1; settingsOverlay.pageChanged() } }
                 ColumnLayout { Layout.fillWidth: true; spacing: 12; visible: settingsOverlay.connection === 1
                 Text {
                     Layout.fillWidth: true
@@ -1009,7 +1020,7 @@ import QtQuick.Layouts
                     wrapMode: Text.Wrap
                 }
                 }
-                GlassButton { Layout.fillWidth: true; compact: true; text: "RATINGS AND GAME INFORMATION · IGDB"; selected: settingsOverlay.connection === 2; onClicked: { settingsOverlay.connection = settingsOverlay.connection === 2 ? -1 : 2; settingsOverlay.pageChanged() } }
+                GlassButton { Layout.fillWidth: true; compact: true; text: settingsOverlay.connectionLabel("RATINGS AND GAME INFORMATION · IGDB", Insights && Insights.configured, ""); selected: settingsOverlay.connection === 2; onClicked: { settingsOverlay.connection = settingsOverlay.connection === 2 ? -1 : 2; settingsOverlay.pageChanged() } }
                 ColumnLayout { Layout.fillWidth: true; spacing: 12; visible: settingsOverlay.connection === 2
                 Text {
                     Layout.fillWidth: true

--- a/src/achievements/RetroAchievementsService.cpp
+++ b/src/achievements/RetroAchievementsService.cpp
@@ -1,3 +1,5 @@
+#include "app/SecretService.h"
+#include <QMutexLocker>
 #include "achievements/RetroAchievementsService.h"
 
 #include "app/AppSettings.h"
@@ -32,6 +34,8 @@ constexpr qint64 kConsoleCacheLifetimeSeconds = 30LL * 24 * 60 * 60;
 constexpr qint64 kHashListCacheLifetimeSeconds = 7LL * 24 * 60 * 60;
 
 RetroAchievementsSecretResult lookupSecret(bool includeSecret) {
+  // libsecret builds its GObject types on first use and cannot take two threads at once.
+  QMutexLocker keyring(&secretServiceLock());
   GError* error = nullptr;
   gchar* password = secret_password_lookup_sync(retroAchievementsSchema(), nullptr, &error,
                                                 "service", kSecretService, nullptr);
@@ -252,6 +256,7 @@ void RetroAchievementsService::beginSecretOperation(SecretAction action,
   m_secretAction = action;
   setBusy(true);
   m_secretWatcher.setFuture(QtConcurrent::run([action, secretValue = QByteArray(value)]() mutable {
+    QMutexLocker keyring(&secretServiceLock());
     if (action == SecretAction::Detect || action == SecretAction::LookupForRefresh) {
       return lookupSecret(action != SecretAction::Detect);
     }

--- a/src/achievements/SteamAccountService.cpp
+++ b/src/achievements/SteamAccountService.cpp
@@ -1,3 +1,5 @@
+#include "app/SecretService.h"
+#include <QMutexLocker>
 #include "achievements/SteamAccountService.h"
 
 #include "app/AppSettings.h"
@@ -41,6 +43,8 @@ constexpr qsizetype kMaximumOwnedGamesResponseBytes = 16 * 1024 * 1024;
 constexpr qint64 kAchievementRefreshSeconds = 15 * 60;
 
 SteamSecretResult lookupSecret(bool includeSecret) {
+  // libsecret builds its GObject types on first use and cannot take two threads at once.
+  QMutexLocker keyring(&secretServiceLock());
   GError* error = nullptr;
   gchar* password = secret_password_lookup_sync(steamSchema(), nullptr, &error, "service",
                                                 kSecretService, nullptr);
@@ -308,6 +312,7 @@ void SteamAccountService::beginSecretOperation(SecretAction action, const QByteA
   m_secretAction = action;
   setBusy(true);
   m_secretWatcher.setFuture(QtConcurrent::run([action, secretValue = QByteArray(value)]() mutable {
+    QMutexLocker keyring(&secretServiceLock());
     if (action == SecretAction::Detect || action == SecretAction::LookupForRefresh ||
         action == SecretAction::LookupForOwnedGames) {
       return lookupSecret(action != SecretAction::Detect);

--- a/src/app/SecretService.h
+++ b/src/app/SecretService.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QRecursiveMutex>
+
+// One lock for every keyring call in the process.
+//
+// Four services keep credentials: Steam, RetroAchievements, IGDB and SteamGridDB. Each reads
+// its own key on a worker thread as the app starts, and libsecret registers its GObject types
+// the first time a schema is built. Two threads doing that at the same moment race, and the
+// registration fails with "cannot register existing type". Every schema built afterwards is
+// invalid, so every lookup fails with "the attribute 'service' was not found in the password
+// schema" and no credential loads at all. Nothing then depends on a key it cannot read, so
+// identification simply never starts and the failure is silent.
+//
+// Hold this around any libsecret call. The work is a handful of lookups at startup, so
+// serialising them costs nothing worth measuring. It is recursive because a worker takes it and
+// then calls a helper that takes it again; with a plain mutex that thread waits on itself, the
+// lookup never returns, and the service stays busy forever.
+inline QRecursiveMutex& secretServiceLock() {
+  static QRecursiveMutex lock;
+  return lock;
+}

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -10,6 +10,7 @@
 #include "input/ControllerFocusGuard.h"
 #include "input/CouchCursorManager.h"
 #include "app/IdleInhibitor.h"
+#include "artwork/CoverImageProvider.h"
 #include "launch/GameLauncher.h"
 #include "launch/PlayRequest.h"
 #include "streaming/SunshineIntegration.h"
@@ -1059,6 +1060,9 @@ int main(int argc, char* argv[]) {
   }
   BackupManager backups(managerPaths, &preferences, steamLibrary != nullptr || backupFixture);
   QQmlApplicationEngine engine;
+  // Cover art is decoded once and kept, so scrolling away and back, or changing a filter, does
+  // not send every card to disk again. The engine takes ownership.
+  engine.addImageProvider(QStringLiteral("covers"), new CoverImageProvider());
   engine.rootContext()->setContextProperty("Backups", &backups);
   engine.rootContext()->setContextProperty("GogSettingsFixture", gogSettingsFixture);
   QObject::connect(&engine, &QQmlApplicationEngine::warnings, [](const QList<QQmlError>& warnings) {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1356,10 +1356,10 @@ int main(int argc, char* argv[]) {
         auto* strip = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchGameStrip"));
         auto* grid = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchGameGrid"));
         auto* view = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchViewButton"));
-        auto* all = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchAllButton"));
-        auto* favorites =
-            quickWindow->findChild<QQuickItem*>(QStringLiteral("couchFavoritesFilterButton"));
-        auto* recent = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchRecentButton"));
+        auto* show = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchShowButton"));
+        auto* sourceFilter =
+            quickWindow->findChild<QQuickItem*>(QStringLiteral("couchSourceButton"));
+        auto* sortOrder = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchSortButton"));
         auto* layout = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchLayoutButton"));
         auto* favorite =
             quickWindow->findChild<QQuickItem*>(QStringLiteral("couchFavoriteButton"));
@@ -1368,7 +1368,6 @@ int main(int argc, char* argv[]) {
         auto* settingsScroll =
             quickWindow->findChild<QQuickItem*>(QStringLiteral("settingsScroll"));
         auto* search = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchSearchButton"));
-        auto* browse = quickWindow->findChild<QQuickItem*>(QStringLiteral("couchBrowseButton"));
         auto* browsePanel =
             quickWindow->findChild<QQuickItem*>(QStringLiteral("couchBrowsePanel"));
         auto* browseCategories =
@@ -1389,10 +1388,9 @@ int main(int argc, char* argv[]) {
         if (!quickWindow->property("couchMode").toBool() || couch == nullptr ||
             couchCursor == nullptr ||
             !couch->isVisible() || strip == nullptr || grid == nullptr || view == nullptr ||
-            all == nullptr || favorites == nullptr || recent == nullptr || layout == nullptr ||
+            show == nullptr || sourceFilter == nullptr || sortOrder == nullptr || layout == nullptr ||
             favorite == nullptr || settings == nullptr ||
             settingsScroll == nullptr || search == nullptr || preferences == nullptr ||
-            browse == nullptr ||
             browsePanel == nullptr || browseCategories == nullptr || browseOptions == nullptr ||
             keyboard == nullptr || keyboardGrid == nullptr || textEntryKeyboard == nullptr ||
             textEntryGrid == nullptr || desktopSearch == nullptr) {
@@ -1406,7 +1404,7 @@ int main(int argc, char* argv[]) {
         controller.keyRequested(Qt::Key_Right, Qt::NoModifier);
         QTimer::singleShot(50, quickWindow,
                            [quickWindow, &application, &controller, couch, couchCursor, strip, grid,
-                            view, all, favorites, recent, layout, favorite, browse, browsePanel,
+                            view, show, sourceFilter, sortOrder, layout, favorite, browsePanel,
                             browseCategories, browseOptions, search, settings, settingsScroll,
                             keyboard, keyboardGrid, textEntryKeyboard, textEntryGrid, desktopSearch,
                             preferences, fail] {
@@ -1495,7 +1493,7 @@ int main(int argc, char* argv[]) {
             fail(QStringLiteral("Couch console view toggle is missing"));
             return;
           }
-          const QList<QQuickItem*> detailToolbarPath = {all, favorites, recent, consoleView, layout};
+          const QList<QQuickItem*> detailToolbarPath = {show, sourceFilter, sortOrder, consoleView, layout};
           for (int step = 0; step < detailToolbarPath.size(); ++step) {
             if (!detailToolbarPath.at(step)->hasActiveFocus()) {
               fail(QStringLiteral("Controller detail toolbar step %1 failed; focus=%2")
@@ -1533,7 +1531,7 @@ int main(int argc, char* argv[]) {
             return;
           }
           sendKey(Qt::Key_Up);
-          const QList<QQuickItem*> toolbarPath = {all, favorites, recent, consoleView, layout, browse};
+          const QList<QQuickItem*> toolbarPath = {show, sourceFilter, sortOrder, consoleView, layout};
           for (int step = 0; step < toolbarPath.size(); ++step) {
             if (!toolbarPath.at(step)->hasActiveFocus()) {
               fail(QStringLiteral("Controller grid toolbar step %1 failed; focus=%2")
@@ -1557,6 +1555,16 @@ int main(int argc, char* argv[]) {
             if (step + 1 < toolbarPath.size()) {
               sendKey(Qt::Key_Right);
             }
+          }
+          // Browse now opens from the Source control, which states the current filter on the
+          // bar. Walk back to it rather than reaching Browse through a button of its own.
+          for (int step = 0; step < 3; ++step) {
+            sendKey(Qt::Key_Left);
+          }
+          if (!sourceFilter->hasActiveFocus()) {
+            fail(QStringLiteral("Controller Left did not return along the couch toolbar; focus=%1")
+                     .arg(focusDescription()));
+            return;
           }
           sendKey(Qt::Key_Return);
           if (!couch->property("browseOpen").toBool() || !browsePanel->isVisible() ||
@@ -1601,9 +1609,19 @@ int main(int argc, char* argv[]) {
             return;
           }
           sendKey(Qt::Key_Escape);
-          if (couch->property("browseOpen").toBool() || !browse->hasActiveFocus()) {
+          // Browse is opened from the Source control, so closing it returns there.
+          if (couch->property("browseOpen").toBool() || !sourceFilter->hasActiveFocus()) {
             fail(QStringLiteral("Controller Back did not close couch Browse"));
             return;
+          }
+          // Source, Sort, Consoles, View, Search: the bar continues rightwards without a gap.
+          for (const QQuickItem* expected : {sortOrder, consoleView, layout}) {
+            sendKey(Qt::Key_Right);
+            if (!expected->hasActiveFocus()) {
+              fail(QStringLiteral("Controller could not walk the couch toolbar; focus=%1")
+                       .arg(focusDescription()));
+              return;
+            }
           }
           sendKey(Qt::Key_Right);
           if (!search->hasActiveFocus()) {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -523,9 +523,13 @@ int main(int argc, char* argv[]) {
   const bool bulkEditorTest = application.arguments().contains(QStringLiteral("--bulk-editor-test"));
   const bool savedFilterTest = application.arguments().contains(QStringLiteral("--saved-filter-test"));
   const bool randomSelectionTest = application.arguments().contains(QStringLiteral("--random-selection-test"));
+  const bool staleSelectionTest =
+      application.arguments().contains(QStringLiteral("--stale-selection-test"));
+  const bool filterBackTest =
+      application.arguments().contains(QStringLiteral("--filter-back-test"));
   const bool artworkEditorTest = application.arguments().contains(QStringLiteral("--artwork-editor-test"));
   const bool manualEditorTest = application.arguments().contains(QStringLiteral("--manual-editor-test"));
-  const bool smokeTest = gogSettingsTest || linkedPreferenceTest || backupEditorTest || bulkEditorTest || savedFilterTest || randomSelectionTest || artworkEditorTest || manualEditorTest || application.arguments().contains(QStringLiteral("--smoke-test"));
+  const bool smokeTest = gogSettingsTest || linkedPreferenceTest || backupEditorTest || bulkEditorTest || savedFilterTest || randomSelectionTest || staleSelectionTest || filterBackTest || artworkEditorTest || manualEditorTest || application.arguments().contains(QStringLiteral("--smoke-test"));
   const bool couchNavigationTest =
       application.arguments().contains(QStringLiteral("--couch-navigation-test"));
   const bool navigationTest = couchNavigationTest ||
@@ -2976,6 +2980,121 @@ int main(int argc, char* argv[]) {
         if (rootWindow->property("detailOpen").toBool()) { fail("Random selection cannot close"); return; }
         application.quit();
       });
+    });
+  } else if (staleSelectionTest) {
+    // Narrowing the library to a single game leaves the grid holding delegates for the hundred
+    // that just left. Moving down from the organize row and pressing A must open the game the
+    // person can see, not one of those, and never a row that is no longer there.
+    QTimer::singleShot(200, &application, [&application, rootWindow, &controller] {
+      const auto fail = [&application](const QString& message) {
+        qCritical().noquote() << message;
+        application.exit(EXIT_FAILURE);
+      };
+      auto* library = qmlContext(rootWindow)
+                          ->contextProperty(QStringLiteral("Library"))
+                          .value<QObject*>();
+      auto* status = rootWindow->findChild<QQuickItem*>(QStringLiteral("statusFilterButton"));
+      if (library == nullptr || status == nullptr) {
+        fail(QStringLiteral("Stale selection test could not find the library controls"));
+        return;
+      }
+      // Narrow a hundred games down to one, the way choosing a source with a single game does.
+      library->setProperty("searchText", QStringLiteral("Black Meridian 3"));
+      QCoreApplication::processEvents();
+      int visible = 0;
+      QMetaObject::invokeMethod(library, "rowCount", Q_RETURN_ARG(int, visible));
+      if (visible != 1) {
+        fail(QStringLiteral("Stale selection fixture expected one visible game, saw %1").arg(visible));
+        return;
+      }
+      QVariantMap shown;
+      QMetaObject::invokeMethod(library, "get", Q_RETURN_ARG(QVariantMap, shown), Q_ARG(int, 0));
+      QTimer::singleShot(200, &application, [&application, rootWindow, &controller, status, shown,
+                                             fail] {
+        status->forceActiveFocus();
+        controller.focusDirectionRequested(Qt::Key_Down);
+        QCoreApplication::processEvents();
+        controller.keyRequested(Qt::Key_Return, Qt::NoModifier);
+        QCoreApplication::processEvents();
+        if (!rootWindow->property("detailOpen").toBool()) {
+          fail(QStringLiteral("Moving down from the organize row could not open a game"));
+          return;
+        }
+        const QVariantMap opened = rootWindow->property("selectedGame").toMap();
+        if (opened.value("title").toString().isEmpty()) {
+          fail(QStringLiteral("Down from the organize row opened a game that is not there"));
+          return;
+        }
+        if (opened.value("appId") != shown.value("appId") ||
+            opened.value("source") != shown.value("source")) {
+          fail(QStringLiteral("Down from the organize row opened %1 rather than the visible %2")
+                   .arg(opened.value("title").toString(), shown.value("title").toString()));
+          return;
+        }
+        application.quit();
+      });
+    });
+  } else if (filterBackTest) {
+    // Back walks out of the library the way you walked in: out of a console, then a search,
+    // then a source, then whatever else is still narrowing the view. Levels that are not
+    // active are skipped, so RetroArch inside Nintendo 64 is two presses from all sources.
+    QTimer::singleShot(200, &application, [&application, rootWindow, &controller] {
+      const auto fail = [&application](const QString& message) {
+        qCritical().noquote() << message;
+        application.exit(EXIT_FAILURE);
+      };
+      auto* library = qmlContext(rootWindow)
+                          ->contextProperty(QStringLiteral("Library"))
+                          .value<QObject*>();
+      if (library == nullptr) {
+        fail(QStringLiteral("Filter back test could not find the library"));
+        return;
+      }
+      const auto back = [&controller] {
+        controller.keyRequested(Qt::Key_Escape, Qt::NoModifier);
+        QCoreApplication::processEvents();
+      };
+      const QString system = QStringLiteral("snes");
+      library->setProperty("sourceFilters", QStringList{QStringLiteral("RetroArch")});
+      library->setProperty("consoleFilter", system);
+      library->setProperty("searchText", QStringLiteral("cart"));
+      QCoreApplication::processEvents();
+      if (library->property("consoleFilter").toString() != system) {
+        fail(QStringLiteral("Filter back fixture could not enter a console"));
+        return;
+      }
+      // Out of the console first, keeping the search and the source.
+      back();
+      if (!library->property("consoleFilter").toString().isEmpty() ||
+          library->property("searchText").toString().isEmpty() ||
+          library->property("sourceFilters").toStringList().isEmpty()) {
+        fail(QStringLiteral("Back did not leave the console on its own"));
+        return;
+      }
+      // Then out of the search, keeping the source.
+      back();
+      if (!library->property("searchText").toString().isEmpty() ||
+          library->property("sourceFilters").toStringList().isEmpty()) {
+        fail(QStringLiteral("Back did not clear the search on its own"));
+        return;
+      }
+      // Then out of the source, reaching the whole library.
+      back();
+      if (!library->property("sourceFilters").toStringList().isEmpty()) {
+        fail(QStringLiteral("Back did not return to all sources"));
+        return;
+      }
+      // Anything else still narrowing the view goes together on the next press.
+      library->setProperty("completionFilter", QStringLiteral("backlog"));
+      library->setProperty("mode", 1);
+      QCoreApplication::processEvents();
+      back();
+      if (!library->property("completionFilter").toString().isEmpty() ||
+          library->property("mode").toInt() != 0) {
+        fail(QStringLiteral("Back did not clear the remaining filters"));
+        return;
+      }
+      application.quit();
     });
   } else if (artworkEditorTest) {
     QTimer::singleShot(150, &application, [&application, rootWindow, &artworkFixture, &controller] {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -975,6 +975,9 @@ int main(int argc, char* argv[]) {
         std::make_unique<GameInsightsService>(steamLibrary->databasePath(), &preferences);
     gameMetadata = std::make_unique<GameMetadata>(steamLibrary->databasePath(), gameInsights.get());
     gameMetadata->setLibrary(&unifiedGames);
+    // The filtered view decides what gets identified first, so opening a console fills that
+    // console in rather than waiting for the rest of the library.
+    gameMetadata->setVisibleLibrary(&library);
     gameMetadata->setCacheLimitMb(preferences.artworkCacheLimitMb());
     QObject::connect(&preferences, &AppSettings::artworkCacheLimitMbChanged, gameMetadata.get(), [&preferences, metadata = gameMetadata.get()] { metadata->setCacheLimitMb(preferences.artworkCacheLimitMb()); });
     unifiedGames.setMetadata(gameMetadata.get());

--- a/src/artwork/CoverImageProvider.cpp
+++ b/src/artwork/CoverImageProvider.cpp
@@ -1,0 +1,83 @@
+#include "artwork/CoverImageProvider.h"
+
+#include <QFileInfo>
+#include <QImageReader>
+#include <QMutexLocker>
+#include <QUrl>
+
+namespace {
+
+// A card asks for the size it needs, so the same artwork at two sizes is two entries.
+QString cacheKey(const QString& id, const QSize& requestedSize) {
+  return id + QLatin1Char('|') + QString::number(requestedSize.width()) + QLatin1Char('x') +
+         QString::number(requestedSize.height());
+}
+
+// A card marks what kind of artwork it is asking for: "f/..." is a file on disk and "q/..." is
+// bundled console art. Anything else is refused rather than guessed at.
+QString readablePath(const QString& id) {
+  if (id.startsWith(QLatin1String("f/")))
+    return id.mid(1);
+  if (id.startsWith(QLatin1String("q/")))
+    return QLatin1Char(':') + id.mid(1);
+  return {};
+}
+
+} // namespace
+
+CoverImageProvider::CoverImageProvider(int limitMegabytes)
+    : QQuickImageProvider(QQuickImageProvider::Image) {
+  m_cache.setMaxCost(qMax(1, limitMegabytes) * 1024 * 1024);
+}
+
+QImage CoverImageProvider::requestImage(const QString& id, QSize* size,
+                                        const QSize& requestedSize) {
+  const QString key = cacheKey(id, requestedSize);
+  {
+    QMutexLocker locked(&m_lock);
+    if (const QImage* cached = m_cache.object(key)) {
+      ++m_hits;
+      if (size != nullptr)
+        *size = cached->size();
+      return *cached;
+    }
+  }
+
+  const QString path = readablePath(id);
+  QImage image;
+  if (!path.isEmpty()) {
+    QImageReader reader(path);
+    reader.setAutoTransform(true);
+    const QSize natural = reader.size();
+    if (natural.isValid() && requestedSize.width() > 0 && requestedSize.height() > 0) {
+      // Decode straight to the size the card wants, keeping the artwork's own proportions so
+      // the card can decide how to fit it.
+      QSize target = natural;
+      target.scale(requestedSize, Qt::KeepAspectRatio);
+      if (!target.isEmpty() && target.width() < natural.width())
+        reader.setScaledSize(target);
+    }
+    image = reader.read();
+  }
+  if (size != nullptr)
+    *size = image.size();
+  if (image.isNull())
+    return image;
+
+  QMutexLocker locked(&m_lock);
+  ++m_misses;
+  const qsizetype cost = image.sizeInBytes();
+  if (cost > 0 && cost < m_cache.maxCost())
+    m_cache.insert(key, new QImage(image), int(cost));
+  return image;
+}
+
+int CoverImageProvider::hits() const {
+  QMutexLocker locked(&m_lock);
+  return m_hits;
+}
+
+int CoverImageProvider::misses() const {
+  QMutexLocker locked(&m_lock);
+  return m_misses;
+}

--- a/src/artwork/CoverImageProvider.h
+++ b/src/artwork/CoverImageProvider.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <QCache>
+#include <QImage>
+#include <QMutex>
+#include <QQuickImageProvider>
+#include <QString>
+
+// Decodes a game's cover once and keeps it for as long as it is worth keeping.
+//
+// Qt keeps a small cache of images no view is currently showing, a couple of megabytes, which
+// is roughly twenty covers at the size a card asks for. That is less than a single screenful,
+// so a card that scrolled out of view and back, or survived a filter change, had to read and
+// decode its artwork from disk again and showed a placeholder until it finished.
+//
+// The cache is deliberately bounded rather than sized to the library. Holding every cover of a
+// large library would grow with both the number of games and the cover size setting, so the
+// libraries that need it most would be the ones that blew the budget, and it would be spent on
+// artwork the person is nowhere near. A few hundred covers is several screens in either
+// direction, which is the distance people actually scroll and come back from. Past that the
+// artwork is decoded again, which costs a few milliseconds for a thumbnail and was never the
+// problem: the problem was a limit far below one screen.
+//
+// Registered as "covers": a card asks for image://covers/f<file path> or image://covers/q<path>
+// for bundled console art.
+class CoverImageProvider final : public QQuickImageProvider {
+public:
+  // 128 MB holds several screens of desktop cards comfortably, and still several at the largest
+  // cover size on a 4K television, where a single card can decode to about 600 KB.
+  explicit CoverImageProvider(int limitMegabytes = 128);
+
+  QImage requestImage(const QString& id, QSize* size, const QSize& requestedSize) override;
+
+  // Counts since startup, for diagnostics and tests.
+  [[nodiscard]] int hits() const;
+  [[nodiscard]] int misses() const;
+
+private:
+  mutable QMutex m_lock;
+  QCache<QString, QImage> m_cache;
+  int m_hits = 0;
+  int m_misses = 0;
+};

--- a/src/launch/GameLauncher.cpp
+++ b/src/launch/GameLauncher.cpp
@@ -375,11 +375,15 @@ LaunchCommand GameLauncher::retroArchCommand(const QString& contentPath, const Q
       corePath == QStringLiteral("DETECT")) {
     return {};
   }
+  // Emulators keep their own windowed or fullscreen setting, and a game started from a
+  // launcher should fill the screen whichever way that is set, so each one is asked explicitly.
   return flatpak ? LaunchCommand{QStringLiteral("flatpak"),
                                  {QStringLiteral("run"), QStringLiteral("org.libretro.RetroArch"),
-                                  QStringLiteral("-L"), corePath, contentPath}}
+                                  QStringLiteral("--fullscreen"), QStringLiteral("-L"), corePath,
+                                  contentPath}}
                  : LaunchCommand{QStringLiteral("retroarch"),
-                                 {QStringLiteral("-L"), corePath, contentPath}};
+                                 {QStringLiteral("--fullscreen"), QStringLiteral("-L"), corePath,
+                                  contentPath}};
 }
 
 LaunchCommand GameLauncher::resolvedCartridgeCommand(const QString& contentPath,
@@ -413,7 +417,7 @@ LaunchCommand GameLauncher::pcsx2Command(const QString& id, bool isElf, bool fla
     return {};
   }
   const QString target = id.mid(5);
-  QStringList arguments;
+  QStringList arguments{QStringLiteral("-fullscreen")};
   if (isElf) {
     arguments << QStringLiteral("-elf") << target;
   } else {
@@ -451,14 +455,17 @@ LaunchCommand GameLauncher::shadps4Command(const QString& path, const QString& n
   }
   const QString target = path.startsWith(QStringLiteral("path:")) ? path.mid(5) : path;
   if (!nativeExecutable.isEmpty()) {
-    return LaunchCommand{nativeExecutable, {QStringLiteral("-g"), target}};
+    return LaunchCommand{nativeExecutable,
+                         {QStringLiteral("-f"), QStringLiteral("true"), QStringLiteral("-g"),
+                          target}};
   }
   if (flatpakAppId.isEmpty()) {
     return {};
   }
   return LaunchCommand{QStringLiteral("flatpak"),
                        {QStringLiteral("run"), flatpakAppId, QStringLiteral("--"),
-                        QStringLiteral("-g"), target}};
+                        QStringLiteral("-f"), QStringLiteral("true"), QStringLiteral("-g"),
+                        target}};
 }
 
 // Batch mode (-b) closes Dolphin with the game, so the tile goes to the game and
@@ -472,12 +479,16 @@ LaunchCommand GameLauncher::dolphinCommand(const QString& path, const QString& n
   if (flatpak) {
     return LaunchCommand{QStringLiteral("flatpak"),
                          {QStringLiteral("run"), QStringLiteral("org.DolphinEmu.dolphin-emu"),
+                          QStringLiteral("-C"),
+                          QStringLiteral("Dolphin.Display.Fullscreen=True"),
                           QStringLiteral("-b"), QStringLiteral("-e"), target}};
   }
   if (nativeExecutable.isEmpty()) {
     return {};
   }
-  return LaunchCommand{nativeExecutable, {QStringLiteral("-b"), QStringLiteral("-e"), target}};
+  return LaunchCommand{nativeExecutable,
+                       {QStringLiteral("-C"), QStringLiteral("Dolphin.Display.Fullscreen=True"),
+                        QStringLiteral("-b"), QStringLiteral("-e"), target}};
 }
 
 LaunchCommand GameLauncher::cemuCommand(const QString& path, bool flatpak) {
@@ -488,9 +499,11 @@ LaunchCommand GameLauncher::cemuCommand(const QString& path, bool flatpak) {
   if (flatpak) {
     return LaunchCommand{QStringLiteral("flatpak"),
                          {QStringLiteral("run"), QStringLiteral("info.cemu.Cemu"),
-                          QStringLiteral("--"), QStringLiteral("-g"), target}};
+                          QStringLiteral("--"), QStringLiteral("--fullscreen"),
+                          QStringLiteral("-g"), target}};
   }
-  return LaunchCommand{QStringLiteral("cemu"), {QStringLiteral("-g"), target}};
+  return LaunchCommand{QStringLiteral("cemu"),
+                       {QStringLiteral("--fullscreen"), QStringLiteral("-g"), target}};
 }
 
 LaunchCommand GameLauncher::battleNetCommand(const QString& id, const QString& prefix,

--- a/src/library/GameRoles.h
+++ b/src/library/GameRoles.h
@@ -44,6 +44,10 @@ enum Role {
   Rating,
   RatingCount,
   Popularity,
+  // The artwork the game's own source provides, before any user choice or downloaded portrait.
+  // Deciding whether a game needs a portrait has to look at this, not at the resolved cover,
+  // or a portrait already downloaded would justify itself.
+  SourceCoverPath,
   CustomHero,
   CustomLogo,
 };
@@ -66,6 +70,7 @@ inline QHash<int, QByteArray> names() {
       {Year, "year"},
       {AppId, "appId"},
       {CoverPath, "coverPath"},
+      {SourceCoverPath, "sourceCoverPath"},
       {HeroPath, "heroPath"},
       {LogoPath, "logoPath"},
       {InstallPath, "installPath"},

--- a/src/library/UnifiedGameModel.cpp
+++ b/src/library/UnifiedGameModel.cpp
@@ -1027,10 +1027,14 @@ QVariantMap UnifiedGameModel::gameMap(const SourceRow& source) const {
 }
 
 void UnifiedGameModel::rebuildRows() {
-  beginResetModel();
-  m_rows.clear();
-  m_rowForKey.clear();
-  m_rowsForGroup.clear();
+  // Nine sources scan on startup and each one signals as it loads, so this runs many times in
+  // the first seconds. A full reset destroys and recreates every card, which is what made the
+  // grid blink through startup, so compose the library first and then emit the smallest change
+  // that describes it: nothing at all when the result is identical, an insert when games were
+  // only added, and a reset only when games genuinely moved or disappeared.
+  QVector<SourceRow> rows;
+  QHash<QString, SourceRow> rowForKey;
+  QHash<QString, QVector<SourceRow>> rowsForGroup;
   for (QAbstractItemModel* model : m_models) {
     for (int row = 0; row < model->rowCount(); ++row) {
       const SourceRow source{.model = model, .row = row};
@@ -1041,10 +1045,10 @@ void UnifiedGameModel::rebuildRows() {
       if (key.isEmpty()) {
         continue;
       }
-      m_rowForKey.insert(key, source);
+      rowForKey.insert(key, source);
       const QString groupId = m_groupForGame.value(key);
       if (!groupId.isEmpty()) {
-        m_rowsForGroup[groupId].append(source);
+        rowsForGroup[groupId].append(source);
       }
     }
   }
@@ -1057,14 +1061,44 @@ void UnifiedGameModel::rebuildRows() {
       }
       const QString groupId = m_groupForGame.value(gameKey(source));
       if (groupId.isEmpty()) {
-        m_rows.append(source);
+        rows.append(source);
       } else if (!addedGroups.contains(groupId)) {
-        SourceRow representative = sourceForKey(m_primaryForGroup.value(groupId));
-        m_rows.append(representative.model == nullptr ? source : representative);
+        SourceRow representative = rowForKey.value(m_primaryForGroup.value(groupId));
+        rows.append(representative.model == nullptr ? source : representative);
         addedGroups.insert(groupId);
       }
     }
   }
+
+  QStringList keys;
+  keys.reserve(rows.size());
+  for (const SourceRow& row : rows) {
+    keys.append(gameKey(row));
+  }
+  const auto adopt = [&] {
+    m_rows = rows;
+    m_rowKeys = keys;
+    m_rowForKey = rowForKey;
+    m_rowsForGroup = rowsForGroup;
+  };
+  if (keys == m_rowKeys) {
+    // A rescan that found the same games. The row mapping may point at different source rows,
+    // so take it, but say nothing: the view is already correct and any real change to a game
+    // arrives through dataChanged.
+    adopt();
+    return;
+  }
+  if (keys.size() > m_rowKeys.size() &&
+      QStringList(keys.mid(0, m_rowKeys.size())) == m_rowKeys) {
+    // A source finished scanning and added games. Appending keeps every card already on screen,
+    // along with its artwork and the selection.
+    beginInsertRows(QModelIndex(), m_rowKeys.size(), keys.size() - 1);
+    adopt();
+    endInsertRows();
+    return;
+  }
+  beginResetModel();
+  adopt();
   endResetModel();
 }
 

--- a/src/library/UnifiedGameModel.cpp
+++ b/src/library/UnifiedGameModel.cpp
@@ -190,6 +190,8 @@ QVariant UnifiedGameModel::data(const QModelIndex& index, int role) const {
     }
     return source.model->index(source.row, 0).data(role);
   }
+  case GameRoles::SourceCoverPath:
+    return source.model->index(source.row, 0).data(GameRoles::CoverPath);
   case GameRoles::HeroPath:
   case GameRoles::CustomHero:
   case GameRoles::LogoPath:
@@ -307,6 +309,7 @@ QHash<int, QByteArray> UnifiedGameModel::roleNames() const {
   roles.insert(GameRoles::RatingCount, "ratingCount");
   roles.insert(GameRoles::Popularity, "popularity");
   roles.insert(GameRoles::CustomCover, "customCover");
+  roles.insert(GameRoles::SourceCoverPath, "sourceCoverPath");
   roles.insert(GameRoles::CustomHero, "customHero");
   roles.insert(GameRoles::CustomLogo, "customLogo");
   roles.insert(GameRoles::Linked, "linked");

--- a/src/library/UnifiedGameModel.h
+++ b/src/library/UnifiedGameModel.h
@@ -89,6 +89,9 @@ private:
   QVector<QAbstractItemModel*> m_models;
   QSet<QString> m_disabledSources;
   QVector<SourceRow> m_rows;
+  // The composed library as game keys, so a rebuild can tell whether anything the view can see
+  // actually changed before it throws every card away.
+  QStringList m_rowKeys;
   // Rebuilt with m_rows so linked-game lookups never walk every source model per role.
   QHash<QString, SourceRow> m_rowForKey;
   QHash<QString, QVector<SourceRow>> m_rowsForGroup;

--- a/src/metadata/GameInsightsService.cpp
+++ b/src/metadata/GameInsightsService.cpp
@@ -1,3 +1,5 @@
+#include "app/SecretService.h"
+#include <QMutexLocker>
 #include "metadata/GameInsightsService.h"
 
 #include "app/AppSettings.h"
@@ -31,6 +33,8 @@ const SecretSchema* insightsSchema() {
 }
 
 InsightsSecretResult secretOperation(int action, QByteArray value) {
+  // libsecret builds its GObject types on first use and cannot take two threads at once.
+  QMutexLocker keyring(&secretServiceLock());
   GError* error = nullptr;
   InsightsSecretResult result;
   if (action == 0 || action == 3) {

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -129,21 +129,17 @@ QString GameMetadata::normalizedTitle(QString title) {
 }
 bool GameMetadata::wantsPortraitCover(const QString& system, const QString& source,
                                       const QString& sourceCover) {
-  // Retro consoles get real box scans from the Libretro thumbnail server, and GameCube and Wii
-  // covers come from GameTDB. That artwork is authentic and a fan-made portrait would replace
-  // it, so those systems never ask for one. Switch, Wii U and PS4 dumps carry only a square
-  // icon, which crops a logo off the card, so they may.
-  const QString id = ConsoleCatalog::idFor(system);
-  static const QSet<QString> iconOnly{QStringLiteral("switch"), QStringLiteral("wiiu"),
-                                      QStringLiteral("ps4")};
-  if (!id.isEmpty() && !iconOnly.contains(id))
-    return false;
+  Q_UNUSED(system);
   // Steam ships an official 600x900 capsule for every game. It downloads on demand, so judging
   // by the file alone would hand a fan portrait to any game whose capsule had not arrived yet.
   if (source.compare(QStringLiteral("Steam"), Qt::CaseInsensitive) == 0)
     return false;
-  // Elsewhere, artwork that is already portrait shaped is the artwork to keep. Replacing a
-  // publisher's cover with fan art is a downgrade, so a portrait only fills a gap or a bad shape.
+  // Everything else is decided by the shape of the artwork the game already has, not by which
+  // system it came from. A physical box that was printed portrait, an NES box or a GameTDB
+  // cover, already works as a cover and is authentic, so it is kept. A box that was printed
+  // wide or square, an N64 carton or a Dreamcast case, cannot fill a card without being cropped
+  // or letterboxed, and a portrait reads better there even when it is fan made. Artwork that
+  // arrives later is reconsidered, since dropUnwantedPortraits applies this same rule.
   QString path = sourceCover;
   if (path.startsWith(QStringLiteral("file://")))
     path = QUrl(path).toLocalFile();
@@ -834,13 +830,18 @@ void GameMetadata::response(const QByteArray& data, const QString& stage) {
       return;
     }
     QDir().mkpath(m_cacheRoot);
+    // Covers are photographs and illustrations, and lossless storage was costing about 750 KB
+    // each. A library of a thousand games would have filled the artwork cache on its own and
+    // then spent the rest of its life evicting and downloading the same covers. JPEG at this
+    // quality is indistinguishable on a card and roughly a fifth of the size.
     const QString path =
         m_cacheRoot + '/' +
         QString::fromLatin1(
             QCryptographicHash::hash(key().toUtf8(), QCryptographicHash::Sha256).toHex()) +
-        '-' + QString::number(m_downloadId) + ".png";
+        '-' + QString::number(m_downloadId) + ".jpg";
     QSaveFile file(path);
-    if (!file.open(QIODevice::WriteOnly) || !image.save(&file, "PNG") || !file.commit()) {
+    const QImage opaque = image.convertToFormat(QImage::Format_RGB32);
+    if (!file.open(QIODevice::WriteOnly) || !opaque.save(&file, "JPG", 92) || !file.commit()) {
       finish("Could not save portrait");
       return;
     }
@@ -1060,7 +1061,8 @@ void GameMetadata::trimPortraitCache() {
   const QDir cache(m_cacheRoot);
   qint64 kept = 0;
   QSet<QString> removed;
-  for (const auto& file : cache.entryInfoList({"*.png"}, QDir::Files, QDir::Time)) {
+  for (const auto& file :
+       cache.entryInfoList({"*.jpg", "*.png"}, QDir::Files, QDir::Time)) {
     if (kept + file.size() <= m_cacheLimitBytes)
       kept += file.size();
     else if (QFile::remove(file.absoluteFilePath()))

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -464,6 +464,34 @@ void GameMetadata::inspect(const QVariantMap& game) {
   m_covers.clear();
   emit changed();
 }
+QByteArray GameMetadata::matchingRulesFingerprint() {
+  // Representative of every rule: dump tags, sorted articles, accents, brand prefixes,
+  // catalogue numbers, editions that must survive, and the platforms each system searches.
+  static const QStringList titles{
+      QStringLiteral("Chrono Trigger (USA)"),
+      QStringLiteral("Star Fox (EU, Rev 1)"),
+      QStringLiteral("Legend of Zelda, The - A Link to the Past (NA)"),
+      QStringLiteral("Slayers (English Translated by Dynamic Designs, Rev 1.01)"),
+      QStringLiteral("Mega Man X3 (Prototype - NTSC Conversion)"),
+      QStringLiteral("Pokémon Stadium 2"),
+      QStringLiteral("Disney's DuckTales"),
+      QStringLiteral("1636 - Pokemon Fire Red"),
+      QStringLiteral("Sonic 3 (& Knuckles)"),
+      QStringLiteral("Persona 3 Reload (Digital Deluxe Edition)")};
+  QByteArray material;
+  for (const QString& title : titles)
+    material += normalizedTitle(title).toUtf8() + '\n';
+  for (const QString& system :
+       {QStringLiteral("snes"), QStringLiteral("nes"), QStringLiteral("n64"),
+        QStringLiteral("dreamcast"), QStringLiteral("switch"), QString{}}) {
+    material += system.toUtf8() + '=';
+    for (int platform : platformIds(system))
+      material += QByteArray::number(platform) + ',';
+    material += '\n';
+  }
+  return QCryptographicHash::hash(material, QCryptographicHash::Sha256).toHex().left(16);
+}
+
 bool GameMetadata::needsIdentifying(const QVariantMap& saved, qint64 now) {
   // An answer produced by older rules is stale however recently it was written. Without this a
   // matching fix would reach existing libraries only as each entry aged out, which for a shelf

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -317,18 +317,51 @@ void GameMetadata::continueLibraryPass() {
   next();
 }
 
+QList<QVariantMap> GameMetadata::orderForIdentification(const QList<QVariantMap>& games,
+                                                        const QSet<QString>& onScreen) {
+  QList<QVariantMap> visible;
+  // Everything else is grouped by system and then taken a system at a time in turn. Walking the
+  // library in order meant a small system sat behind every ROM of a large one, which is why
+  // eight Nintendo 64 games could go unidentified while a 1,387 game shelf worked through.
+  QList<QString> order;
+  QHash<QString, QList<QVariantMap>> bySystem;
+  for (const QVariantMap& game : games) {
+    if (onScreen.contains(game.value("metadataKey").toString())) {
+      visible.append(game);
+      continue;
+    }
+    const QString system = game.value("system").toString();
+    if (!bySystem.contains(system))
+      order.append(system);
+    bySystem[system].append(game);
+  }
+  QList<QVariantMap> rest;
+  for (bool moved = true; moved;) {
+    moved = false;
+    for (const QString& system : order) {
+      auto& remaining = bySystem[system];
+      if (remaining.isEmpty())
+        continue;
+      rest.append(remaining.takeFirst());
+      moved = true;
+    }
+  }
+  return visible + rest;
+}
+
 void GameMetadata::promoteVisibleGames() {
-  if (m_queue.isEmpty() || m_visible == nullptr)
+  if (m_queue.isEmpty())
     return;
   QSet<QString> onScreen;
-  for (int row = 0; row < m_visible->rowCount(); ++row)
-    onScreen.insert(
-        m_visible->data(m_visible->index(row, 0), GameRoles::MetadataKey).toString());
-  if (onScreen.isEmpty())
-    return;
-  std::stable_partition(m_queue.begin(), m_queue.end(), [&onScreen](const QVariantMap& game) {
-    return onScreen.contains(game.value("metadataKey").toString());
-  });
+  if (m_visible != nullptr)
+    for (int row = 0; row < m_visible->rowCount(); ++row)
+      onScreen.insert(
+          m_visible->data(m_visible->index(row, 0), GameRoles::MetadataKey).toString());
+  const QList<QVariantMap> ordered =
+      orderForIdentification(QList<QVariantMap>(m_queue.cbegin(), m_queue.cend()), onScreen);
+  m_queue.clear();
+  for (const QVariantMap& game : ordered)
+    m_queue.enqueue(game);
 }
 
 void GameMetadata::dropUnwantedPortraits() {

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -268,6 +268,13 @@ GameMetadata::GameMetadata(const QString& databasePath, GameInsightsService* ins
   }
   if (insights)
     connect(insights, &GameInsightsService::catalogFinished, this, &GameMetadata::matchResult);
+    // Credentials are read from the keyring on a worker thread, so the library can settle
+    // before they arrive. Without this the pass looked once, found no connection, and never
+    // looked again, leaving the whole library unidentified until something else changed.
+    connect(insights, &GameInsightsService::changed, this, [this] {
+      if (!m_stoppedByHand && !m_editing && !busy())
+        m_settle.start();
+    });
   if (QFileInfo::exists(m_cacheRoot + "/configured"))
     secretOperation(0);
 }
@@ -1076,6 +1083,9 @@ void GameMetadata::secretOperation(int action, QByteArray value) {
     }
     finish(action == 2 ? "SteamGridDB disconnected. Cached covers are kept."
                        : "SteamGridDB key available");
+    // The key arriving can be the thing that makes work possible, so look again.
+    if (!m_stoppedByHand && !m_editing && !busy())
+      m_settle.start();
   });
   m_secrets.setFuture(QtConcurrent::run([action, value]() mutable {
     InsightsSecretResult result;

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -584,7 +584,11 @@ void GameMetadata::next() {
   m_busy = true;
   m_igdbStage = "games";
   auto saved = entry(key());
-  if (saved.value("updated").toLongLong() > QDateTime::currentSecsSinceEpoch() - 30 * 86400) {
+  // The same rule that decided this game was worth queuing decides whether it is identified
+  // again. Judging freshness by the timestamp alone here meant every game queued because the
+  // rules had changed was dequeued, sent straight to artwork, and never re-identified, so its
+  // recorded rule version never moved and the whole library stayed on old answers forever.
+  if (!needsIdentifying(saved, QDateTime::currentSecsSinceEpoch())) {
     gridSearch();
     return;
   }

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -1,5 +1,6 @@
 #include "metadata/GameMetadata.h"
 #include "library/ConsoleCatalog.h"
+#include <algorithm>
 #include <QSet>
 #include "library/GameRoles.h"
 #include "library/UnifiedGameModel.h"
@@ -261,14 +262,73 @@ void GameMetadata::setLibrary(UnifiedGameModel* library) {
   // Sources populate the library over the first few seconds, so wait for rows to arrive before
   // judging what artwork a game has. The review runs once and is cheap: only entries that
   // actually hold a portrait are examined.
-  const auto review = [this] {
-    if (m_reviewedPortraits || m_library == nullptr || m_library->rowCount() == 0)
+  const auto settled = [this] {
+    if (m_library == nullptr || m_library->rowCount() == 0)
       return;
-    m_reviewedPortraits = true;
-    dropUnwantedPortraits();
+    if (!m_reviewedPortraits) {
+      m_reviewedPortraits = true;
+      dropUnwantedPortraits();
+    }
+    // Sources arrive over several seconds. Wait for a quiet moment before queuing, so a
+    // library still loading is not walked once per source.
+    m_settle.start();
   };
-  connect(m_library, &QAbstractItemModel::rowsInserted, this, review);
-  connect(m_library, &QAbstractItemModel::modelReset, this, review);
+  m_settle.setSingleShot(true);
+  m_settle.setInterval(2000);
+  connect(&m_settle, &QTimer::timeout, this, &GameMetadata::continueLibraryPass);
+  connect(m_library, &QAbstractItemModel::rowsInserted, this, settled);
+  connect(m_library, &QAbstractItemModel::modelReset, this, settled);
+}
+
+void GameMetadata::setVisibleLibrary(QAbstractItemModel* visible) {
+  m_visible = visible;
+  if (m_visible == nullptr)
+    return;
+  // Changing the view changes what matters most. Reorder what is still pending rather than
+  // starting again, so nothing already done is repeated.
+  const auto viewChanged = [this] {
+    promoteVisibleGames();
+    if (!busy())
+      m_settle.start();
+  };
+  connect(m_visible, &QAbstractItemModel::modelReset, this, viewChanged);
+  connect(m_visible, &QAbstractItemModel::rowsInserted, this, viewChanged);
+  connect(m_visible, &QAbstractItemModel::rowsRemoved, this, viewChanged);
+}
+
+void GameMetadata::continueLibraryPass() {
+  // Stopping by hand means stopped, until the next launch or an explicit update.
+  if (m_stoppedByHand || busy() || m_library == nullptr)
+    return;
+  if ((m_insights == nullptr || !m_insights->configured()) && !hasGridKey())
+    return;
+  m_cancelled = false;
+  for (int row = 0; row < m_library->rowCount(); ++row) {
+    QVariantMap game;
+    const auto roles = m_library->roleNames();
+    for (auto it = roles.cbegin(); it != roles.cend(); ++it)
+      game.insert(QString::fromUtf8(it.value()),
+                  m_library->data(m_library->index(row), it.key()));
+    enqueue(game);
+  }
+  if (m_queue.isEmpty())
+    return;
+  promoteVisibleGames();
+  next();
+}
+
+void GameMetadata::promoteVisibleGames() {
+  if (m_queue.isEmpty() || m_visible == nullptr)
+    return;
+  QSet<QString> onScreen;
+  for (int row = 0; row < m_visible->rowCount(); ++row)
+    onScreen.insert(
+        m_visible->data(m_visible->index(row, 0), GameRoles::MetadataKey).toString());
+  if (onScreen.isEmpty())
+    return;
+  std::stable_partition(m_queue.begin(), m_queue.end(), [&onScreen](const QVariantMap& game) {
+    return onScreen.contains(game.value("metadataKey").toString());
+  });
 }
 
 void GameMetadata::dropUnwantedPortraits() {
@@ -358,6 +418,7 @@ void GameMetadata::refreshLibrary() {
     return;
   }
   m_cancelled = false;
+  m_stoppedByHand = false;
   m_queue.clear();
   for (int i = 0; i < m_library->rowCount(); ++i) {
     QVariantMap game;
@@ -366,6 +427,7 @@ void GameMetadata::refreshLibrary() {
       game.insert(QString::fromUtf8(it.value()), m_library->data(m_library->index(i), it.key()));
     enqueue(game);
   }
+  promoteVisibleGames();
   next();
 }
 void GameMetadata::next() {
@@ -904,6 +966,8 @@ void GameMetadata::secretOperation(int action, QByteArray value) {
 void GameMetadata::cancel() {
   m_queue.clear();
   m_cancelled = true;
+  m_stoppedByHand = true;
+  m_settle.stop();
   m_status = m_busy ? "Stopping after the current request" : "Metadata update stopped";
   emit changed();
 }

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -557,6 +557,16 @@ void GameMetadata::gridSearch() {
   }
   if (!m_manual && !wantsPortraitCover(m_active.value("system").toString(),
                                        m_active.value("sourceCoverPath").toString())) {
+    // An earlier run may have downloaded a portrait over artwork that should have been kept.
+    // Drop it so the game shows its own art again. A portrait the user picked is stored as a
+    // custom cover, which outranks this and is untouched. The file stays for the ordinary
+    // cache trim to reclaim.
+    auto value = entry(key());
+    if (value.contains("portrait")) {
+      value.remove("portrait");
+      value.remove("gridCoverId");
+      persist(key(), value);
+    }
     finish("IGDB data saved. This game keeps the artwork its source provides.");
     return;
   }

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -297,7 +297,18 @@ void GameMetadata::next() {
   if (m_busy || m_secrets.isRunning() || m_cancelled)
     return;
   if (m_queue.isEmpty()) {
-    m_status = "Library metadata is up to date";
+    // Say how many games could not be identified confidently, so the exceptions are a known
+    // quantity rather than something to discover one game at a time.
+    int unidentified = 0;
+    for (auto it = m_entries.cbegin(); it != m_entries.cend(); ++it)
+      if (it.value().value("matchStatus").toString() == "Needs identification")
+        ++unidentified;
+    m_status = unidentified == 0
+                   ? QStringLiteral("Library metadata is up to date")
+                   : QStringLiteral("Library metadata is up to date. %1 %2 identification; open a "
+                                    "game's details to choose its match.")
+                         .arg(unidentified)
+                         .arg(unidentified == 1 ? "game needs" : "games need");
     emit changed();
     return;
   }

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -319,9 +319,34 @@ void GameMetadata::setVisibleLibrary(QAbstractItemModel* visible) {
   connect(m_visible, &QAbstractItemModel::rowsRemoved, this, viewChanged);
 }
 
+void GameMetadata::setEditing(bool editing) {
+  if (m_editing == editing)
+    return;
+  m_editing = editing;
+  if (editing) {
+    // Stand the queue down and hold it, rather than dropping it, so nothing already worked out
+    // is repeated when the person is done.
+    m_pausedQueue = m_queue;
+    m_queue.clear();
+    m_settle.stop();
+    const auto saved = entry(m_selected.value("metadataKey").toString());
+    const QString state = saved.value("matchStatus").toString();
+    m_status = state.isEmpty() ? QStringLiteral("Not identified yet") : state;
+    emit changed();
+    return;
+  }
+  m_queue = m_pausedQueue;
+  m_pausedQueue.clear();
+  if (!m_queue.isEmpty())
+    next();
+  else
+    m_settle.start();
+  emit changed();
+}
+
 void GameMetadata::continueLibraryPass() {
   // Stopping by hand means stopped, until the next launch or an explicit update.
-  if (m_stoppedByHand || busy() || m_library == nullptr)
+  if (m_stoppedByHand || m_editing || busy() || m_library == nullptr)
     return;
   if ((m_insights == nullptr || !m_insights->configured()) && !hasGridKey())
     return;

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -1,5 +1,6 @@
 #include "metadata/GameMetadata.h"
 #include "library/ConsoleCatalog.h"
+#include <QSet>
 #include "library/GameRoles.h"
 #include "library/UnifiedGameModel.h"
 #include <QBuffer>
@@ -35,23 +36,105 @@ QString quoted(QString text) {
   text.replace(QRegularExpression("[\\x00-\\x1f]"), " ");
   return '"' + text.left(200) + '"';
 }
-QString cleanTitle(QString title) {
-  // Strip dump metadata only. Hacks, prototypes, remasters and editions keep their names.
-  title.remove(QRegularExpression(
+// One part of a parenthesised dump tag: a region, a language, a release flag, a revision, or a
+// translation or hack note. Editions and subtitles are deliberately absent, so "(Director's Cut)"
+// is never mistaken for dump metadata.
+bool dumpTagPart(const QString& part) {
+  static const QRegularExpression known(
       QStringLiteral(
-          R"(\s*\((?:(?:USA|Europe|Japan|World|U|E|J)(?:, ?(?:USA|Europe|Japan|World))*|(?:En|Ja|Fr|De|Es|It|Nl|Pt|Ko|Zh)(?:, ?[A-Za-z]{2})*|Rev [0-9.]+)\))"),
-      QRegularExpression::CaseInsensitiveOption));
-  title.remove(QStringLiteral("[!]"));
+          R"(^(?:NA|JP|EU|US|USA|EUR|JPN|Europe|Japan|World|Korea|China|Taiwan|Brazil|Australia|Asia|TW|KR|CN|AU|BR|CA|HK|RU|SP|FR|DE|ES|IT|NL|SE|PD|PE|U|E|J|W|UE|JU)$)"
+          R"(|^(?:En|Ja|Fr|De|Es|It|Nl|Pt|Ko|Zh|Sv|Da|No|Fi|Ru|Pl)$)"
+          R"(|^(?:Prototype|Proto|Beta|Alpha|Sample|Demo|Unl|Unlicensed|Pirate|Alt|Aftermarket|Homebrew|Enhanced Version|Virtual Console|Switch Online|Classic Mini)$)"
+          R"(|^(?:NTSC|PAL)(?: |-)Conversion$)"
+          R"(|^Rev(?:ision)?\.?(?: ?[0-9A-Za-z.]+)?$)"
+          R"(|^(?:v|Version) ?[0-9][0-9A-Za-z.]*$)"
+          R"(|Translat(?:ed|ion)|\bPatch\b|\bHack\b|\bFan ?Trans)"),
+      QRegularExpression::CaseInsensitiveOption);
+  return known.match(part.trimmed()).hasMatch();
+}
+
+// A group is dump metadata only when every comma or dash separated part is a known tag. That
+// keeps "(Balloon Fight)" and other real subtitles, and removes "(NA, Rev 1)" whole.
+bool dumpTagGroup(const QString& contents) {
+  // A note about a translation or a patch is dump metadata however many clauses it runs to,
+  // as in "(English Translated by Aeon Genesis, Rev 1.01 With Fixes by MTeam)".
+  static const QRegularExpression romHack(
+      QStringLiteral(R"(Translat(?:ed|ion)|\bPatch(?:ed)?\b|\bHack\b|\bFan ?Trans|\bFixes by\b)"),
+      QRegularExpression::CaseInsensitiveOption);
+  if (romHack.match(contents).hasMatch())
+    return true;
+  const QStringList parts =
+      contents.split(QRegularExpression(QStringLiteral(",| - ")), Qt::SkipEmptyParts);
+  if (parts.isEmpty())
+    return false;
+  for (const QString& part : parts)
+    if (!dumpTagPart(part))
+      return false;
+  return true;
+}
+
+QString cleanTitle(QString title) {
+  // ROM sets tag dumps with the region, language, revision, release state and any translation
+  // patch. IGDB knows none of that, so a tagged title never matches its catalogue entry.
+  // Editions, remasters and subtitles are not tags and keep their names.
+  static const QRegularExpression group(QStringLiteral(R"(\s*\(([^()]*)\))"));
+  static const QRegularExpression squareTag(QStringLiteral(R"(\s*\[[^\[\]]*\])"));
+  QString previous;
+  while (previous != title) {
+    previous = title;
+    QString stripped;
+    qsizetype at = 0;
+    auto matches = group.globalMatch(title);
+    while (matches.hasNext()) {
+      const auto match = matches.next();
+      if (!dumpTagGroup(match.captured(1)))
+        continue;
+      stripped += title.mid(at, match.capturedStart() - at);
+      at = match.capturedEnd();
+    }
+    title = stripped + title.mid(at);
+    // Square brackets only ever carry dump flags such as [!], [b1] or [T+Eng].
+    title.remove(squareTag);
+    title = title.simplified();
+  }
+  // "Legend of Zelda, The" is how a ROM set sorts a title, and the article can sit before a
+  // subtitle as in "Legend of Zelda, The - Ocarina of Time". Put it back in front so the search
+  // reads the way IGDB stores it.
+  static const QRegularExpression sortedArticle(
+      QStringLiteral(
+          R"(^(.*?),\s*(The|A|An|Der|Die|Das|Le|La|Les|El|Los|Il|Lo)(\s*[-:].*)?$)"),
+      QRegularExpression::CaseInsensitiveOption);
+  const auto article = sortedArticle.match(title);
+  if (article.hasMatch())
+    title = article.captured(2) + QLatin1Char(' ') + article.captured(1) + article.captured(3);
   return title.simplified();
 }
 } // namespace
 QString GameMetadata::normalizedTitle(QString title) {
   title = cleanTitle(title);
-  return title.normalized(QString::NormalizationForm_KC)
-      .toCaseFolded()
-      .replace(QRegularExpression(QStringLiteral("[^\\p{L}\\p{N}\"]+")), " ")
-      .simplified();
+  QString normalized = title.normalized(QString::NormalizationForm_KC)
+                           .toCaseFolded()
+                           .replace(QRegularExpression(QStringLiteral("[^\\p{L}\\p{N}\"]+")), " ")
+                           .simplified();
+  // A leading article is never what separates two games, and the catalogues disagree about it.
+  static const QRegularExpression leadingArticle(QStringLiteral("^(?:the|a|an) (?=.)"));
+  return normalized.remove(leadingArticle);
 }
+namespace {
+// Retro consoles get real box scans from the Libretro thumbnail server, and GameCube and Wii
+// covers come from GameTDB, so a fan-made portrait would replace authentic artwork. Switch,
+// Wii U and PS4 dumps only carry a square icon, which crops badly on a card, so those still
+// want a portrait. Games with no console, such as PC titles, want one too.
+bool prefersSourceCoverArt(const QString& system) {
+  const QString id = ConsoleCatalog::idFor(system);
+  if (id.isEmpty())
+    return false;
+  static const QSet<QString> iconOnly{QStringLiteral("switch"), QStringLiteral("wiiu"),
+                                      QStringLiteral("ps4")};
+  return !iconOnly.contains(id);
+}
+} // namespace
+
 int GameMetadata::platformId(const QString& system) {
   static const QHash<QString, int> ids{
       {"nes", 18}, {"snes", 19},    {"gb", 33},      {"gbc", 22},       {"gba", 24},
@@ -184,7 +267,8 @@ void GameMetadata::enqueue(const QVariantMap& game) {
   const qint64 now = QDateTime::currentSecsSinceEpoch();
   const bool ratings = m_insights && m_insights->configured() &&
                        saved.value("updated").toLongLong() <= now - 30 * 86400;
-  const bool portrait = hasGridKey() && !QFileInfo::exists(saved.value("portrait").toString()) &&
+  const bool portrait = hasGridKey() && !prefersSourceCoverArt(game.value("system").toString()) &&
+                        !QFileInfo::exists(saved.value("portrait").toString()) &&
                         saved.value("coverAttempt").toLongLong() <= now - 86400;
   if (!ratings && !portrait)
     return;
@@ -341,7 +425,21 @@ void GameMetadata::matchResult(const QByteArray& data, const QString& error) {
       exact.append(match);
   if (exact.size() == 1)
     acceptMatch(exact.first().toMap());
-  else {
+  else if (exact.size() > 1) {
+    // Several catalogue entries carry the same name on the same platform: usually a regional
+    // duplicate or a compilation beside the game. The entry people actually rated is the one
+    // to keep, so pick the most rated and fall back to the lowest id for a stable answer.
+    QVariantMap best;
+    for (const auto& candidate : exact) {
+      const auto map = candidate.toMap();
+      if (best.isEmpty() ||
+          map.value("ratingCount").toInt() > best.value("ratingCount").toInt() ||
+          (map.value("ratingCount").toInt() == best.value("ratingCount").toInt() &&
+           map.value("id").toLongLong() < best.value("id").toLongLong()))
+        best = map;
+    }
+    acceptMatch(best);
+  } else {
     auto value = saved;
     value["matchStatus"] = "Needs identification";
     value["updated"] = QDateTime::currentSecsSinceEpoch();
@@ -407,6 +505,10 @@ void GameMetadata::findCovers() {
 void GameMetadata::gridSearch() {
   if (!hasGridKey()) {
     finish("IGDB data saved. Connect SteamGridDB for portrait covers.");
+    return;
+  }
+  if (!m_manual && prefersSourceCoverArt(m_active.value("system").toString())) {
+    finish("IGDB data saved. This system keeps its own box art.");
     return;
   }
   auto value = entry(key());

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -125,7 +125,17 @@ QString GameMetadata::normalizedTitle(QString title) {
                            .simplified();
   // A leading article is never what separates two games, and the catalogues disagree about it.
   static const QRegularExpression leadingArticle(QStringLiteral("^(?:the|a|an) (?=.)"));
-  return normalized.remove(leadingArticle);
+  normalized.remove(leadingArticle);
+  // Accents are a spelling difference, not a different game: a cartridge labelled Pokemon
+  // Stadium 2 is the catalogue's Pokémon Stadium 2.
+  QString folded;
+  folded.reserve(normalized.size());
+  for (const QChar character : normalized.normalized(QString::NormalizationForm_D)) {
+    if (character.category() != QChar::Mark_NonSpacing) {
+      folded.append(character);
+    }
+  }
+  return folded.normalized(QString::NormalizationForm_C);
 }
 bool GameMetadata::wantsPortraitCover(const QString& system, const QString& source,
                                       const QString& sourceCover) {
@@ -152,21 +162,32 @@ bool GameMetadata::wantsPortraitCover(const QString& system, const QString& sour
   return double(size.width()) / double(size.height()) > kPortraitAspectLimit;
 }
 
-int GameMetadata::platformId(const QString& system) {
-  static const QHash<QString, int> ids{
-      {"nes", 18}, {"snes", 19},    {"gb", 33},      {"gbc", 22},       {"gba", 24},
-      {"n64", 4},  {"genesis", 29}, {"psx", 7},      {"dreamcast", 23}, {"gamecube", 21},
-      {"wii", 5},  {"ps2", 8},      {"switch", 130}, {"wiiu", 41},      {"ps4", 48}};
-  return ids.value(ConsoleCatalog::idFor(system), system.isEmpty() ? 6 : 0);
+QList<int> GameMetadata::platformIds(const QString& system) {
+  // IGDB catalogues a Japanese release under its own machine, so a Super Famicom cartridge is
+  // platform 58 rather than the Super Nintendo's 19. Filtering on the western platform alone
+  // threw away games IGDB had already returned by name, which was the single largest reason a
+  // shelf of imports stayed unidentified.
+  static const QHash<QString, QList<int>> ids{
+      {"nes", {18, 99}},   {"snes", {19, 58}}, {"gb", {33}},      {"gbc", {22}},
+      {"gba", {24}},       {"n64", {4}},       {"genesis", {29}}, {"psx", {7}},
+      {"dreamcast", {23}}, {"gamecube", {21}}, {"wii", {5}},      {"ps2", {8}},
+      {"switch", {130}},   {"wiiu", {41}},     {"ps4", {48}}};
+  const QString id = ConsoleCatalog::idFor(system);
+  if (ids.contains(id))
+    return ids.value(id);
+  return system.isEmpty() ? QList<int>{6} : QList<int>{};
 }
 QByteArray GameMetadata::searchQuery(const QString& title, const QString& system) {
-  const int platform = platformId(system);
-  if (title.trimmed().isEmpty() || platform == 0)
+  const QList<int> platforms = platformIds(system);
+  if (title.trimmed().isEmpty() || platforms.isEmpty())
     return {};
+  QByteArrayList numbers;
+  for (int platform : platforms)
+    numbers.append(QByteArray::number(platform));
   return QByteArray(fields) + "search " + quoted(cleanTitle(title)).toUtf8() +
-         "; where platforms = (" + QByteArray::number(platform) + "); limit 20;";
+         "; where platforms = (" + numbers.join(',') + "); limit 20;";
 }
-QVariantList GameMetadata::parseMatches(const QByteArray& data, int platform) {
+QVariantList GameMetadata::parseMatches(const QByteArray& data, const QList<int>& platforms) {
   QVariantList result;
   const auto doc = QJsonDocument::fromJson(data);
   if (!doc.isArray())
@@ -175,8 +196,14 @@ QVariantList GameMetadata::parseMatches(const QByteArray& data, int platform) {
     const auto obj = value.toObject();
     if (obj.value("id").toInteger() <= 0 || obj.value("name").toString().isEmpty())
       continue;
-    if (platform > 0 && !obj.value("platforms").toArray().contains(platform))
-      continue;
+    if (!platforms.isEmpty()) {
+      const auto listed = obj.value("platforms").toArray();
+      bool onPlatform = false;
+      for (int platform : platforms)
+        onPlatform = onPlatform || listed.contains(platform);
+      if (!onPlatform)
+        continue;
+    }
     QVariantMap match{{"id", obj.value("id").toInteger()}, {"title", obj.value("name").toString()}};
     const qint64 released = obj.value("first_release_date").toInteger();
     match["year"] = released > 0 ? QDateTime::fromSecsSinceEpoch(released).date().year() : 0;
@@ -585,7 +612,7 @@ void GameMetadata::matchResult(const QByteArray& data, const QString& error) {
     finish("IGDB returned invalid data. Cached metadata is unchanged.");
     return;
   }
-  const auto matches = parseMatches(data, platformId(m_active.value("system").toString()));
+  const auto matches = parseMatches(data, platformIds(m_active.value("system").toString()));
   if (m_manual) {
     m_candidates = matches;
     m_candidateProvider = "igdb";
@@ -594,6 +621,16 @@ void GameMetadata::matchResult(const QByteArray& data, const QString& error) {
     return;
   }
   const auto saved = entry(key());
+  // A licensed game is often catalogued with its publisher in front, as Disney's DuckTales for
+  // a cartridge labelled DuckTales. Comparing with that prefix removed as well recognises it.
+  static const QRegularExpression brandPrefix(QStringLiteral("^[\\p{L}\\p{N} ]{2,24}? s "));
+  const auto sameGame = [](const QString& candidate, const QString& local) {
+    if (candidate == local)
+      return true;
+    QString withoutBrand = candidate;
+    withoutBrand.remove(brandPrefix);
+    return !withoutBrand.isEmpty() && withoutBrand == local;
+  };
   // A match the user chose stays chosen. Refreshing its rating must never hand the game to a
   // different catalogue entry, however well another one scores.
   const bool userChose = saved.value("manualMatch").toBool() && saved.value("igdbId").toLongLong() > 0;
@@ -606,8 +643,8 @@ void GameMetadata::matchResult(const QByteArray& data, const QString& error) {
     }
     if (m_igdbStage == "mappedGame" ||
         saved.value("igdbId").toLongLong() == match.toMap().value("id").toLongLong() ||
-        normalizedTitle(match.toMap().value("title").toString()) ==
-            normalizedTitle(m_active.value("title").toString()))
+        sameGame(normalizedTitle(match.toMap().value("title").toString()),
+                 normalizedTitle(m_active.value("title").toString())))
       exact.append(match);
   }
   if (exact.size() == 1)

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -258,6 +258,15 @@ void GameMetadata::inspect(const QVariantMap& game) {
   m_covers.clear();
   emit changed();
 }
+bool GameMetadata::needsIdentifying(const QVariantMap& saved, qint64 now) {
+  // An answer produced by older rules is stale however recently it was written. Without this a
+  // matching fix would reach existing libraries only as each entry aged out, which for a shelf
+  // marked "Needs identification" means a month of looking broken.
+  if (saved.value("matchVersion").toInt() < kMatchVersion)
+    return true;
+  return saved.value("updated").toLongLong() <= now - kRatingFreshnessSeconds;
+}
+
 void GameMetadata::enqueue(const QVariantMap& game) {
   if (game.value("isPortal").toBool() || game.value("metadataKey").toString().isEmpty())
     return;
@@ -265,8 +274,7 @@ void GameMetadata::enqueue(const QVariantMap& game) {
   if (saved.value("rejected").toBool())
     return;
   const qint64 now = QDateTime::currentSecsSinceEpoch();
-  const bool ratings = m_insights && m_insights->configured() &&
-                       saved.value("updated").toLongLong() <= now - 30 * 86400;
+  const bool ratings = m_insights && m_insights->configured() && needsIdentifying(saved, now);
   const bool portrait = hasGridKey() && !prefersSourceCoverArt(game.value("system").toString()) &&
                         !QFileInfo::exists(saved.value("portrait").toString()) &&
                         saved.value("coverAttempt").toLongLong() <= now - 86400;
@@ -427,13 +435,22 @@ void GameMetadata::matchResult(const QByteArray& data, const QString& error) {
     return;
   }
   const auto saved = entry(key());
+  // A match the user chose stays chosen. Refreshing its rating must never hand the game to a
+  // different catalogue entry, however well another one scores.
+  const bool userChose = saved.value("manualMatch").toBool() && saved.value("igdbId").toLongLong() > 0;
   QVariantList exact;
-  for (const auto& match : matches)
+  for (const auto& match : matches) {
+    if (userChose) {
+      if (saved.value("igdbId").toLongLong() == match.toMap().value("id").toLongLong())
+        exact.append(match);
+      continue;
+    }
     if (m_igdbStage == "mappedGame" ||
         saved.value("igdbId").toLongLong() == match.toMap().value("id").toLongLong() ||
         normalizedTitle(match.toMap().value("title").toString()) ==
             normalizedTitle(m_active.value("title").toString()))
       exact.append(match);
+  }
   if (exact.size() == 1)
     acceptMatch(exact.first().toMap());
   else if (exact.size() > 1) {
@@ -454,6 +471,7 @@ void GameMetadata::matchResult(const QByteArray& data, const QString& error) {
     auto value = saved;
     value["matchStatus"] = "Needs identification";
     value["updated"] = QDateTime::currentSecsSinceEpoch();
+    value["matchVersion"] = kMatchVersion;
     persist(key(), value);
     gridSearch();
   }
@@ -485,6 +503,7 @@ void GameMetadata::acceptMatch(const QVariantMap& match) {
   value["platform"] = m_active.value("system");
   value["localTitle"] = m_active.value("title");
   value["manualMatch"] = m_manual || value.value("manualMatch").toBool();
+  value["matchVersion"] = kMatchVersion;
   persist(key(), value);
   m_candidates.clear();
   requestIgdb("fields game_id,value; where game_id = " +

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -126,7 +126,8 @@ QString GameMetadata::normalizedTitle(QString title) {
   static const QRegularExpression leadingArticle(QStringLiteral("^(?:the|a|an) (?=.)"));
   return normalized.remove(leadingArticle);
 }
-bool GameMetadata::wantsPortraitCover(const QString& system, const QString& sourceCover) {
+bool GameMetadata::wantsPortraitCover(const QString& system, const QString& source,
+                                      const QString& sourceCover) {
   // Retro consoles get real box scans from the Libretro thumbnail server, and GameCube and Wii
   // covers come from GameTDB. That artwork is authentic and a fan-made portrait would replace
   // it, so those systems never ask for one. Switch, Wii U and PS4 dumps carry only a square
@@ -136,9 +137,12 @@ bool GameMetadata::wantsPortraitCover(const QString& system, const QString& sour
                                       QStringLiteral("ps4")};
   if (!id.isEmpty() && !iconOnly.contains(id))
     return false;
-  // Whatever the source, artwork that is already portrait shaped is the artwork to keep. Steam
-  // ships an official 600x900 capsule, and other launchers carry publisher covers; replacing
-  // those with fan art is a downgrade, so a portrait only fills a gap or a bad shape.
+  // Steam ships an official 600x900 capsule for every game. It downloads on demand, so judging
+  // by the file alone would hand a fan portrait to any game whose capsule had not arrived yet.
+  if (source.compare(QStringLiteral("Steam"), Qt::CaseInsensitive) == 0)
+    return false;
+  // Elsewhere, artwork that is already portrait shaped is the artwork to keep. Replacing a
+  // publisher's cover with fan art is a downgrade, so a portrait only fills a gap or a bad shape.
   QString path = sourceCover;
   if (path.startsWith(QStringLiteral("file://")))
     path = QUrl(path).toLocalFile();
@@ -250,7 +254,52 @@ GameMetadata::~GameMetadata() {
   m_database = {};
   QSqlDatabase::removeDatabase(m_connection);
 }
-void GameMetadata::setLibrary(UnifiedGameModel* library) { m_library = library; }
+void GameMetadata::setLibrary(UnifiedGameModel* library) {
+  m_library = library;
+  if (m_library == nullptr)
+    return;
+  // Sources populate the library over the first few seconds, so wait for rows to arrive before
+  // judging what artwork a game has. The review runs once and is cheap: only entries that
+  // actually hold a portrait are examined.
+  const auto review = [this] {
+    if (m_reviewedPortraits || m_library == nullptr || m_library->rowCount() == 0)
+      return;
+    m_reviewedPortraits = true;
+    dropUnwantedPortraits();
+  };
+  connect(m_library, &QAbstractItemModel::rowsInserted, this, review);
+  connect(m_library, &QAbstractItemModel::modelReset, this, review);
+}
+
+void GameMetadata::dropUnwantedPortraits() {
+  if (m_library == nullptr)
+    return;
+  int dropped = 0;
+  for (int row = 0; row < m_library->rowCount(); ++row) {
+    const QModelIndex game = m_library->index(row);
+    const QString id = game.data(GameRoles::MetadataKey).toString();
+    if (id.isEmpty())
+      continue;
+    auto value = entry(id);
+    if (!value.contains("portrait"))
+      continue;
+    if (wantsPortraitCover(game.data(GameRoles::System).toString(),
+                           game.data(GameRoles::Source).toString(),
+                           game.data(GameRoles::SourceCoverPath).toString()))
+      continue;
+    // A portrait the user chose is stored as a custom cover, which outranks this and stays.
+    value.remove("portrait");
+    value.remove("gridCoverId");
+    persist(id, value);
+    ++dropped;
+  }
+  if (dropped > 0) {
+    m_status = QStringLiteral("Restored artwork on %1 %2")
+                   .arg(dropped)
+                   .arg(dropped == 1 ? "game" : "games");
+    emit changed();
+  }
+}
 void GameMetadata::persist(const QString& id, const QVariantMap& value) {
   if (id.isEmpty())
     return;
@@ -293,6 +342,7 @@ void GameMetadata::enqueue(const QVariantMap& game) {
   const bool ratings = m_insights && m_insights->configured() && needsIdentifying(saved, now);
   const bool portrait = hasGridKey() &&
                         wantsPortraitCover(game.value("system").toString(),
+                                           game.value("source").toString(),
                                            game.value("sourceCoverPath").toString()) &&
                         !QFileInfo::exists(saved.value("portrait").toString()) &&
                         saved.value("coverAttempt").toLongLong() <= now - 86400;
@@ -556,6 +606,7 @@ void GameMetadata::gridSearch() {
     return;
   }
   if (!m_manual && !wantsPortraitCover(m_active.value("system").toString(),
+                                       m_active.value("source").toString(),
                                        m_active.value("sourceCoverPath").toString())) {
     // An earlier run may have downloaded a portrait over artwork that should have been kept.
     // Drop it so the game shows its own art again. A portrait the user picked is stored as a

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -1,3 +1,5 @@
+#include "app/SecretService.h"
+#include <QMutexLocker>
 #include "metadata/GameMetadata.h"
 #include "library/ConsoleCatalog.h"
 #include <algorithm>
@@ -272,7 +274,7 @@ GameMetadata::GameMetadata(const QString& databasePath, GameInsightsService* ins
     // before they arrive. Without this the pass looked once, found no connection, and never
     // looked again, leaving the whole library unidentified until something else changed.
     connect(insights, &GameInsightsService::changed, this, [this] {
-      if (!m_stoppedByHand && !m_editing && !busy())
+      if (!m_stoppedByHand && !m_editing)
         m_settle.start();
     });
   if (QFileInfo::exists(m_cacheRoot + "/configured"))
@@ -308,6 +310,10 @@ void GameMetadata::setLibrary(UnifiedGameModel* library) {
   connect(&m_settle, &QTimer::timeout, this, &GameMetadata::continueLibraryPass);
   connect(m_library, &QAbstractItemModel::rowsInserted, this, settled);
   connect(m_library, &QAbstractItemModel::modelReset, this, settled);
+  // Sources that load straight from their own database have already filled the library by the
+  // time this runs, and those rows arrived before anything was listening. Waiting only for the
+  // next change then waits forever, and nothing is ever identified.
+  settled();
 }
 
 void GameMetadata::setVisibleLibrary(QAbstractItemModel* visible) {
@@ -353,8 +359,14 @@ void GameMetadata::setEditing(bool editing) {
 
 void GameMetadata::continueLibraryPass() {
   // Stopping by hand means stopped, until the next launch or an explicit update.
-  if (m_stoppedByHand || m_editing || busy() || m_library == nullptr)
+  if (m_stoppedByHand || m_editing || m_library == nullptr)
     return;
+  // Reading keys from the keyring is work that finishes on its own, so look again shortly
+  // rather than waiting to be told. Wanting credentials is different: that waits for an event.
+  if (busy()) {
+    m_settle.start();
+    return;
+  }
   if ((m_insights == nullptr || !m_insights->configured()) && !hasGridKey())
     return;
   m_cancelled = false;
@@ -1067,6 +1079,9 @@ void GameMetadata::secretOperation(int action, QByteArray value) {
     if (!result.success) {
       result.secret.fill('\0');
       finish("Secret Service could not update the SteamGridDB key");
+      // Ratings do not need this key, so a failure here must not end the pass.
+      if (!m_stoppedByHand && !m_editing)
+        m_settle.start();
       return;
     }
     m_gridKey.fill('\0');
@@ -1088,6 +1103,7 @@ void GameMetadata::secretOperation(int action, QByteArray value) {
       m_settle.start();
   });
   m_secrets.setFuture(QtConcurrent::run([action, value]() mutable {
+    QMutexLocker keyring(&secretServiceLock());
     InsightsSecretResult result;
     SecretSchema* schema =
         secret_schema_new("io.github.tsouth89.Omakade.SteamGridDB", SECRET_SCHEMA_NONE, "service",

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -330,6 +330,10 @@ void GameMetadata::setVisibleLibrary(QAbstractItemModel* visible) {
   connect(m_visible, &QAbstractItemModel::modelReset, this, viewChanged);
   connect(m_visible, &QAbstractItemModel::rowsInserted, this, viewChanged);
   connect(m_visible, &QAbstractItemModel::rowsRemoved, this, viewChanged);
+  // Opening a console swaps the whole view in one pass and reports it as a layout change, not
+  // as rows coming and going. Without this, walking into a console never reordered anything and
+  // its games waited behind the rest of the library.
+  connect(m_visible, &QAbstractItemModel::layoutChanged, this, viewChanged);
 }
 
 void GameMetadata::setEditing(bool editing) {
@@ -481,6 +485,18 @@ void GameMetadata::inspect(const QVariantMap& game) {
   m_selected = game;
   m_candidates.clear();
   m_covers.clear();
+  // Someone looking at a game's details is waiting on that game, so it goes to the front rather
+  // than taking its turn behind the rest of the library.
+  const QString key = game.value("metadataKey").toString();
+  if (!key.isEmpty()) {
+    for (qsizetype at = 0; at < m_queue.size(); ++at) {
+      if (m_queue.at(at).value("metadataKey").toString() != key)
+        continue;
+      if (at > 0)
+        m_queue.move(at, 0);
+      break;
+    }
+  }
   emit changed();
 }
 QByteArray GameMetadata::matchingRulesFingerprint() {

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -533,6 +533,7 @@ void GameMetadata::next() {
   }
   m_active = m_queue.dequeue();
   m_manual = false;
+  m_numberedRetryTitle.clear();
   m_busy = true;
   m_igdbStage = "games";
   auto saved = entry(key());
@@ -575,6 +576,7 @@ void GameMetadata::search(const QString& title) {
   m_igdbStage = "games";
   m_active = m_selected;
   m_manual = true;
+  m_numberedRetryTitle.clear();
   m_candidateProvider = "igdb";
   m_candidates.clear();
   m_covers.clear();
@@ -669,7 +671,9 @@ void GameMetadata::matchResult(const QByteArray& data, const QString& error) {
     if (m_igdbStage == "mappedGame" ||
         saved.value("igdbId").toLongLong() == match.toMap().value("id").toLongLong() ||
         sameGame(normalizedTitle(match.toMap().value("title").toString()),
-                 normalizedTitle(m_active.value("title").toString())))
+                 normalizedTitle(m_numberedRetryTitle.isEmpty()
+                                     ? m_active.value("title").toString()
+                                     : m_numberedRetryTitle)))
       exact.append(match);
   }
   if (exact.size() == 1)
@@ -689,6 +693,22 @@ void GameMetadata::matchResult(const QByteArray& data, const QString& error) {
     }
     acceptMatch(best);
   } else {
+    // Some ROM sets number their files, as "1636 - Pokemon Fire Red". Searching for the number
+    // finds nothing. Trying again without it only after the title as written has failed means a
+    // game that really begins with a number, 1080 Snowboarding or 1942, is never mangled.
+    static const QRegularExpression catalogueNumber(QStringLiteral("^\\d{2,5}\\s*-\\s*(?=\\S)"));
+    const QString written = m_active.value("title").toString();
+    if (!m_manual && m_numberedRetryTitle.isEmpty() &&
+        catalogueNumber.match(written).hasMatch()) {
+      QString withoutNumber = written;
+      withoutNumber.remove(catalogueNumber);
+      const QByteArray retry = searchQuery(withoutNumber, m_active.value("system").toString());
+      if (!retry.isEmpty()) {
+        m_numberedRetryTitle = withoutNumber;
+        requestIgdb(retry, "games", "games");
+        return;
+      }
+    }
     auto value = saved;
     value["matchStatus"] = "Needs identification";
     value["updated"] = QDateTime::currentSecsSinceEpoch();
@@ -748,6 +768,7 @@ void GameMetadata::findCovers() {
   m_cancelled = false;
   m_active = m_selected;
   m_manual = true;
+  m_numberedRetryTitle.clear();
   m_busy = true;
   m_candidates.clear();
   m_covers.clear();

--- a/src/metadata/GameMetadata.cpp
+++ b/src/metadata/GameMetadata.cpp
@@ -30,6 +30,12 @@ namespace {
 constexpr auto fields = "fields "
                         "name,platforms,first_release_date,total_rating,total_rating_count,"
                         "aggregated_rating,aggregated_rating_count; ";
+// IGDB allows four requests a second; 350 ms keeps a comfortable margin. SteamGridDB is not
+// documented as precisely, so its calls are held a little further apart. With both providers
+// paced at the request, the gap between games only has to yield to the event loop.
+constexpr int kGridRequestGapMs = 250;
+constexpr int kBetweenGamesMs = 100;
+
 QString quoted(QString text) {
   text.replace('\\', "\\\\");
   text.replace('"', "\\\"");
@@ -120,20 +126,30 @@ QString GameMetadata::normalizedTitle(QString title) {
   static const QRegularExpression leadingArticle(QStringLiteral("^(?:the|a|an) (?=.)"));
   return normalized.remove(leadingArticle);
 }
-namespace {
-// Retro consoles get real box scans from the Libretro thumbnail server, and GameCube and Wii
-// covers come from GameTDB, so a fan-made portrait would replace authentic artwork. Switch,
-// Wii U and PS4 dumps only carry a square icon, which crops badly on a card, so those still
-// want a portrait. Games with no console, such as PC titles, want one too.
-bool prefersSourceCoverArt(const QString& system) {
+bool GameMetadata::wantsPortraitCover(const QString& system, const QString& sourceCover) {
+  // Retro consoles get real box scans from the Libretro thumbnail server, and GameCube and Wii
+  // covers come from GameTDB. That artwork is authentic and a fan-made portrait would replace
+  // it, so those systems never ask for one. Switch, Wii U and PS4 dumps carry only a square
+  // icon, which crops a logo off the card, so they may.
   const QString id = ConsoleCatalog::idFor(system);
-  if (id.isEmpty())
-    return false;
   static const QSet<QString> iconOnly{QStringLiteral("switch"), QStringLiteral("wiiu"),
                                       QStringLiteral("ps4")};
-  return !iconOnly.contains(id);
+  if (!id.isEmpty() && !iconOnly.contains(id))
+    return false;
+  // Whatever the source, artwork that is already portrait shaped is the artwork to keep. Steam
+  // ships an official 600x900 capsule, and other launchers carry publisher covers; replacing
+  // those with fan art is a downgrade, so a portrait only fills a gap or a bad shape.
+  QString path = sourceCover;
+  if (path.startsWith(QStringLiteral("file://")))
+    path = QUrl(path).toLocalFile();
+  if (path.isEmpty() || !QFileInfo::exists(path))
+    return true;
+  QImageReader reader(path);
+  const QSize size = reader.size();
+  if (!size.isValid() || size.height() <= 0)
+    return true;
+  return double(size.width()) / double(size.height()) > kPortraitAspectLimit;
 }
-} // namespace
 
 int GameMetadata::platformId(const QString& system) {
   static const QHash<QString, int> ids{
@@ -275,7 +291,9 @@ void GameMetadata::enqueue(const QVariantMap& game) {
     return;
   const qint64 now = QDateTime::currentSecsSinceEpoch();
   const bool ratings = m_insights && m_insights->configured() && needsIdentifying(saved, now);
-  const bool portrait = hasGridKey() && !prefersSourceCoverArt(game.value("system").toString()) &&
+  const bool portrait = hasGridKey() &&
+                        wantsPortraitCover(game.value("system").toString(),
+                                           game.value("sourceCoverPath").toString()) &&
                         !QFileInfo::exists(saved.value("portrait").toString()) &&
                         saved.value("coverAttempt").toLongLong() <= now - 86400;
   if (!ratings && !portrait)
@@ -352,7 +370,7 @@ void GameMetadata::next() {
   if (m_insights && m_insights->busy()) {
     m_busy = false;
     m_queue.prepend(m_active);
-    QTimer::singleShot(500, this, &GameMetadata::next);
+    QTimer::singleShot(kBetweenGamesMs, this, &GameMetadata::next);
     return;
   }
   gridSearch();
@@ -537,8 +555,9 @@ void GameMetadata::gridSearch() {
     finish("IGDB data saved. Connect SteamGridDB for portrait covers.");
     return;
   }
-  if (!m_manual && prefersSourceCoverArt(m_active.value("system").toString())) {
-    finish("IGDB data saved. This system keeps its own box art.");
+  if (!m_manual && !wantsPortraitCover(m_active.value("system").toString(),
+                                       m_active.value("sourceCoverPath").toString())) {
+    finish("IGDB data saved. This game keeps the artwork its source provides.");
     return;
   }
   auto value = entry(key());
@@ -597,6 +616,18 @@ void GameMetadata::chooseCover(int index) {
 }
 void GameMetadata::get(const QUrl& url, const QString& stage) {
   emit changed();
+  // Hold SteamGridDB's API calls apart. Image downloads come from a CDN and are slow enough on
+  // their own. Without this the queue would burst three calls per game back to back.
+  if (stage != "image" && m_sinceGridRequest.isValid()) {
+    const qint64 waited = m_sinceGridRequest.elapsed();
+    if (waited < kGridRequestGapMs) {
+      QTimer::singleShot(kGridRequestGapMs - waited, this,
+                         [this, url, stage] { get(url, stage); });
+      return;
+    }
+  }
+  if (stage != "image")
+    m_sinceGridRequest.restart();
   QNetworkRequest request(url);
   request.setTransferTimeout(15000);
   request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
@@ -735,7 +766,7 @@ void GameMetadata::finish(const QString& message) {
   m_status = message;
   emit changed();
   if (!m_queue.isEmpty())
-    QTimer::singleShot(500, this, &GameMetadata::next);
+    QTimer::singleShot(kBetweenGamesMs, this, &GameMetadata::next);
 }
 void GameMetadata::storeGridKey(QString key) {
   if (busy())

--- a/src/metadata/GameMetadata.h
+++ b/src/metadata/GameMetadata.h
@@ -54,6 +54,10 @@ public:
                                                                             : QVariantList{};
   }
   Q_INVOKABLE void inspect(const QVariantMap& game);
+  // While someone is identifying a game by hand, the background pass stands down. Without this
+  // the queue keeps the service busy and every manual control stays disabled, because they are
+  // all gated on the same busy state.
+  Q_INVOKABLE void setEditing(bool editing);
   Q_INVOKABLE void refreshLibrary();
   // Continues the library pass on its own: after the library settles, whenever games are added,
   // and whenever the view changes. Stopping it by hand keeps it stopped until the next launch.
@@ -131,6 +135,8 @@ private:
   QElapsedTimer m_sinceGridRequest;
   bool m_reviewedPortraits = false;
   bool m_stoppedByHand = false;
+  bool m_editing = false;
+  QQueue<QVariantMap> m_pausedQueue;
   QAbstractItemModel* m_visible = nullptr;
   QTimer m_settle;
   void continueLibraryPass();

--- a/src/metadata/GameMetadata.h
+++ b/src/metadata/GameMetadata.h
@@ -89,9 +89,11 @@ public:
   Q_INVOKABLE void testGridConnection();
   Q_INVOKABLE void clearPortraitCache();
   static QString normalizedTitle(QString title);
-  static int platformId(const QString& system);
+  // The IGDB platforms a system's games can be listed under. A Japanese release is often
+  // catalogued under the regional machine rather than the western one.
+  static QList<int> platformIds(const QString& system);
   static QByteArray searchQuery(const QString& title, const QString& system);
-  static QVariantList parseMatches(const QByteArray& data, int platform);
+  static QVariantList parseMatches(const QByteArray& data, const QList<int>& platforms);
   static QVariantList parseCovers(const QByteArray& data);
   static bool trustedImageUrl(const QUrl& url);
 signals:

--- a/src/metadata/GameMetadata.h
+++ b/src/metadata/GameMetadata.h
@@ -44,6 +44,15 @@ public:
   }
   Q_INVOKABLE void inspect(const QVariantMap& game);
   Q_INVOKABLE void refreshLibrary();
+  // Identification depends on how titles are cleaned and how a match is accepted. Raise this
+  // whenever those rules change: every entry decided by older rules is then re-identified on
+  // the next update, instead of waiting out the ordinary freshness window with a stale answer.
+  static constexpr int kMatchVersion = 2;
+  // How long a rating stays fresh before it is fetched again.
+  static constexpr qint64 kRatingFreshnessSeconds = 30 * 86400;
+  // True when a stored entry should be identified again: either the rules that decided it have
+  // changed, or its rating has simply aged out.
+  [[nodiscard]] static bool needsIdentifying(const QVariantMap& saved, qint64 now);
   Q_INVOKABLE void search(const QString& title);
   Q_INVOKABLE void chooseMatch(int index);
   Q_INVOKABLE void rejectMatch();

--- a/src/metadata/GameMetadata.h
+++ b/src/metadata/GameMetadata.h
@@ -4,6 +4,7 @@
 #include <QFutureWatcher>
 #include <QHash>
 #include <QNetworkAccessManager>
+#include <QElapsedTimer>
 #include <QObject>
 #include <QQueue>
 #include <QSqlDatabase>
@@ -53,6 +54,12 @@ public:
   // True when a stored entry should be identified again: either the rules that decided it have
   // changed, or its rating has simply aged out.
   [[nodiscard]] static bool needsIdentifying(const QVariantMap& saved, qint64 now);
+  // A downloaded portrait replaces the artwork a game already has, so it is only worth
+  // fetching when that artwork is missing or cannot serve as a cover. Takes the system and the
+  // path to the source's own art.
+  [[nodiscard]] static bool wantsPortraitCover(const QString& system, const QString& sourceCover);
+  // Artwork at least as tall as 4:3 already works as a cover and is left alone.
+  static constexpr double kPortraitAspectLimit = 0.8;
   Q_INVOKABLE void search(const QString& title);
   Q_INVOKABLE void chooseMatch(int index);
   Q_INVOKABLE void rejectMatch();
@@ -100,6 +107,8 @@ private:
   QNetworkAccessManager* m_network;
   QFutureWatcher<InsightsSecretResult> m_secrets;
   QByteArray m_gridKey;
+  // Each provider is paced on its own, so the queue does not need a blanket pause between games.
+  QElapsedTimer m_sinceGridRequest;
   QQueue<QVariantMap> m_queue;
   QVariantMap m_selected, m_active;
   QVariantList m_candidates, m_covers;

--- a/src/metadata/GameMetadata.h
+++ b/src/metadata/GameMetadata.h
@@ -27,6 +27,10 @@ public:
                QObject* parent = nullptr, QNetworkAccessManager* network = nullptr);
   ~GameMetadata() override;
   void setLibrary(UnifiedGameModel* library);
+  // Drops portraits that were downloaded over artwork the game's own source provides. Runs by
+  // itself as the library settles, so a rule change reaches an existing library without anyone
+  // being asked to run anything.
+  void dropUnwantedPortraits();
   void setCacheLimitMb(int megabytes);
   QVariantMap entry(const QString& key) const { return m_entries.value(key); }
   bool busy() const { return m_busy || !m_queue.isEmpty() || m_secrets.isRunning(); }
@@ -57,7 +61,8 @@ public:
   // A downloaded portrait replaces the artwork a game already has, so it is only worth
   // fetching when that artwork is missing or cannot serve as a cover. Takes the system and the
   // path to the source's own art.
-  [[nodiscard]] static bool wantsPortraitCover(const QString& system, const QString& sourceCover);
+  [[nodiscard]] static bool wantsPortraitCover(const QString& system, const QString& source,
+                                               const QString& sourceCover);
   // Artwork at least as tall as 4:3 already works as a cover and is left alone.
   static constexpr double kPortraitAspectLimit = 0.8;
   Q_INVOKABLE void search(const QString& title);
@@ -109,6 +114,7 @@ private:
   QByteArray m_gridKey;
   // Each provider is paced on its own, so the queue does not need a blanket pause between games.
   QElapsedTimer m_sinceGridRequest;
+  bool m_reviewedPortraits = false;
   QQueue<QVariantMap> m_queue;
   QVariantMap m_selected, m_active;
   QVariantList m_candidates, m_covers;

--- a/src/metadata/GameMetadata.h
+++ b/src/metadata/GameMetadata.h
@@ -5,6 +5,8 @@
 #include <QHash>
 #include <QNetworkAccessManager>
 #include <QElapsedTimer>
+#include <QAbstractItemModel>
+#include <QTimer>
 #include <QObject>
 #include <QQueue>
 #include <QSqlDatabase>
@@ -27,6 +29,9 @@ public:
                QObject* parent = nullptr, QNetworkAccessManager* network = nullptr);
   ~GameMetadata() override;
   void setLibrary(UnifiedGameModel* library);
+  // The filtered view the user is looking at. Games on screen are identified first, so opening
+  // a console fills it in rather than waiting for the rest of the library.
+  void setVisibleLibrary(QAbstractItemModel* visible);
   // Drops portraits that were downloaded over artwork the game's own source provides. Runs by
   // itself as the library settles, so a rule change reaches an existing library without anyone
   // being asked to run anything.
@@ -49,6 +54,8 @@ public:
   }
   Q_INVOKABLE void inspect(const QVariantMap& game);
   Q_INVOKABLE void refreshLibrary();
+  // Continues the library pass on its own: after the library settles, whenever games are added,
+  // and whenever the view changes. Stopping it by hand keeps it stopped until the next launch.
   // Identification depends on how titles are cleaned and how a match is accepted. Raise this
   // whenever those rules change: every entry decided by older rules is then re-identified on
   // the next update, instead of waiting out the ordinary freshness window with a stale answer.
@@ -115,6 +122,11 @@ private:
   // Each provider is paced on its own, so the queue does not need a blanket pause between games.
   QElapsedTimer m_sinceGridRequest;
   bool m_reviewedPortraits = false;
+  bool m_stoppedByHand = false;
+  QAbstractItemModel* m_visible = nullptr;
+  QTimer m_settle;
+  void continueLibraryPass();
+  void promoteVisibleGames();
   QQueue<QVariantMap> m_queue;
   QVariantMap m_selected, m_active;
   QVariantList m_candidates, m_covers;

--- a/src/metadata/GameMetadata.h
+++ b/src/metadata/GameMetadata.h
@@ -149,6 +149,10 @@ private:
   QHash<QByteArray, QByteArray> m_queryCache;
   QByteArray m_queryKey;
   QString m_igdbStage;
+  // A ROM set can number its files, as 1636 - Pokemon Fire Red. Searching for that finds
+  // nothing, so a failed search is tried once more without the number. Held here so a title
+  // that genuinely starts with a number is only ever searched for as written first.
+  QString m_numberedRetryTitle;
   bool m_cancelled = false;
   bool m_busy = false;
   bool m_manual = false;

--- a/src/metadata/GameMetadata.h
+++ b/src/metadata/GameMetadata.h
@@ -61,10 +61,17 @@ public:
   Q_INVOKABLE void refreshLibrary();
   // Continues the library pass on its own: after the library settles, whenever games are added,
   // and whenever the view changes. Stopping it by hand keeps it stopped until the next launch.
-  // Identification depends on how titles are cleaned and how a match is accepted. Raise this
-  // whenever those rules change: every entry decided by older rules is then re-identified on
-  // the next update, instead of waiting out the ordinary freshness window with a stale answer.
-  static constexpr int kMatchVersion = 2;
+  // Identification depends on how titles are cleaned, which platforms count, and how a match is
+  // accepted. Raise this whenever any of those change: every entry decided by older rules is
+  // then re-identified on the next update, instead of waiting out the ordinary freshness window
+  // with a stale answer. Forgetting leaves a library stuck on answers the rules would no longer
+  // give, so matchingRulesFingerprint below fails the build's tests until this is raised.
+  //   2  dump tags, sorted articles, tie-breaking between equal titles
+  //   3  regional platforms, accents, publisher prefixes, catalogue numbers
+  static constexpr int kMatchVersion = 3;
+  // Everything the identification rules depend on, folded into one value. A test pins it, so a
+  // change to any rule fails until kMatchVersion is raised alongside it.
+  [[nodiscard]] static QByteArray matchingRulesFingerprint();
   // How long a rating stays fresh before it is fetched again.
   static constexpr qint64 kRatingFreshnessSeconds = 30 * 86400;
   // True when a stored entry should be identified again: either the rules that decided it have

--- a/src/metadata/GameMetadata.h
+++ b/src/metadata/GameMetadata.h
@@ -6,6 +6,7 @@
 #include <QNetworkAccessManager>
 #include <QElapsedTimer>
 #include <QAbstractItemModel>
+#include <QSet>
 #include <QTimer>
 #include <QObject>
 #include <QQueue>
@@ -65,6 +66,11 @@ public:
   // True when a stored entry should be identified again: either the rules that decided it have
   // changed, or its rating has simply aged out.
   [[nodiscard]] static bool needsIdentifying(const QVariantMap& saved, qint64 now);
+  // The order games are identified in. Anything on screen comes first, and the rest is taken a
+  // system at a time in turn, so a shelf of 1,387 SNES ROMs cannot starve the eight N64 games
+  // behind it. Pure so the ordering can be tested without a network.
+  [[nodiscard]] static QList<QVariantMap> orderForIdentification(const QList<QVariantMap>& games,
+                                                                 const QSet<QString>& onScreen);
   // A downloaded portrait replaces the artwork a game already has, so it is only worth
   // fetching when that artwork is missing or cannot serve as a cover. Takes the system and the
   // path to the source's own art.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -456,6 +456,23 @@ set_tests_properties(omakade_artwork_editor omakade_artwork_editor_couch
   ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1;HYPRLAND_INSTANCE_SIGNATURE="
   TIMEOUT 30)
 
+# Narrowing the library leaves the grid holding delegates for the games that just left. Moving
+# down from the organize row must reach the game on screen, never one of those.
+add_test(NAME omakade_stale_selection
+  COMMAND omakade --stale-selection-test --owned-layout-test --render-size=1600x900)
+set_tests_properties(omakade_stale_selection PROPERTIES
+  ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1;HYPRLAND_INSTANCE_SIGNATURE="
+  TIMEOUT 30)
+
+# Back walks out of a console, then a search, then a source, then anything else narrowing the
+# view, in both Desktop and Couch Mode.
+add_test(NAME omakade_filter_back COMMAND omakade --filter-back-test --render-size=1600x900)
+add_test(NAME omakade_filter_back_couch
+  COMMAND omakade --filter-back-test --couch --render-size=1920x1080)
+set_tests_properties(omakade_filter_back omakade_filter_back_couch PROPERTIES
+  ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1;HYPRLAND_INSTANCE_SIGNATURE="
+  TIMEOUT 30)
+
 add_test(NAME omakade_random_selection COMMAND omakade --random-selection-test)
 add_test(NAME omakade_random_selection_couch COMMAND omakade --random-selection-test --couch)
 add_test(NAME omakade_random_selection_render COMMAND omakade

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -6825,18 +6825,32 @@ void CoreTests::metadataMatchingKeepsPlatformsAndEditions() {
   QVERIFY(GameMetadata::normalizedTitle("Super Mario World") != GameMetadata::normalizedTitle("Super \"Mario\" World"));
   QVERIFY(!GameMetadata::searchQuery("Super Mario World (USA)", "snes").contains("USA"));
   QVERIFY(GameMetadata::searchQuery("Mario", "unknown-console").isEmpty());
+  // A Japanese release is catalogued under its own machine, so both are searched.
+  QVERIFY(GameMetadata::searchQuery("Alcahest", "snes").contains("platforms = (19,58)"));
+  QCOMPARE(GameMetadata::platformIds("snes"), QList<int>({19, 58}));
+  QVERIFY(GameMetadata::platformIds("unknown-console").isEmpty());
   QVERIFY(GameMetadata::searchQuery("Mario", "gamecube").contains("platforms = (21)"));
   const auto matches = GameMetadata::parseMatches(R"json([
     {"id":1,"name":"Metroid Prime","platforms":[21],"total_rating":89.5,"total_rating_count":300},
     {"id":2,"name":"Metroid Prime Remastered","platforms":[130],"total_rating":94,"total_rating_count":90},
     {"id":3,"name":"Unrated","platforms":[21]},
     {"id":4,"name":"Bad rating","platforms":[21],"total_rating":999,"total_rating_count":1},
-    {"id":0,"name":"Invalid","platforms":[21]}])json",21);
+    {"id":0,"name":"Invalid","platforms":[21]}])json", QList<int>{21});
   QCOMPARE(matches.size(),3);
   QCOMPARE(matches.at(0).toMap().value("rating").toInt(),90);
   QCOMPARE(matches.at(1).toMap().value("rating").toInt(),-1);
   QCOMPARE(matches.at(2).toMap().value("rating").toInt(),-1);
-  QVERIFY(GameMetadata::parseMatches("{broken",21).isEmpty());
+  QVERIFY(GameMetadata::parseMatches("{broken", QList<int>{21}).isEmpty());
+  // A Super Famicom listing is the same cartridge as its Super Nintendo release.
+  const auto regional = GameMetadata::parseMatches(
+      R"json([{"id":9,"name":"Alcahest","platforms":[58]}])json", QList<int>{19, 58});
+  QCOMPARE(regional.size(), 1);
+  QVERIFY(GameMetadata::parseMatches(
+              R"json([{"id":9,"name":"Alcahest","platforms":[58]}])json", QList<int>{19})
+          .isEmpty());
+  // Accents and a publisher in front of a licensed title are not different games.
+  QCOMPARE(GameMetadata::normalizedTitle("Pokemon Stadium 2"),
+           GameMetadata::normalizedTitle("Pokémon Stadium 2"));
   const auto covers = GameMetadata::parseCovers(R"json({"success":true,"data":[
     {"id":1,"width":600,"height":900,"url":"https://cdn2.steamgriddb.com/grid/good.png"},
     {"id":2,"width":512,"height":512,"url":"https://cdn2.steamgriddb.com/grid/square.png"},

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -6665,6 +6665,34 @@ void CoreTests::metadataMatchingKeepsPlatformsAndEditions() {
                    {"updated", now - GameMetadata::kRatingFreshnessSeconds - 1}};
   QVERIFY(GameMetadata::needsIdentifying(aged, now));
 
+  // A small system must not sit behind a large one. Games on screen come first, then the rest
+  // is taken a system at a time in turn, so eight N64 games are reached immediately rather than
+  // after 1,387 SNES ROMs.
+  QList<QVariantMap> waiting;
+  for (int i = 0; i < 6; ++i)
+    waiting.append({{"metadataKey", QStringLiteral("snes-%1").arg(i)}, {"system", "snes"}});
+  waiting.append({{"metadataKey", "n64-0"}, {"system", "n64"}});
+  waiting.append({{"metadataKey", "n64-1"}, {"system", "n64"}});
+  waiting.append({{"metadataKey", "dc-0"}, {"system", "dreamcast"}});
+  const auto ordered = GameMetadata::orderForIdentification(waiting, {QStringLiteral("snes-4")});
+  QCOMPARE(ordered.size(), waiting.size());
+  // What is on screen is identified first.
+  QCOMPARE(ordered.at(0).value("metadataKey").toString(), QStringLiteral("snes-4"));
+  // Then one game per system in turn, so no system waits for another to finish.
+  QCOMPARE(ordered.at(1).value("system").toString(), QStringLiteral("snes"));
+  QCOMPARE(ordered.at(2).value("system").toString(), QStringLiteral("n64"));
+  QCOMPARE(ordered.at(3).value("system").toString(), QStringLiteral("dreamcast"));
+  QCOMPARE(ordered.at(4).value("system").toString(), QStringLiteral("snes"));
+  QCOMPARE(ordered.at(5).value("system").toString(), QStringLiteral("n64"));
+  // Both N64 games and the Dreamcast game are reached well before the SNES shelf finishes.
+  int lastSnes = 0;
+  for (int i = 0; i < ordered.size(); ++i)
+    if (ordered.at(i).value("system").toString() == QStringLiteral("snes"))
+      lastSnes = i;
+  for (int i = 0; i < ordered.size(); ++i)
+    if (ordered.at(i).value("system").toString() != QStringLiteral("snes"))
+      QVERIFY(i < lastSnes);
+
   // A downloaded portrait replaces whatever artwork a game already has, so it is only worth
   // fetching when that artwork is missing or cannot serve as a cover.
   QTemporaryDir artwork;

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -6589,6 +6589,32 @@ void CoreTests::consoleLayoutsPinAndExpand() {
 
 void CoreTests::metadataMatchingKeepsPlatformsAndEditions() {
   QCOMPARE(GameMetadata::normalizedTitle("Chrono Trigger (USA)"), QStringLiteral("chrono trigger"));
+  // ROM sets tag every dump. None of it reaches IGDB, so none of it may reach the comparison.
+  const QString zelda = QStringLiteral("legend of zelda a link to the past");
+  QCOMPARE(GameMetadata::normalizedTitle("Tetris Attack (NA)"), QStringLiteral("tetris attack"));
+  QCOMPARE(GameMetadata::normalizedTitle("Star Fox (EU, Rev 1)"), QStringLiteral("star fox"));
+  QCOMPARE(GameMetadata::normalizedTitle("Super Goal! 2 (JP, Rev 1.01)"), QStringLiteral("super goal 2"));
+  QCOMPARE(GameMetadata::normalizedTitle("Donkey Kong Country (NA) [!]"), QStringLiteral("donkey kong country"));
+  QCOMPARE(GameMetadata::normalizedTitle("90 Minutes (NTSC Conversion)"), QStringLiteral("90 minutes"));
+  QCOMPARE(GameMetadata::normalizedTitle("Mega Man X3 (Prototype - NTSC Conversion)"), QStringLiteral("mega man x3"));
+  QCOMPARE(GameMetadata::normalizedTitle("A Bug's Life (TW)"), QStringLiteral("bug s life"));
+  // A translation note runs to any number of clauses and is still just dump metadata.
+  QCOMPARE(GameMetadata::normalizedTitle(
+               "Slayers (English Translated by Dynamic Designs and Matt's Messy Room, Rev 1.01)"),
+           QStringLiteral("slayers"));
+  QCOMPARE(GameMetadata::normalizedTitle(
+               "Cyber Knight (English Translated by Aeon Genesis, Rev 1.01 With Fixes by MTeam)"),
+           QStringLiteral("cyber knight"));
+  // A sorted article matches the way the catalogue writes it, before or without a subtitle.
+  QCOMPARE(GameMetadata::normalizedTitle("Legend of Zelda, The - A Link to the Past (NA)"), zelda);
+  QCOMPARE(GameMetadata::normalizedTitle("The Legend of Zelda: A Link to the Past"), zelda);
+  QCOMPARE(GameMetadata::normalizedTitle("Lion King, The (NA)"), QStringLiteral("lion king"));
+  // Editions, remasters and real subtitles are not dump tags and stay in the title.
+  QCOMPARE(GameMetadata::normalizedTitle("Sonic 3 (& Knuckles)"), QStringLiteral("sonic 3 knuckles"));
+  QVERIFY(GameMetadata::normalizedTitle("Alan Wake (Remastered)").contains("remastered"));
+  QVERIFY(GameMetadata::normalizedTitle("Persona 3 Reload (Digital Deluxe Edition)").contains("deluxe"));
+  QVERIFY(GameMetadata::normalizedTitle("Runner2 (Future Legend of Rhythm Alien)").contains("rhythm alien"));
+  QCOMPARE(GameMetadata::normalizedTitle("Prototype 2"), QStringLiteral("prototype 2"));
   QVERIFY(GameMetadata::normalizedTitle("Metroid Prime") != GameMetadata::normalizedTitle("Metroid Prime Remastered"));
   QVERIFY(GameMetadata::normalizedTitle("Final Fantasy VII") != GameMetadata::normalizedTitle("Final Fantasy VIII"));
   QVERIFY(GameMetadata::normalizedTitle("Super Mario World") != GameMetadata::normalizedTitle("Super \"Mario\" World"));

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -3503,12 +3503,14 @@ void CoreTests::retroArchLauncherBuildsSafeCommands() {
   const QString core = QStringLiteral("/cores/genesis_plus_gx_libretro.so");
   const LaunchCommand native = GameLauncher::retroArchCommand(content, core, false);
   QCOMPARE(native.program, QStringLiteral("retroarch"));
-  QCOMPARE(native.arguments, QStringList({QStringLiteral("-L"), core, content}));
+  // A game started from a launcher fills the screen, whatever the emulator is set to.
+  QCOMPARE(native.arguments,
+           QStringList({QStringLiteral("--fullscreen"), QStringLiteral("-L"), core, content}));
   const LaunchCommand flatpak = GameLauncher::retroArchCommand(content, core, true);
   QCOMPARE(flatpak.program, QStringLiteral("flatpak"));
   QCOMPARE(flatpak.arguments,
            QStringList({QStringLiteral("run"), QStringLiteral("org.libretro.RetroArch"),
-                        QStringLiteral("-L"), core, content}));
+                        QStringLiteral("--fullscreen"), QStringLiteral("-L"), core, content}));
   QVERIFY(!GameLauncher::retroArchCommand(content, QStringLiteral("DETECT"), false).isValid());
   QVERIFY(!GameLauncher::retroArchCommand({}, core, false).isValid());
   const LaunchCommand playlist =
@@ -5267,7 +5269,8 @@ void CoreTests::pcsx2LauncherBuildsSafeCommands() {
   const LaunchCommand native =
       GameLauncher::pcsx2Command(QStringLiteral("path:/games/Crash.iso"), false, false);
   QCOMPARE(native.program, QStringLiteral("pcsx2-qt"));
-  QCOMPARE(native.arguments, QStringList({QStringLiteral("/games/Crash.iso")}));
+  QCOMPARE(native.arguments,
+           QStringList({QStringLiteral("-fullscreen"), QStringLiteral("/games/Crash.iso")}));
   const LaunchCommand flatpak =
       GameLauncher::pcsx2Command(QStringLiteral("path:/games/Crash.iso"), false, true);
   QCOMPARE(flatpak.program, QStringLiteral("flatpak"));
@@ -5276,8 +5279,8 @@ void CoreTests::pcsx2LauncherBuildsSafeCommands() {
   // ELF entries must receive -elf <file>.
   const LaunchCommand elf =
       GameLauncher::pcsx2Command(QStringLiteral("path:/games/homebrew.elf"), true, false);
-  QCOMPARE(elf.arguments,
-           QStringList({QStringLiteral("-elf"), QStringLiteral("/games/homebrew.elf")}));
+  QCOMPARE(elf.arguments, QStringList({QStringLiteral("-fullscreen"), QStringLiteral("-elf"),
+                                       QStringLiteral("/games/homebrew.elf")}));
   QVERIFY(!GameLauncher::pcsx2Command(QStringLiteral("bad;id"), false, false).isValid());
 }
 
@@ -5600,8 +5603,9 @@ void CoreTests::shadps4LauncherBuildsSafeCommands() {
   const LaunchCommand native = GameLauncher::shadps4Command(
       QStringLiteral("/games/CUSA00001/eboot.bin"), QStringLiteral("shadps4"));
   QCOMPARE(native.program, QStringLiteral("shadps4"));
-  QCOMPARE(native.arguments, QStringList({QStringLiteral("-g"),
-                                          QStringLiteral("/games/CUSA00001/eboot.bin")}));
+  QCOMPARE(native.arguments,
+           QStringList({QStringLiteral("-f"), QStringLiteral("true"), QStringLiteral("-g"),
+                        QStringLiteral("/games/CUSA00001/eboot.bin")}));
   const LaunchCommand flatpak = GameLauncher::shadps4Command(
       QStringLiteral("/games/CUSA00001/eboot.bin"), {}, QStringLiteral("net.shadps4.shadPS4"));
   QCOMPARE(flatpak.program, QStringLiteral("flatpak"));
@@ -5899,7 +5903,8 @@ void CoreTests::cartridgeLaunchResolverPrefersPlaylistCoreThenStandalone() {
       QStringLiteral("/usr/lib/libretro/snes9x_libretro.so"));
   QCOMPARE(playlist.program, QStringLiteral("retroarch"));
   QCOMPARE(playlist.arguments,
-           QStringList({QStringLiteral("-L"), QStringLiteral("/cores/snes9x_libretro.so"), rom}));
+           QStringList({QStringLiteral("--fullscreen"), QStringLiteral("-L"),
+                        QStringLiteral("/cores/snes9x_libretro.so"), rom}));
 
   const LaunchCommand standalone = GameLauncher::resolvedCartridgeCommand(
       rom, {}, false, true, QStringLiteral("snes9x"),
@@ -5912,7 +5917,7 @@ void CoreTests::cartridgeLaunchResolverPrefersPlaylistCoreThenStandalone() {
       QStringLiteral("/usr/lib/libretro/snes9x_libretro.so"));
   QCOMPARE(mapped.program, QStringLiteral("retroarch"));
   QCOMPARE(mapped.arguments,
-           QStringList({QStringLiteral("-L"),
+           QStringList({QStringLiteral("--fullscreen"), QStringLiteral("-L"),
                         QStringLiteral("/usr/lib/libretro/snes9x_libretro.so"), rom}));
 
   const LaunchCommand fallback = GameLauncher::resolvedCartridgeCommand(
@@ -5970,8 +5975,8 @@ void CoreTests::cemuLauncherBuildsSafeCommands() {
   const LaunchCommand native =
       GameLauncher::cemuCommand(QStringLiteral("/games/mario.rpx"), false);
   QCOMPARE(native.program, QStringLiteral("cemu"));
-  QCOMPARE(native.arguments,
-           QStringList({QStringLiteral("-g"), QStringLiteral("/games/mario.rpx")}));
+  QCOMPARE(native.arguments, QStringList({QStringLiteral("--fullscreen"), QStringLiteral("-g"),
+                                          QStringLiteral("/games/mario.rpx")}));
   const LaunchCommand flatpak =
       GameLauncher::cemuCommand(QStringLiteral("/games/mario.wua"), true);
   QCOMPARE(flatpak.program, QStringLiteral("flatpak"));
@@ -6412,7 +6417,8 @@ void CoreTests::dolphinScannerReadsDiscHeadersAndLaunches() {
 
   const LaunchCommand native = GameLauncher::dolphinCommand(byId.value("GZLE01").path, QStringLiteral("dolphin-emu"), false);
   QCOMPARE(native.program, QStringLiteral("dolphin-emu"));
-  QCOMPARE(native.arguments, (QStringList{QStringLiteral("-b"), QStringLiteral("-e"), byId.value("GZLE01").path}));
+  QCOMPARE(native.arguments, (QStringList{QStringLiteral("-C"), QStringLiteral("Dolphin.Display.Fullscreen=True"),
+                        QStringLiteral("-b"), QStringLiteral("-e"), byId.value("GZLE01").path}));
   const LaunchCommand flatpak = GameLauncher::dolphinCommand(QStringLiteral("path:") + byId.value("RMCE01").path, QString{}, true);
   QCOMPARE(flatpak.program, QStringLiteral("flatpak"));
   QCOMPARE(flatpak.arguments.first(), QStringLiteral("run"));
@@ -6476,7 +6482,7 @@ void CoreTests::dreamcastFoldersBecomeAPortal() {
       roms.data(roms.index(0), GameRoles::InstallPath).toString(), QString{}, false, false, QString{},
       QStringLiteral("/usr/lib/libretro/flycast_libretro.so"));
   QCOMPARE(command.program, QStringLiteral("retroarch"));
-  QCOMPARE(command.arguments.at(1), QStringLiteral("/usr/lib/libretro/flycast_libretro.so"));
+  QCOMPARE(command.arguments.at(2), QStringLiteral("/usr/lib/libretro/flycast_libretro.so"));
 }
 
 void CoreTests::consoleLayoutsPinAndExpand() {

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -6750,6 +6750,12 @@ void CoreTests::metadataMatchingKeepsPlatformsAndEditions() {
   QCOMPARE(GameMetadata::normalizedTitle("Super Mario All-Stars (NA)"),
            QStringLiteral("super mario all stars"));
 
+  // Every identification rule folded into one value. If this fails, a rule changed: raise
+  // GameMetadata::kMatchVersion alongside it and update this expectation, or every library
+  // already out there stays on answers the rules would no longer give.
+  QCOMPARE(GameMetadata::matchingRulesFingerprint(), QByteArray("506f0b8fef280446"));
+  QCOMPARE(GameMetadata::kMatchVersion, 3);
+
   // An entry decided by older matching rules is stale however recently it was written, so a
   // matching fix reaches an existing library on the next update instead of a month later.
   const qint64 now = 1788700000;

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -6644,18 +6644,21 @@ void CoreTests::metadataMatchingKeepsPlatformsAndEditions() {
   const QString boxScan = write("snes.png", 700, 500);       // a wide SNES box scan
   QVERIFY(!capsule.isEmpty() && !icon.isEmpty() && !boxScan.isEmpty());
   // Official portrait artwork is never replaced, whether it arrives as a path or a file URL.
-  QVERIFY(!GameMetadata::wantsPortraitCover("", capsule));
-  QVERIFY(!GameMetadata::wantsPortraitCover("", QUrl::fromLocalFile(capsule).toString()));
+  QVERIFY(!GameMetadata::wantsPortraitCover("", "GOG", capsule));
+  QVERIFY(!GameMetadata::wantsPortraitCover("", "GOG", QUrl::fromLocalFile(capsule).toString()));
+  // Steam guarantees an official capsule, so it never takes fan art even before that capsule
+  // has downloaded.
+  QVERIFY(!GameMetadata::wantsPortraitCover("", "Steam", ""));
   // A square icon crops a logo off the card, so those games may take a portrait.
-  QVERIFY(GameMetadata::wantsPortraitCover("switch", icon));
-  QVERIFY(GameMetadata::wantsPortraitCover("ps4", icon));
+  QVERIFY(GameMetadata::wantsPortraitCover("switch", "Ryujinx", icon));
+  QVERIFY(GameMetadata::wantsPortraitCover("ps4", "shadPS4", icon));
   // Retro consoles keep their authentic box art even though it is the wrong shape.
-  QVERIFY(!GameMetadata::wantsPortraitCover("snes", boxScan));
-  QVERIFY(!GameMetadata::wantsPortraitCover("Nintendo - Super Nintendo Entertainment System", boxScan));
-  QVERIFY(!GameMetadata::wantsPortraitCover("gamecube", ""));
+  QVERIFY(!GameMetadata::wantsPortraitCover("snes", "RetroArch", boxScan));
+  QVERIFY(!GameMetadata::wantsPortraitCover("Nintendo - Super Nintendo Entertainment System", "RetroArch", boxScan));
+  QVERIFY(!GameMetadata::wantsPortraitCover("gamecube", "Dolphin", ""));
   // A game with no artwork at all has nothing to lose.
-  QVERIFY(GameMetadata::wantsPortraitCover("", ""));
-  QVERIFY(GameMetadata::wantsPortraitCover("", artwork.filePath("missing.png")));
+  QVERIFY(GameMetadata::wantsPortraitCover("", "Lutris", ""));
+  QVERIFY(GameMetadata::wantsPortraitCover("", "Lutris", artwork.filePath("missing.png")));
   QVERIFY(GameMetadata::normalizedTitle("Metroid Prime") != GameMetadata::normalizedTitle("Metroid Prime Remastered"));
   QVERIFY(GameMetadata::normalizedTitle("Final Fantasy VII") != GameMetadata::normalizedTitle("Final Fantasy VIII"));
   QVERIFY(GameMetadata::normalizedTitle("Super Mario World") != GameMetadata::normalizedTitle("Super \"Mario\" World"));

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -138,6 +138,62 @@ private:
   QString m_coverPath;
 };
 
+// A source that can rescan and find the same games, or find more, so the library's reaction to
+// each can be held to what it should be.
+class RescanningSourceModel final : public QAbstractListModel {
+public:
+  explicit RescanningSourceModel(int games) : m_games(games) {}
+  [[nodiscard]] int rowCount(const QModelIndex& parent = QModelIndex()) const override {
+    return parent.isValid() ? 0 : m_games;
+  }
+  [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override {
+    if (!index.isValid() || index.row() >= m_games)
+      return {};
+    switch (role) {
+    case GameRoles::Title:
+      return QStringLiteral("Game %1").arg(index.row());
+    case GameRoles::Source:
+      return QStringLiteral("Rescanning");
+    case GameRoles::Runner:
+      return QString{};
+    case GameRoles::AppId:
+      return QStringLiteral("game-%1").arg(index.row());
+    case GameRoles::Installed:
+      return true;
+    default:
+      return {};
+    }
+  }
+  [[nodiscard]] QHash<int, QByteArray> roleNames() const override {
+    return {{GameRoles::Title, "title"},
+            {GameRoles::Source, "source"},
+            {GameRoles::Runner, "runner"},
+            {GameRoles::AppId, "appId"},
+            {GameRoles::Installed, "installed"}};
+  }
+  // A scan that finished and found exactly what was already there.
+  void rescanFindingNothingNew() {
+    beginResetModel();
+    endResetModel();
+  }
+  // A scan that finished and found more games.
+  void grow(int extra) {
+    beginResetModel();
+    m_games += extra;
+    endResetModel();
+  }
+  void loseFirstGame() {
+    beginResetModel();
+    --m_games;
+    ++m_offset;
+    endResetModel();
+  }
+
+private:
+  int m_games = 0;
+  int m_offset = 0;
+};
+
 class DelayedSteamModel final : public QAbstractListModel {
 public:
   [[nodiscard]] int rowCount(const QModelIndex& parent = QModelIndex()) const override {
@@ -755,6 +811,7 @@ private slots:
   void consoleLayoutsPinAndExpand();
   void metadataMatchingKeepsPlatformsAndEditions();
   void coverCacheDecodesArtworkOnce();
+  void libraryOnlyResetsWhenGamesActuallyMove();
   void coverSizesPersistIndependently();
   void controllerNavigationFollowsWindowFocus();
   void metadataPersistsRatingsAndPreservesCustomArt();
@@ -6587,6 +6644,40 @@ void CoreTests::consoleLayoutsPinAndExpand() {
   cubes.refreshFromRoots({dolphinRoot});
   QCOMPARE(count("Dolphin"), 2);
   QCOMPARE(portalCount(), 0);
+}
+
+void CoreTests::libraryOnlyResetsWhenGamesActuallyMove() {
+  QTemporaryDir temp;
+  RescanningSourceModel source(4);
+  UnifiedGameModel library(temp.filePath("library.sqlite3"));
+  library.addSourceModel(&source);
+  QCOMPARE(library.rowCount(), 4);
+
+  QSignalSpy resets(&library, &QAbstractItemModel::modelReset);
+  QSignalSpy inserted(&library, &QAbstractItemModel::rowsInserted);
+
+  // Nine sources scan on startup and most find exactly what was already there. A reset throws
+  // away every card on screen along with its artwork, so a scan that changed nothing must say
+  // nothing. This is what made the grid blink repeatedly through startup.
+  for (int scan = 0; scan < 5; ++scan)
+    source.rescanFindingNothingNew();
+  QCOMPARE(resets.count(), 0);
+  QCOMPARE(inserted.count(), 0);
+  QCOMPARE(library.rowCount(), 4);
+
+  // A source that finished scanning and found more games appends them, keeping the cards that
+  // are already on screen.
+  source.grow(3);
+  QCOMPARE(resets.count(), 0);
+  QCOMPARE(inserted.count(), 1);
+  QCOMPARE(library.rowCount(), 7);
+  QCOMPARE(inserted.first().at(1).toInt(), 4);
+  QCOMPARE(inserted.first().at(2).toInt(), 6);
+
+  // A reset is still correct when games genuinely move or disappear.
+  source.loseFirstGame();
+  QCOMPARE(resets.count(), 1);
+  QCOMPARE(library.rowCount(), 6);
 }
 
 void CoreTests::coverCacheDecodesArtworkOnce() {

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -6629,6 +6629,33 @@ void CoreTests::metadataMatchingKeepsPlatformsAndEditions() {
   QVariantMap aged{{"matchVersion", GameMetadata::kMatchVersion},
                    {"updated", now - GameMetadata::kRatingFreshnessSeconds - 1}};
   QVERIFY(GameMetadata::needsIdentifying(aged, now));
+
+  // A downloaded portrait replaces whatever artwork a game already has, so it is only worth
+  // fetching when that artwork is missing or cannot serve as a cover.
+  QTemporaryDir artwork;
+  const auto write = [&artwork](const QString& name, int width, int height) {
+    QImage image(width, height, QImage::Format_RGB32);
+    image.fill(Qt::darkCyan);
+    const QString path = artwork.filePath(name);
+    return image.save(path) ? path : QString{};
+  };
+  const QString capsule = write("steam.jpg", 600, 900);      // Steam's official library capsule
+  const QString icon = write("switch.png", 1024, 1024);      // a Switch dump's square icon
+  const QString boxScan = write("snes.png", 700, 500);       // a wide SNES box scan
+  QVERIFY(!capsule.isEmpty() && !icon.isEmpty() && !boxScan.isEmpty());
+  // Official portrait artwork is never replaced, whether it arrives as a path or a file URL.
+  QVERIFY(!GameMetadata::wantsPortraitCover("", capsule));
+  QVERIFY(!GameMetadata::wantsPortraitCover("", QUrl::fromLocalFile(capsule).toString()));
+  // A square icon crops a logo off the card, so those games may take a portrait.
+  QVERIFY(GameMetadata::wantsPortraitCover("switch", icon));
+  QVERIFY(GameMetadata::wantsPortraitCover("ps4", icon));
+  // Retro consoles keep their authentic box art even though it is the wrong shape.
+  QVERIFY(!GameMetadata::wantsPortraitCover("snes", boxScan));
+  QVERIFY(!GameMetadata::wantsPortraitCover("Nintendo - Super Nintendo Entertainment System", boxScan));
+  QVERIFY(!GameMetadata::wantsPortraitCover("gamecube", ""));
+  // A game with no artwork at all has nothing to lose.
+  QVERIFY(GameMetadata::wantsPortraitCover("", ""));
+  QVERIFY(GameMetadata::wantsPortraitCover("", artwork.filePath("missing.png")));
   QVERIFY(GameMetadata::normalizedTitle("Metroid Prime") != GameMetadata::normalizedTitle("Metroid Prime Remastered"));
   QVERIFY(GameMetadata::normalizedTitle("Final Fantasy VII") != GameMetadata::normalizedTitle("Final Fantasy VIII"));
   QVERIFY(GameMetadata::normalizedTitle("Super Mario World") != GameMetadata::normalizedTitle("Super \"Mario\" World"));

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -11,6 +11,7 @@
 #include "achievements/SteamAchievementApi.h"
 #include "app/AppSettings.h"
 #include "artwork/SwitchTitleReader.h"
+#include "artwork/CoverImageProvider.h"
 #include "artwork/TgaImage.h"
 #include "artwork/ZArchiveReader.h"
 #include "backup/BackupArchive.h"
@@ -753,6 +754,7 @@ private slots:
   void dreamcastFoldersBecomeAPortal();
   void consoleLayoutsPinAndExpand();
   void metadataMatchingKeepsPlatformsAndEditions();
+  void coverCacheDecodesArtworkOnce();
   void coverSizesPersistIndependently();
   void controllerNavigationFollowsWindowFocus();
   void metadataPersistsRatingsAndPreservesCustomArt();
@@ -6585,6 +6587,39 @@ void CoreTests::consoleLayoutsPinAndExpand() {
   cubes.refreshFromRoots({dolphinRoot});
   QCOMPARE(count("Dolphin"), 2);
   QCOMPARE(portalCount(), 0);
+}
+
+void CoreTests::coverCacheDecodesArtworkOnce() {
+  QTemporaryDir temp;
+  const QString path = temp.filePath("cover.png");
+  QImage art(600, 900, QImage::Format_RGB32);
+  art.fill(Qt::darkMagenta);
+  QVERIFY(art.save(path));
+
+  CoverImageProvider provider(16);
+  QSize produced;
+  const QSize wanted(128, 192);
+  const QImage first = provider.requestImage("f" + path, &produced, wanted);
+  QVERIFY(!first.isNull());
+  QCOMPARE(provider.misses(), 1);
+  QCOMPARE(provider.hits(), 0);
+  // Artwork is decoded to the size the card asked for, keeping its proportions.
+  QCOMPARE(first.size(), QSize(128, 192));
+
+  // The same card asking again is served from memory. Without this a library of any size read
+  // every cover from disk again on each scroll and filter change.
+  const QImage again = provider.requestImage("f" + path, &produced, wanted);
+  QCOMPARE(again, first);
+  QCOMPARE(provider.misses(), 1);
+  QCOMPARE(provider.hits(), 1);
+
+  // A different size is different artwork to a card, so it is decoded on its own.
+  provider.requestImage("f" + path, &produced, QSize(256, 384));
+  QCOMPARE(provider.misses(), 2);
+
+  // Anything that is not marked as a file or as bundled art is refused rather than guessed at.
+  QVERIFY(provider.requestImage("http://example.com/cover.png", &produced, wanted).isNull());
+  QVERIFY(provider.requestImage("f" + temp.filePath("missing.png"), &produced, wanted).isNull());
 }
 
 void CoreTests::metadataMatchingKeepsPlatformsAndEditions() {

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -6615,6 +6615,20 @@ void CoreTests::metadataMatchingKeepsPlatformsAndEditions() {
   QVERIFY(GameMetadata::normalizedTitle("Persona 3 Reload (Digital Deluxe Edition)").contains("deluxe"));
   QVERIFY(GameMetadata::normalizedTitle("Runner2 (Future Legend of Rhythm Alien)").contains("rhythm alien"));
   QCOMPARE(GameMetadata::normalizedTitle("Prototype 2"), QStringLiteral("prototype 2"));
+  QCOMPARE(GameMetadata::normalizedTitle("Super Mario All-Stars (NA)"),
+           QStringLiteral("super mario all stars"));
+
+  // An entry decided by older matching rules is stale however recently it was written, so a
+  // matching fix reaches an existing library on the next update instead of a month later.
+  const qint64 now = 1788700000;
+  QVariantMap current{{"matchVersion", GameMetadata::kMatchVersion}, {"updated", now - 60}};
+  QVERIFY(!GameMetadata::needsIdentifying(current, now));
+  QVariantMap olderRules{{"matchVersion", GameMetadata::kMatchVersion - 1}, {"updated", now - 60}};
+  QVERIFY(GameMetadata::needsIdentifying(olderRules, now));
+  QVERIFY(GameMetadata::needsIdentifying(QVariantMap{{"updated", now - 60}}, now));
+  QVariantMap aged{{"matchVersion", GameMetadata::kMatchVersion},
+                   {"updated", now - GameMetadata::kRatingFreshnessSeconds - 1}};
+  QVERIFY(GameMetadata::needsIdentifying(aged, now));
   QVERIFY(GameMetadata::normalizedTitle("Metroid Prime") != GameMetadata::normalizedTitle("Metroid Prime Remastered"));
   QVERIFY(GameMetadata::normalizedTitle("Final Fantasy VII") != GameMetadata::normalizedTitle("Final Fantasy VIII"));
   QVERIFY(GameMetadata::normalizedTitle("Super Mario World") != GameMetadata::normalizedTitle("Super \"Mario\" World"));

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -6806,10 +6806,17 @@ void CoreTests::metadataMatchingKeepsPlatformsAndEditions() {
   // A square icon crops a logo off the card, so those games may take a portrait.
   QVERIFY(GameMetadata::wantsPortraitCover("switch", "Ryujinx", icon));
   QVERIFY(GameMetadata::wantsPortraitCover("ps4", "shadPS4", icon));
-  // Retro consoles keep their authentic box art even though it is the wrong shape.
-  QVERIFY(!GameMetadata::wantsPortraitCover("snes", "RetroArch", boxScan));
-  QVERIFY(!GameMetadata::wantsPortraitCover("Nintendo - Super Nintendo Entertainment System", "RetroArch", boxScan));
-  QVERIFY(!GameMetadata::wantsPortraitCover("gamecube", "Dolphin", ""));
+  // A box printed wide cannot fill a card, so those take a portrait whatever system they are.
+  QVERIFY(GameMetadata::wantsPortraitCover("snes", "RetroArch", boxScan));
+  QVERIFY(GameMetadata::wantsPortraitCover("n64", "RetroArch", boxScan));
+  QVERIFY(GameMetadata::wantsPortraitCover("dreamcast", "RetroArch", icon));
+  // A box printed portrait already works as a cover and is authentic, so it is kept. NES boxes
+  // and GameTDB covers are both this shape.
+  const QString nesBox = write("nes.png", 640, 880);
+  QVERIFY(!nesBox.isEmpty());
+  QVERIFY(!GameMetadata::wantsPortraitCover("nes", "RetroArch", nesBox));
+  QVERIFY(!GameMetadata::wantsPortraitCover("Nintendo - Nintendo Entertainment System", "RetroArch", nesBox));
+  QVERIFY(!GameMetadata::wantsPortraitCover("gamecube", "Dolphin", capsule));
   // A game with no artwork at all has nothing to lose.
   QVERIFY(GameMetadata::wantsPortraitCover("", "Lutris", ""));
   QVERIFY(GameMetadata::wantsPortraitCover("", "Lutris", artwork.filePath("missing.png")));


### PR DESCRIPTION
Stacked on #36. Everything here was written today in response to testing, and several commits are fixes for regressions introduced by earlier commits in this same branch. That history is worth knowing while reviewing: the end state is tested, but it was not arrived at cleanly.

## Rendering and loading

- The combined library rebuilt itself with a full model reset on any signal from any of nine sources, even when the result was identical. Measured over thirty seconds of startup on a 1,464 game library: 26 full resets, 18 of them changing nothing. Now nothing is emitted when unchanged, games added are appended, and a reset is kept for games genuinely moving. A test holds this.
- Card delegates decoded their artwork twice, once at full size before layout gave them a size. 8,478 image loads became 5,604 over the same window.
- Covers are decoded once and kept in a bounded 128 MB cache, since Qt keeps roughly twenty. Measured: 136 decoded from disk, 1,071 served from memory, none decoded twice.

## Identification

Four separate faults, found in this order:

1. Four services read credentials from the keyring on separate worker threads at startup. libsecret builds its GObject types on first use and two threads racing corrupts the registration, so every lookup afterwards failed and no credential loaded. Keyring calls are serialised.
2. The pass waited on the library's change signals, but sources that load from their own database had already filled it, so the wait never ended.
3. Queuing and processing used different staleness rules. Queuing was version aware; processing judged by timestamp alone, so a game queued because the rules had changed was dequeued, skipped, and never re-identified. This is the one that made the library look frozen while the app was busy.
4. Prioritising what is on screen only listened for rows appearing and disappearing. Opening a console reports a layout change instead, so walking into a console reordered nothing.

Matching itself: regional platforms (a Super Famicom cartridge is platform 58, not 19, which was 22 of 34 failures), accents, publisher prefixes, and ROM catalogue numbers. A fingerprint test now fails if any matching rule changes without raising `kMatchVersion`, because I changed the rules once and forgot, leaving 575 entries stuck.

## Covers

A portrait is fetched only when a game's own artwork is missing or cannot serve as a cover, decided by shape rather than by system. Steam keeps its official capsules, NES keeps its portrait boxes, N64 and SNES take portraits. Portraits store as JPEG: 161 KB against 726 KB on twelve real files, taking a full SNES set from 983 MB to 218 MB.

## Couch Mode and navigation

- The bar states what is filtered and reaches Source and Sort directly. Ten controls became eight and the widest labels still fit at 720p.
- Recycled grid delegates stayed focusable while standing for no row, so moving down from the organize row could open a game that was not there. Fixed at the source, with a test that fails without it.
- Back walks out of a console, then a search, then a source, then everything else.
- Emulators are asked to launch fullscreen using the flag each one documents. Ryujinx is left alone, since I could not verify one.

## Checks

97 CTest cases pass. Six are new and each was verified to fail without its fix. Remote CI has not run on either branch before now. No aarch64 package has been built for this candidate.