### PR TITLE
Keep ROM folders out of individual source settings

### DIFF
--- a/qml/components/SettingsPanel.qml
+++ b/qml/components/SettingsPanel.qml
@@ -441,7 +441,7 @@ import QtQuick.Layouts
                 }
                 ColumnLayout {
                     Layout.fillWidth: true
-                    visible: !DemoMode
+                    visible: !DemoMode && settingsOverlay.sourceDetail === ""
                     spacing: 8
                     Text {
                         text: "ROM FOLDERS"


### PR DESCRIPTION
ROM Folders appeared below every source's settings. Keep the section on the Sources overview, alongside manually added games and extra GOG folders.

Fixes #40.

Validation:
- Release build and all 124 CTest cases passed.
- The isolated QML check reproduces the old bug and passes 52 visibility transitions with the fix, covering source pages in desktop and Couch Mode.
- Live desktop and Couch Mode checks passed across all 12 source pages, including keyboard focus and returning to the Sources overview.
