### PR TITLE
Add Xenia (Xbox 360) as a game source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,8 @@ add_library(omakade_core STATIC
   src/library/Shadps4GameModel.h
   src/library/CemuGameModel.cpp
   src/library/CemuGameModel.h
+  src/library/XeniaGameModel.cpp
+  src/library/XeniaGameModel.h
   src/library/ManualGameModel.cpp
   src/library/ManualGameModel.h
   src/library/PersonalDataRules.h
@@ -161,6 +163,8 @@ add_library(omakade_core STATIC
   src/sources/shadps4/Shadps4Scanner.h
   src/sources/cemu/CemuScanner.cpp
   src/sources/cemu/CemuScanner.h
+  src/sources/xenia/XeniaScanner.cpp
+  src/sources/xenia/XeniaScanner.h
   src/sources/dolphin/DolphinScanner.cpp
   src/sources/dolphin/DolphinScanner.h
   src/library/DolphinGameModel.cpp

--- a/docs/BACKUP-FORMAT.md
+++ b/docs/BACKUP-FORMAT.md
@@ -61,6 +61,7 @@ the identities actually exposed by each source model:
 | battlenet_games | Battle.net | game_id | runner |
 | dolphin_games | Dolphin | game_id | flatpak_app_id |
 | cemu_games | Cemu | game_id | empty |
+| xenia_games | Xenia | game_id | empty |
 | shadps4_games | shadPS4 | game_id | flatpak_app_id |
 | manual_games | Manual | id | empty |
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -1657,7 +1657,7 @@ ApplicationWindow {
                         id: cemuSourceButton
                         objectName: "cemuSourceButton"
                         property Item controllerLeftTarget: shadps4SourceButton
-                        property Item controllerRightTarget: dolphinSourceButton
+                        property Item controllerRightTarget: xeniaSourceButton
                         property Item controllerDownTarget: statusFilterButton
                         text: "CEMU"
                         compact: true
@@ -1674,9 +1674,29 @@ ApplicationWindow {
                         }
                     }
                     GlassButton {
+                        id: xeniaSourceButton
+                        objectName: "xeniaSourceButton"
+                        property Item controllerLeftTarget: cemuSourceButton
+                        property Item controllerRightTarget: dolphinSourceButton
+                        property Item controllerDownTarget: statusFilterButton
+                        text: "XENIA"
+                        compact: true
+                        visible: Preferences.xeniaEnabled
+                        property string sourceName: "Xenia"
+                        selected: Library.sourceFilters.indexOf("Xenia") >= 0
+                        onClicked: {
+                            Library.sourceFilters = ["Xenia"]
+                            libraryView.currentIndex = Library.rowCount() > 0 ? 0 : -1
+                        }
+                        onSecondaryClicked: {
+                            Library.toggleSource("Xenia")
+                            libraryView.currentIndex = Library.rowCount() > 0 ? 0 : -1
+                        }
+                    }
+                    GlassButton {
                         id: dolphinSourceButton
                         objectName: "dolphinSourceButton"
-                        property Item controllerLeftTarget: cemuSourceButton
+                        property Item controllerLeftTarget: xeniaSourceButton
                         property Item controllerRightTarget: manualSourceButton
                         property Item controllerDownTarget: statusFilterButton
                         text: "DOLPHIN"
@@ -1981,6 +2001,8 @@ ApplicationWindow {
                             ? "shadPS4 was not found"
                             : Library.sourceFilter === "Cemu" && CemuLibrary && !CemuLibrary.cemuDetected
                             ? "Cemu was not found"
+                            : Library.sourceFilter === "Xenia" && XeniaLibrary && !XeniaLibrary.xeniaDetected
+                            ? "Xenia was not found"
                             : Library.sourceFilter === "Dolphin" && DolphinLibrary && !DolphinLibrary.dolphinDetected
                             ? "Dolphin was not found"
                             : Library.sourceFilter === "Battle.net" && BattleNetLibrary && !BattleNetLibrary.battleNetDetected
@@ -2009,6 +2031,8 @@ ApplicationWindow {
                               ? Shadps4Library.errorText
                               : Library.sourceFilter === "Cemu" && CemuLibrary && CemuLibrary.errorText.length > 0
                               ? CemuLibrary.errorText
+                              : Library.sourceFilter === "Xenia" && XeniaLibrary && XeniaLibrary.errorText.length > 0
+                              ? XeniaLibrary.errorText
                               : Library.sourceFilter === "Dolphin" && DolphinLibrary && DolphinLibrary.errorText.length > 0
                               ? DolphinLibrary.errorText
                               : Library.sourceFilter === "GOG" && HeroicLibrary && HeroicLibrary.errorText.length > 0

--- a/qml/components/CouchLibraryView.qml
+++ b/qml/components/CouchLibraryView.qml
@@ -30,6 +30,7 @@ FocusScope {
         { label: "RYUJINX", value: "Ryujinx", enabled: Preferences.ryujinxEnabled },
         { label: "SHADPS4", value: "shadPS4", enabled: Preferences.shadps4Enabled },
         { label: "CEMU", value: "Cemu", enabled: Preferences.cemuEnabled },
+        { label: "XENIA", value: "Xenia", enabled: Preferences.xeniaEnabled },
         { label: "DOLPHIN", value: "Dolphin", enabled: Preferences.dolphinEnabled },
         { label: "MANUAL", value: "Manual", enabled: true }
     ].filter(function(option) { return option.enabled === undefined || option.enabled })

--- a/qml/components/SettingsPanel.qml
+++ b/qml/components/SettingsPanel.qml
@@ -258,6 +258,11 @@ import QtQuick.Layouts
                           error: CemuLibrary ? CemuLibrary.errorText : "",
                           paths: CemuLibrary ? CemuLibrary.detectedPaths : [],
                           lastScan: CemuLibrary ? CemuLibrary.lastScan : 0 },
+                        { name: "XENIA", enabled: Preferences.xeniaEnabled,
+                          status: XeniaLibrary ? XeniaLibrary.statusText : "Unavailable",
+                          error: XeniaLibrary ? XeniaLibrary.errorText : "",
+                          paths: XeniaLibrary ? XeniaLibrary.detectedPaths : [],
+                          lastScan: XeniaLibrary ? XeniaLibrary.lastScan : 0 },
                         { name: "DOLPHIN", enabled: Preferences.dolphinEnabled,
                           status: DolphinLibrary ? DolphinLibrary.statusText : "Unavailable",
                           error: DolphinLibrary ? DolphinLibrary.errorText : "",
@@ -330,6 +335,10 @@ import QtQuick.Layouts
                                         Preferences.cemuEnabled = !Preferences.cemuEnabled
                                         nowEnabled = Preferences.cemuEnabled
                                         if (Preferences.cemuEnabled) CemuLibrary.refresh()
+                                    } else if (modelData.name === "XENIA") {
+                                        Preferences.xeniaEnabled = !Preferences.xeniaEnabled
+                                        nowEnabled = Preferences.xeniaEnabled
+                                        if (Preferences.xeniaEnabled) XeniaLibrary.refresh()
                                     } else if (modelData.name === "DOLPHIN") {
                                         Preferences.dolphinEnabled = !Preferences.dolphinEnabled
                                         nowEnabled = Preferences.dolphinEnabled
@@ -367,6 +376,7 @@ import QtQuick.Layouts
                                     else if (modelData.name === "RYUJINX") RyujinxLibrary.refresh()
                                     else if (modelData.name === "SHADPS4") Shadps4Library.refresh()
                                     else if (modelData.name === "CEMU") CemuLibrary.refresh()
+                                    else if (modelData.name === "XENIA") XeniaLibrary.refresh()
                                     else if (modelData.name === "DOLPHIN") DolphinLibrary.refresh()
                                     else RetroArchLibrary.refresh()
                                 }

--- a/qml/screens/GameDetails.qml
+++ b/qml/screens/GameDetails.qml
@@ -511,6 +511,7 @@ Item {
                                  || root.selectedInstallation.source === "Ryujinx"
                                  || root.selectedInstallation.source === "shadPS4"
                                  || root.selectedInstallation.source === "Cemu"
+                                 || root.selectedInstallation.source === "Xenia"
                                  || root.selectedInstallation.source === "Dolphin"
                                  || root.selectedInstallation.source === "Battle.net"
                         text: "MANAGE IN " + (root.selectedInstallation.source || "LAUNCHER").toUpperCase()

--- a/src/app/AppSettings.cpp
+++ b/src/app/AppSettings.cpp
@@ -336,6 +336,19 @@ void AppSettings::setCemuEnabled(bool value) {
   emit sourcesChanged();
 }
 
+bool AppSettings::xeniaEnabled() const { return m_xeniaEnabled; }
+
+void AppSettings::setXeniaEnabled(bool value) {
+  const bool wasAuto = m_xeniaAuto;
+  m_xeniaAuto = false;
+  if (m_xeniaEnabled == value && !wasAuto) {
+    return;
+  }
+  m_xeniaEnabled = value;
+  save();
+  emit sourcesChanged();
+}
+
 bool AppSettings::dolphinEnabled() const { return m_dolphinEnabled; }
 
 void AppSettings::setDolphinEnabled(bool value) {
@@ -360,6 +373,10 @@ void AppSettings::setShadps4AutoEnabled(bool value) { m_shadps4Auto = value; }
 bool AppSettings::cemuAutoEnabled() const { return m_cemuAuto; }
 
 void AppSettings::setCemuAutoEnabled(bool value) { m_cemuAuto = value; }
+
+bool AppSettings::xeniaAutoEnabled() const { return m_xeniaAuto; }
+
+void AppSettings::setXeniaAutoEnabled(bool value) { m_xeniaAuto = value; }
 
 bool AppSettings::consolePortalsEnabled() const { return m_consolePortalsEnabled; }
 
@@ -637,6 +654,10 @@ void AppSettings::load() {
       QStringLiteral("(?m)^cemu_enabled\\s*=\\s*(true|false)\\s*$"));
   m_cemuAuto = !cemuKey.match(contents).hasMatch();
   m_cemuEnabled = readEnabled(QStringLiteral("cemu_enabled"), false);
+  const QRegularExpression xeniaKey(
+      QStringLiteral("(?m)^xenia_enabled\\s*=\\s*(true|false)\\s*$"));
+  m_xeniaAuto = !xeniaKey.match(contents).hasMatch();
+  m_xeniaEnabled = readEnabled(QStringLiteral("xenia_enabled"), false);
   const QRegularExpression dolphinKey(QStringLiteral("(?m)^dolphin_enabled\\s*=\\s*(true|false)\\s*$"));
   m_dolphinAuto = !dolphinKey.match(contents).hasMatch();
   m_dolphinEnabled = readEnabled(QStringLiteral("dolphin_enabled"), false);
@@ -755,6 +776,10 @@ bool AppSettings::save() const {
   if (!m_cemuAuto) {
     contents += QStringLiteral("cemu_enabled = %1\n")
                     .arg(m_cemuEnabled ? QStringLiteral("true") : QStringLiteral("false"));
+  }
+  if (!m_xeniaAuto) {
+    contents += QStringLiteral("xenia_enabled = %1\n")
+                    .arg(m_xeniaEnabled ? QStringLiteral("true") : QStringLiteral("false"));
   }
   if (!m_dolphinAuto) {
     contents += QStringLiteral("dolphin_enabled = %1\n")

--- a/src/app/AppSettings.h
+++ b/src/app/AppSettings.h
@@ -28,6 +28,7 @@ class AppSettings final : public QObject {
   Q_PROPERTY(bool ryujinxEnabled READ ryujinxEnabled WRITE setRyujinxEnabled NOTIFY sourcesChanged)
   Q_PROPERTY(bool shadps4Enabled READ shadps4Enabled WRITE setShadps4Enabled NOTIFY sourcesChanged)
   Q_PROPERTY(bool cemuEnabled READ cemuEnabled WRITE setCemuEnabled NOTIFY sourcesChanged)
+  Q_PROPERTY(bool xeniaEnabled READ xeniaEnabled WRITE setXeniaEnabled NOTIFY sourcesChanged)
   Q_PROPERTY(bool dolphinEnabled READ dolphinEnabled WRITE setDolphinEnabled NOTIFY sourcesChanged)
   Q_PROPERTY(
       bool battleNetEnabled READ battleNetEnabled WRITE setBattleNetEnabled NOTIFY sourcesChanged)
@@ -94,6 +95,8 @@ public:
   [[nodiscard]] bool shadps4Enabled() const;
   void setShadps4Enabled(bool value);
   [[nodiscard]] bool cemuEnabled() const;
+  [[nodiscard]] bool xeniaEnabled() const;
+  void setXeniaEnabled(bool value);
   void setCemuEnabled(bool value);
   // True while the user has not written an explicit pcsx2_enabled/ryujinx_enabled key,
   // letting the app enable the source automatically when its emulator is detected.
@@ -105,6 +108,8 @@ public:
   [[nodiscard]] bool dolphinAutoEnabled() const;
   void setDolphinAutoEnabled(bool value);
   [[nodiscard]] bool cemuAutoEnabled() const;
+  [[nodiscard]] bool xeniaAutoEnabled() const;
+  void setXeniaAutoEnabled(bool value);
   void setPcsx2AutoEnabled(bool value);
   void setRyujinxAutoEnabled(bool value);
   void setShadps4AutoEnabled(bool value);
@@ -200,10 +205,12 @@ private:
   bool m_ryujinxEnabled = false;
   bool m_shadps4Enabled = false;
   bool m_cemuEnabled = false;
+  bool m_xeniaEnabled = false;
   bool m_pcsx2Auto = true;
   bool m_ryujinxAuto = true;
   bool m_shadps4Auto = true;
   bool m_cemuAuto = true;
+  bool m_xeniaAuto = true;
   bool m_dolphinEnabled = false;
   bool m_dolphinAuto = true;
   bool m_consolePortalsEnabled = true;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -25,6 +25,7 @@
 #include "library/RyujinxGameModel.h"
 #include "library/Shadps4GameModel.h"
 #include "library/CemuGameModel.h"
+#include "library/XeniaGameModel.h"
 #include "library/DolphinGameModel.h"
 #include "library/RetroArchGameModel.h"
 #include "library/SteamGameModel.h"
@@ -703,6 +704,7 @@ int main(int argc, char* argv[]) {
   std::unique_ptr<RyujinxGameModel> ryujinxGames;
   std::unique_ptr<Shadps4GameModel> shadps4Games;
   std::unique_ptr<CemuGameModel> cemuGames;
+  std::unique_ptr<XeniaGameModel> xeniaGames;
   std::unique_ptr<DolphinGameModel> dolphinGames;
   std::unique_ptr<BattleNetGameModel> battleNetGames;
   std::unique_ptr<ConsolePortalModel> consolePortals;
@@ -715,6 +717,7 @@ int main(int argc, char* argv[]) {
   RyujinxGameModel* ryujinxLibrary = nullptr;
   Shadps4GameModel* shadps4Library = nullptr;
   CemuGameModel* cemuLibrary = nullptr;
+  XeniaGameModel* xeniaLibrary = nullptr;
   DolphinGameModel* dolphinLibrary = nullptr;
   BattleNetGameModel* battleNetLibrary = nullptr;
   QString libraryDatabasePath;
@@ -798,6 +801,8 @@ int main(int argc, char* argv[]) {
     shadps4Library = shadps4Games.get();
     cemuGames = std::make_unique<CemuGameModel>(steamLibrary->databasePath());
     cemuLibrary = cemuGames.get();
+    xeniaGames = std::make_unique<XeniaGameModel>(steamLibrary->databasePath());
+    xeniaLibrary = xeniaGames.get();
     dolphinGames = std::make_unique<DolphinGameModel>(steamLibrary->databasePath());
     dolphinLibrary = dolphinGames.get();
     battleNetGames =
@@ -808,6 +813,7 @@ int main(int argc, char* argv[]) {
     consolePortals->addRomModel(dolphinGames.get());
     consolePortals->addRomModel(ryujinxGames.get());
     consolePortals->addRomModel(cemuGames.get());
+    consolePortals->addRomModel(xeniaGames.get());
     consolePortals->addRomModel(pcsx2Games.get());
     consolePortals->addRomModel(shadps4Games.get());
   }
@@ -854,6 +860,9 @@ int main(int argc, char* argv[]) {
   if (cemuGames != nullptr) {
     unifiedGames.addSourceModel(cemuGames.get());
   }
+  if (xeniaGames != nullptr) {
+    unifiedGames.addSourceModel(xeniaGames.get());
+  }
   if (dolphinGames != nullptr) {
     unifiedGames.addSourceModel(dolphinGames.get());
   }
@@ -874,6 +883,7 @@ int main(int argc, char* argv[]) {
     unifiedGames.setSourceEnabled(QStringLiteral("Ryujinx"), preferences.ryujinxEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("shadPS4"), preferences.shadps4Enabled());
     unifiedGames.setSourceEnabled(QStringLiteral("Cemu"), preferences.cemuEnabled());
+    unifiedGames.setSourceEnabled(QStringLiteral("Xenia"), preferences.xeniaEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("Dolphin"), preferences.dolphinEnabled());
     unifiedGames.setSourceEnabled(QStringLiteral("Battle.net"), preferences.battleNetEnabled());
   };
@@ -900,6 +910,9 @@ int main(int argc, char* argv[]) {
     } else if (key.source.compare(QStringLiteral("Cemu"), Qt::CaseInsensitive) == 0 &&
                preferences.cemuAutoEnabled()) {
       unifiedGames.setSourceEnabled(QStringLiteral("Cemu"), true);
+    } else if (key.source.compare(QStringLiteral("Xenia"), Qt::CaseInsensitive) == 0 &&
+               preferences.xeniaAutoEnabled()) {
+      unifiedGames.setSourceEnabled(QStringLiteral("Xenia"), true);
     } else if (key.source.compare(QStringLiteral("Dolphin"), Qt::CaseInsensitive) == 0 &&
                preferences.dolphinAutoEnabled()) {
       unifiedGames.setSourceEnabled(QStringLiteral("Dolphin"), true);
@@ -949,6 +962,11 @@ int main(int argc, char* argv[]) {
                  cemuLibrary != nullptr &&
                  (preferences.cemuEnabled() || preferences.cemuAutoEnabled())) {
         cemuLibrary->refresh();
+        refreshStarted = true;
+      } else if (key.source.compare(QStringLiteral("Xenia"), Qt::CaseInsensitive) == 0 &&
+                 xeniaLibrary != nullptr &&
+                 (preferences.xeniaEnabled() || preferences.xeniaAutoEnabled())) {
+        xeniaLibrary->refresh();
         refreshStarted = true;
       } else if (key.source.compare(QStringLiteral("Dolphin"), Qt::CaseInsensitive) == 0 &&
                  dolphinLibrary != nullptr &&
@@ -1195,6 +1213,7 @@ int main(int argc, char* argv[]) {
   engine.rootContext()->setContextProperty(QStringLiteral("RyujinxLibrary"), ryujinxLibrary);
   engine.rootContext()->setContextProperty(QStringLiteral("Shadps4Library"), shadps4Library);
   engine.rootContext()->setContextProperty(QStringLiteral("CemuLibrary"), cemuLibrary);
+  engine.rootContext()->setContextProperty(QStringLiteral("XeniaLibrary"), xeniaLibrary);
   engine.rootContext()->setContextProperty(QStringLiteral("DolphinLibrary"), dolphinLibrary);
   engine.rootContext()->setContextProperty(QStringLiteral("BattleNetLibrary"), battleNetLibrary);
   engine.rootContext()->setContextProperty(QStringLiteral("Launcher"), &launcher);
@@ -3148,6 +3167,16 @@ int main(int argc, char* argv[]) {
                        if (cemuLibrary->cemuDetected() && preferences.cemuAutoEnabled()) {
                          preferences.setCemuAutoEnabled(false);
                          preferences.setCemuEnabled(true);
+                       }
+                     });
+  }
+  if (xeniaLibrary != nullptr && (preferences.xeniaEnabled() || preferences.xeniaAutoEnabled())) {
+    QTimer::singleShot(745, xeniaLibrary, &XeniaGameModel::refresh);
+    QObject::connect(xeniaLibrary, &XeniaGameModel::statusChanged, xeniaLibrary,
+                     [&preferences, xeniaLibrary] {
+                       if (xeniaLibrary->xeniaDetected() && preferences.xeniaAutoEnabled()) {
+                         preferences.setXeniaAutoEnabled(false);
+                         preferences.setXeniaEnabled(true);
                        }
                      });
   }

--- a/src/backup/BackupDatabase.cpp
+++ b/src/backup/BackupDatabase.cpp
@@ -125,7 +125,7 @@ bool restoreDatabase(QSqlDatabase& database, const QString& artworkDirectory,
           QStringLiteral("faugus_games"), QStringLiteral("retroarch_games"),
           QStringLiteral("pcsx2_games"), QStringLiteral("ryujinx_games"),
           QStringLiteral("battlenet_games"), QStringLiteral("dolphin_games"),
-          QStringLiteral("cemu_games"), QStringLiteral("shadps4_games")})
+          QStringLiteral("cemu_games"), QStringLiteral("xenia_games"), QStringLiteral("shadps4_games")})
       if (tables.contains(table) && !query.exec("UPDATE " + table + " SET favorite=0, hidden=0"))
         return fail("Could not reset legacy personal flags.");
   }

--- a/src/backup/BackupSnapshot.cpp
+++ b/src/backup/BackupSnapshot.cpp
@@ -64,6 +64,7 @@ bool captureDatabase(QSqlDatabase& database, const QJsonObject& settings, Backup
       {"battlenet_games", "'Battle.net'", "game_id", "COALESCE(runner, '')"},
       {"dolphin_games", "'Dolphin'", "game_id", "COALESCE(flatpak_app_id, '')"},
       {"cemu_games", "'Cemu'", "game_id", "''"},
+      {"xenia_games", "'Xenia'", "game_id", "''"},
       {"shadps4_games", "'shadPS4'", "game_id", "COALESCE(flatpak_app_id, '')"},
       {"manual_games", "'Manual'", "id", "''", "WHERE active = 1"}};
   for (const auto& source : sources) {

--- a/src/launch/GameLauncher.cpp
+++ b/src/launch/GameLauncher.cpp
@@ -77,6 +77,11 @@ bool validCemuPath(const QString& id) {
                          true);
 }
 
+bool validXeniaPath(const QString& id) {
+  const QString path = id.startsWith(QStringLiteral("path:")) ? id.mid(5) : id;
+  return validLaunchPath(path, {QStringLiteral("iso"), QStringLiteral("xex")}, false);
+}
+
 bool validRyujinxId(const QString& id) {
   // Ryujinx launches a ROM file path; title ids are display metadata only.
   // QProcess passes this as one argument without a shell, so ordinary filename punctuation is
@@ -506,6 +511,18 @@ LaunchCommand GameLauncher::cemuCommand(const QString& path, bool flatpak) {
                        {QStringLiteral("--fullscreen"), QStringLiteral("-g"), target}};
 }
 
+LaunchCommand GameLauncher::xeniaCommand(const QString& path) {
+  if (!validXeniaPath(path)) {
+    return {};
+  }
+  const QString target = path.startsWith(QStringLiteral("path:")) ? path.mid(5) : path;
+  const QString executable = xeniaExecutable();
+  if (executable.isEmpty()) {
+    return {};
+  }
+  return LaunchCommand{executable, {target}};
+}
+
 LaunchCommand GameLauncher::battleNetCommand(const QString& id, const QString& prefix,
                                              const QString& runner, bool flatpak) {
   if (!validBattleNetId(id) || !validBattleNetPrefix(prefix) ||
@@ -650,6 +667,13 @@ bool GameLauncher::launch(const QString& source, const QString& id, bool flatpak
                                                   : launchTarget;
     return launchDolphin(target, flatpak, false);
   }
+  if (source.compare(QStringLiteral("Xenia"), Qt::CaseInsensitive) == 0) {
+    const QString target = launchTarget.isEmpty() ? (id.startsWith(QStringLiteral("path:"))
+                                                         ? id.mid(5)
+                                                         : installPath)
+                                                  : launchTarget;
+    return launchXenia(target, false);
+  }
   if (source.compare(QStringLiteral("Battle.net"), Qt::CaseInsensitive) == 0) {
     return launchBattleNet(id, launchTarget, runner, flatpak, false);
   }
@@ -697,6 +721,9 @@ bool GameLauncher::manage(const QString& source, const QString& id, bool flatpak
   }
   if (source.compare(QStringLiteral("Dolphin"), Qt::CaseInsensitive) == 0) {
     return launchDolphin(launchTarget.isEmpty() ? id : launchTarget, flatpak, true);
+  }
+  if (source.compare(QStringLiteral("Xenia"), Qt::CaseInsensitive) == 0) {
+    return launchXenia(launchTarget.isEmpty() ? id : launchTarget, true);
   }
   if (source.compare(QStringLiteral("Battle.net"), Qt::CaseInsensitive) == 0) {
     return launchBattleNet(id, launchTarget, runner, flatpak, true);
@@ -1049,6 +1076,39 @@ bool GameLauncher::launchShadps4(const QString& path, bool flatpak, const QStrin
   }
   if (!startCommand(command, !manageOnly)) {
     setError(QStringLiteral("shadPS4 could not be started. Open shadPS4 and try again."));
+    return false;
+  }
+  setError({});
+  return true;
+}
+
+QString GameLauncher::xeniaExecutable() {
+  // Xenia ships as AppImages and bare binaries under a handful of names; the
+  // user's PATH decides. Common aliases cover canary and canary-experimental.
+  for (const QString& candidate :
+       {QStringLiteral("xenia_canary"), QStringLiteral("xenia-canary"),
+        QStringLiteral("xenia_canary-linux"), QStringLiteral("xenia")}) {
+    const QString found = QStandardPaths::findExecutable(candidate);
+    if (!found.isEmpty()) {
+      return found;
+    }
+  }
+  return {};
+}
+
+bool GameLauncher::launchXenia(const QString& path, bool manageOnly) {
+  if (xeniaExecutable().isEmpty()) {
+    setError(QStringLiteral("Xenia is not installed."));
+    return false;
+  }
+  const LaunchCommand command =
+      manageOnly ? LaunchCommand{xeniaExecutable(), {}} : xeniaCommand(path);
+  if (!command.isValid()) {
+    setError(QStringLiteral("This game has an invalid Xenia target."));
+    return false;
+  }
+  if (!startCommand(command, !manageOnly)) {
+    setError(QStringLiteral("Xenia could not be started. Open Xenia and try again."));
     return false;
   }
   setError({});

--- a/src/launch/GameLauncher.h
+++ b/src/launch/GameLauncher.h
@@ -42,6 +42,8 @@ public:
                                                     const QString& nativeExecutable,
                                                     const QString& flatpakAppId = {});
   [[nodiscard]] static LaunchCommand cemuCommand(const QString& path, bool flatpak);
+  [[nodiscard]] static LaunchCommand xeniaCommand(const QString& path);
+  [[nodiscard]] static QString xeniaExecutable();
   [[nodiscard]] static LaunchCommand dolphinCommand(const QString& path, const QString& nativeExecutable,
                                                     bool flatpak);
   [[nodiscard]] static LaunchCommand battleNetCommand(const QString& id, const QString& prefix,
@@ -72,6 +74,7 @@ private:
   bool launchShadps4(const QString& path, bool flatpak, const QString& flatpakAppId,
                      bool manageOnly);
   bool launchCemu(const QString& path, bool flatpak, bool manageOnly);
+  bool launchXenia(const QString& path, bool manageOnly);
   bool launchDolphin(const QString& path, bool flatpak, bool manageOnly);
   bool launchBattleNet(const QString& id, const QString& prefix, const QString& runner,
                        bool flatpak, bool manageOnly);

--- a/src/library/LibraryFilterModel.cpp
+++ b/src/library/LibraryFilterModel.cpp
@@ -331,7 +331,7 @@ void LibraryFilterModel::setShowHidden(bool value) {
 
 QStringList LibraryFilterModel::emulatorSources() {
   return {QStringLiteral("RetroArch"), QStringLiteral("Dolphin"), QStringLiteral("Ryujinx"),
-          QStringLiteral("Cemu"), QStringLiteral("PCSX2"), QStringLiteral("shadPS4")};
+          QStringLiteral("Cemu"), QStringLiteral("Xenia"), QStringLiteral("PCSX2"), QStringLiteral("shadPS4")};
 }
 
 QString LibraryFilterModel::sourceFilter() const {

--- a/src/library/XeniaGameModel.cpp
+++ b/src/library/XeniaGameModel.cpp
@@ -1,0 +1,306 @@
+#include "library/XeniaGameModel.h"
+
+#include "library/DatabaseTuning.h"
+#include "library/GameRoles.h"
+
+#include <QCryptographicHash>
+#include <QDateTime>
+#include <QDir>
+#include <QFileInfo>
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QUrl>
+#include <QtConcurrent>
+
+namespace {
+QColor colorFor(const QString& id, int offset) {
+  const QByteArray hash = QCryptographicHash::hash(id.toUtf8(), QCryptographicHash::Sha256);
+  return QColor::fromHsl((static_cast<unsigned char>(hash.at(offset)) * 359) / 255, 115,
+                         offset == 0 ? 105 : 72);
+}
+
+QString localUrl(const QString& path) {
+  return path.isEmpty() ? QString{} : QUrl::fromLocalFile(path).toString();
+}
+} // namespace
+
+XeniaGameModel::XeniaGameModel(const QString& omakadeDatabasePath, QObject* parent)
+    : QAbstractListModel(parent),
+      m_connectionName(QStringLiteral("omakade-xenia-%1").arg(reinterpret_cast<quintptr>(this))) {
+  connect(&m_scanWatcher, &QFutureWatcher<XeniaScanResult>::finished, this, [this] {
+    m_scanning = false;
+    applyScan(m_scanWatcher.result());
+    emit statusChanged();
+  });
+  if (openDatabase(omakadeDatabasePath) && ensureSchema()) {
+    loadDatabase();
+    loadSourceState();
+  }
+}
+
+XeniaGameModel::~XeniaGameModel() {
+  if (m_scanWatcher.isRunning()) {
+    m_scanWatcher.waitForFinished();
+  }
+  m_database.close();
+  m_database = {};
+  QSqlDatabase::removeDatabase(m_connectionName);
+}
+
+int XeniaGameModel::rowCount(const QModelIndex& parent) const {
+  return parent.isValid() ? 0 : static_cast<int>(m_games.size());
+}
+
+QVariant XeniaGameModel::data(const QModelIndex& index, int role) const {
+  if (!index.isValid() || index.row() < 0 || index.row() >= m_games.size()) {
+    return {};
+  }
+  return valueForRole(m_games.at(index.row()), role);
+}
+
+QHash<int, QByteArray> XeniaGameModel::roleNames() const {
+  auto roles = GameRoles::names();
+  roles.insert(GameRoles::LaunchTarget, "launchTarget");
+  return roles;
+}
+
+bool XeniaGameModel::xeniaDetected() const { return m_xeniaDetected; }
+QString XeniaGameModel::statusText() const { return m_statusText; }
+QString XeniaGameModel::errorText() const { return m_errorText; }
+QStringList XeniaGameModel::detectedPaths() const { return m_detectedPaths; }
+qint64 XeniaGameModel::lastScan() const { return m_lastScan; }
+
+void XeniaGameModel::toggleFavorite(int row) {
+  if (row < 0 || row >= m_games.size() || !m_database.isOpen()) {
+    return;
+  }
+  Game& game = m_games[row];
+  game.favorite = !game.favorite;
+  QSqlQuery query(m_database);
+  query.prepare(QStringLiteral("UPDATE xenia_games SET favorite = ? WHERE game_id = ?"));
+  query.addBindValue(game.favorite);
+  query.addBindValue(game.xenia.gameId);
+  if (!query.exec()) {
+    game.favorite = !game.favorite;
+    setStatus(m_statusText, query.lastError().text());
+    return;
+  }
+  emit dataChanged(index(row), index(row), {GameRoles::Favorite});
+}
+
+void XeniaGameModel::toggleHidden(int row) {
+  if (row < 0 || row >= m_games.size() || !m_database.isOpen()) {
+    return;
+  }
+  Game& game = m_games[row];
+  game.hidden = !game.hidden;
+  QSqlQuery query(m_database);
+  query.prepare(QStringLiteral("UPDATE xenia_games SET hidden = ? WHERE game_id = ?"));
+  query.addBindValue(game.hidden);
+  query.addBindValue(game.xenia.gameId);
+  if (!query.exec()) {
+    game.hidden = !game.hidden;
+    setStatus(m_statusText, query.lastError().text());
+    return;
+  }
+  emit dataChanged(index(row), index(row), {GameRoles::Hidden});
+}
+
+void XeniaGameModel::refresh() {
+  if (m_scanWatcher.isRunning()) {
+    return;
+  }
+  m_scanning = true;
+  const QStringList roots = XeniaScanner::discoverRoots();
+  setStatus(QStringLiteral("Scanning Xenia library"));
+  m_scanWatcher.setFuture(QtConcurrent::run([roots] { return XeniaScanner::scan(roots); }));
+}
+
+void XeniaGameModel::refreshFromRoots(const QStringList& roots) {
+  applyScan(XeniaScanner::scan(roots));
+}
+
+bool XeniaGameModel::openDatabase(const QString& path) {
+  if (path != QStringLiteral(":memory:")) {
+    QDir().mkpath(QFileInfo(path).absolutePath());
+  }
+  m_database = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), m_connectionName);
+  m_database.setDatabaseName(path);
+  if (!openTunedDatabase(m_database)) {
+    setStatus(QStringLiteral("Xenia cache unavailable"), m_database.lastError().text());
+    return false;
+  }
+  return true;
+}
+
+bool XeniaGameModel::ensureSchema() {
+  QSqlQuery query(m_database);
+  if (!query.exec(QStringLiteral(
+          "CREATE TABLE IF NOT EXISTS xenia_games (game_id TEXT PRIMARY KEY, name TEXT NOT NULL, "
+          "path TEXT, title_id TEXT, cover_path TEXT, flatpak INTEGER NOT NULL DEFAULT 0, "
+          "favorite INTEGER NOT NULL DEFAULT 0, hidden INTEGER NOT NULL DEFAULT 0, observed_at "
+          "INTEGER NOT NULL)"))) {
+    setStatus(QStringLiteral("Could not initialize Xenia cache"), query.lastError().text());
+    return false;
+  }
+  if (!query.exec(QStringLiteral(
+          "CREATE TABLE IF NOT EXISTS source_state (source TEXT PRIMARY KEY, last_scan INTEGER, "
+          "last_error TEXT, paths TEXT NOT NULL DEFAULT '')"))) {
+    setStatus(QStringLiteral("Could not initialize Xenia cache"), query.lastError().text());
+    return false;
+  }
+  return true;
+}
+
+void XeniaGameModel::loadDatabase() {
+  QVector<Game> loaded;
+  QSqlQuery query(m_database);
+  if (!query.exec(QStringLiteral(
+          "SELECT game_id, name, path, title_id, cover_path, flatpak, favorite, hidden FROM "
+          "xenia_games WHERE observed_at > 0 ORDER BY name COLLATE NOCASE"))) {
+    setStatus(QStringLiteral("Could not load cached Xenia games"), query.lastError().text());
+    return;
+  }
+  while (query.next()) {
+    XeniaGameRecord record{.gameId = query.value(0).toString(),
+                           .titleId = query.value(3).toString(),
+                           .title = query.value(1).toString(),
+                           .path = query.value(2).toString(),
+                           .coverPath = query.value(4).toString(),
+                           .flatpak = query.value(5).toBool()};
+    loaded.append({.xenia = record,
+                   .favorite = query.value(6).toBool(),
+                   .hidden = query.value(7).toBool(),
+                   .accentStart = colorFor(record.gameId, 0),
+                   .accentEnd = colorFor(record.gameId, 1)});
+  }
+  beginResetModel();
+  m_games = loaded;
+  endResetModel();
+}
+
+void XeniaGameModel::loadSourceState() {
+  QSqlQuery query(m_database);
+  query.prepare(
+      QStringLiteral("SELECT last_scan, last_error, paths FROM source_state WHERE source = 'xenia'"));
+  if (!query.exec() || !query.next()) {
+    return;
+  }
+  m_lastScan = query.value(0).toLongLong();
+  m_errorText = query.value(1).toString();
+  m_detectedPaths = query.value(2).toString().split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+  m_xeniaDetected = !m_detectedPaths.isEmpty();
+  if (m_lastScan > 0) {
+    m_statusText = QStringLiteral("Loaded cached Xenia games");
+  }
+}
+
+void XeniaGameModel::applyScan(const XeniaScanResult& result) {
+  m_xeniaDetected = !result.roots.isEmpty();
+  if (result.incomplete || (result.roots.isEmpty() && !m_games.isEmpty())) {
+    setStatus(QStringLiteral("Xenia scan interrupted; kept the cached library"),
+              result.warnings.join(QLatin1Char('\n')));
+    return;
+  }
+  if (!m_database.transaction()) {
+    setStatus(QStringLiteral("Could not update Xenia games"), m_database.lastError().text());
+    return;
+  }
+  const qint64 scanTimestamp = QDateTime::currentSecsSinceEpoch();
+  QSqlQuery query(m_database);
+  bool okay = query.exec(QStringLiteral("UPDATE xenia_games SET observed_at = 0"));
+  for (const XeniaGameRecord& game : result.games) {
+    query.prepare(QStringLiteral(
+        "INSERT INTO xenia_games(game_id, name, path, title_id, cover_path, flatpak, "
+        "observed_at) VALUES(?, ?, ?, ?, ?, ?, strftime('%s', 'now')) ON CONFLICT(game_id) DO "
+        "UPDATE SET name = excluded.name, path = excluded.path, title_id = excluded.title_id, "
+        "cover_path = excluded.cover_path, flatpak = excluded.flatpak, observed_at = "
+        "excluded.observed_at"));
+    query.addBindValue(game.gameId);
+    query.addBindValue(game.title);
+    query.addBindValue(game.path);
+    query.addBindValue(game.titleId);
+    query.addBindValue(game.coverPath);
+    query.addBindValue(game.flatpak);
+    okay = okay && query.exec();
+  }
+  query.prepare(QStringLiteral(
+      "INSERT INTO source_state(source, last_scan, last_error, paths) VALUES('xenia', "
+      "?, ?, ?) ON CONFLICT(source) DO UPDATE SET last_scan = "
+      "excluded.last_scan, last_error = excluded.last_error, paths = excluded.paths"));
+  query.addBindValue(scanTimestamp);
+  query.addBindValue(result.warnings.join(QLatin1Char('\n')));
+  query.addBindValue(result.roots.isEmpty() ? QStringLiteral("")
+                                            : result.roots.join(QLatin1Char('\n')));
+  okay = okay && query.exec();
+  if (!okay || !m_database.commit()) {
+    m_database.rollback();
+    setStatus(QStringLiteral("Could not update Xenia games"), query.lastError().text());
+    return;
+  }
+  loadDatabase();
+  m_detectedPaths = result.roots;
+  m_lastScan = scanTimestamp;
+  setStatus(m_xeniaDetected ? QStringLiteral("Imported %1 Xenia game(s)").arg(result.games.size())
+                            : QStringLiteral("Xenia was not found"),
+            result.warnings.join(QLatin1Char('\n')));
+}
+
+QVariant XeniaGameModel::valueForRole(const Game& game, int role) const {
+  switch (role) {
+  case GameRoles::Title:
+    return game.xenia.title;
+  case GameRoles::Subtitle:
+    return QStringLiteral("Xenia");
+  case GameRoles::Description:
+    return QStringLiteral("Xbox 360 game launched through Xenia.");
+  case GameRoles::Hours:
+  case GameRoles::Progress:
+  case GameRoles::AchievementsUnlocked:
+  case GameRoles::AchievementsTotal:
+    return 0;
+  case GameRoles::Favorite:
+    return game.favorite;
+  case GameRoles::Recent:
+    return false;
+  case GameRoles::LastPlayed:
+    return 0;
+  case GameRoles::AccentStart:
+    return game.accentStart;
+  case GameRoles::AccentEnd:
+    return game.accentEnd;
+  case GameRoles::CoverMark:
+    return game.xenia.title.left(1).toUpper();
+  case GameRoles::Year:
+    return 0;
+  case GameRoles::AppId:
+    return game.xenia.gameId;
+  case GameRoles::CoverPath:
+    return localUrl(game.xenia.coverPath);
+  case GameRoles::HeroPath:
+  case GameRoles::LogoPath:
+    return QString{};
+  case GameRoles::InstallPath:
+    return game.xenia.path;
+  case GameRoles::Source:
+    return QStringLiteral("Xenia");
+  case GameRoles::Runner:
+    return QString{};
+  case GameRoles::LaunchTarget:
+    return game.xenia.path;
+  case GameRoles::Flatpak:
+    return game.xenia.flatpak;
+  case GameRoles::Hidden:
+    return game.hidden;
+  case GameRoles::System:
+    return QStringLiteral("xbox360");
+  default:
+    return {};
+  }
+}
+
+void XeniaGameModel::setStatus(const QString& status, const QString& error) {
+  m_statusText = status;
+  m_errorText = error;
+  emit statusChanged();
+}

--- a/src/library/XeniaGameModel.h
+++ b/src/library/XeniaGameModel.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "sources/xenia/XeniaScanner.h"
+
+#include <QAbstractListModel>
+#include <QColor>
+#include <QFutureWatcher>
+#include <QSqlDatabase>
+
+class XeniaGameModel final : public QAbstractListModel {
+  Q_OBJECT
+  Q_PROPERTY(bool xeniaDetected READ xeniaDetected NOTIFY statusChanged)
+  Q_PROPERTY(bool scanning READ scanning NOTIFY statusChanged)
+  Q_PROPERTY(QString statusText READ statusText NOTIFY statusChanged)
+  Q_PROPERTY(QString errorText READ errorText NOTIFY statusChanged)
+  Q_PROPERTY(QStringList detectedPaths READ detectedPaths NOTIFY statusChanged)
+  Q_PROPERTY(qint64 lastScan READ lastScan NOTIFY statusChanged)
+
+public:
+  explicit XeniaGameModel(const QString& omakadeDatabasePath, QObject* parent = nullptr);
+  ~XeniaGameModel() override;
+
+  [[nodiscard]] int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+  [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
+  [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
+  [[nodiscard]] bool xeniaDetected() const;
+  [[nodiscard]] bool scanning() const { return m_scanning; }
+  [[nodiscard]] QString statusText() const;
+  [[nodiscard]] QString errorText() const;
+  [[nodiscard]] QStringList detectedPaths() const;
+  [[nodiscard]] qint64 lastScan() const;
+
+  Q_INVOKABLE void toggleFavorite(int row);
+  Q_INVOKABLE void toggleHidden(int row);
+  Q_INVOKABLE void refresh();
+  void refreshFromRoots(const QStringList& roots);
+
+signals:
+  void statusChanged();
+
+private:
+  struct Game {
+    XeniaGameRecord xenia;
+    bool favorite = false;
+    bool hidden = false;
+    QColor accentStart;
+    QColor accentEnd;
+  };
+
+  bool openDatabase(const QString& path);
+  bool ensureSchema();
+  void loadDatabase();
+  void loadSourceState();
+  void applyScan(const XeniaScanResult& result);
+  [[nodiscard]] QVariant valueForRole(const Game& game, int role) const;
+  void setStatus(const QString& status, const QString& error = {});
+
+  QVector<Game> m_games;
+  QSqlDatabase m_database;
+  QString m_connectionName;
+  QFutureWatcher<XeniaScanResult> m_scanWatcher;
+  bool m_scanning = false;
+  bool m_xeniaDetected = false;
+  QString m_statusText;
+  QString m_errorText;
+  QStringList m_detectedPaths;
+  qint64 m_lastScan = 0;
+};

--- a/src/sources/xenia/XeniaScanner.cpp
+++ b/src/sources/xenia/XeniaScanner.cpp
@@ -1,0 +1,338 @@
+#include "sources/xenia/XeniaScanner.h"
+
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileInfo>
+#include <QRegularExpression>
+#include <QSet>
+#include <QStandardPaths>
+
+namespace {
+constexpr int kMaximumScanDepth = 5;
+constexpr qint64 kMaximumTomlBytes = 4 * 1024 * 1024;
+
+const QStringList& discExtensions() {
+  static const QStringList extensions = {QStringLiteral("iso"), QStringLiteral("xex"),
+                                         QStringLiteral("zar")};
+  return extensions;
+}
+
+bool isDiscFile(const QString& fileName) {
+  const QString suffix = QFileInfo(fileName).suffix();
+  for (const QString& extension : discExtensions()) {
+    if (suffix.compare(extension, Qt::CaseInsensitive) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool looksLikeTitleDirectory(const QDir& directory) {
+  // Extracted dumps keep the executable at the root; the data folder marks a
+  // full dump rather than a folder that merely contains other games.
+  return QFileInfo::exists(directory.filePath(QStringLiteral("default.xex")));
+}
+
+QString cleanTitle(const QString& fileName) {
+  static const QRegularExpression bracketed(QStringLiteral("\\[.*?\\]"));
+  static const QRegularExpression parenthesized(QStringLiteral("\\(.*?\\)"));
+  QString name = QFileInfo(fileName).completeBaseName();
+  name.remove(bracketed);
+  name.remove(parenthesized);
+  // "Legend of Zelda, The - ..." reads better with the article in front.
+  static const QRegularExpression trailingArticle(QStringLiteral("^(.+?), (The|A|An)( - .*)?$"));
+  const QRegularExpressionMatch match = trailingArticle.match(name.simplified());
+  if (match.hasMatch()) {
+    name = match.captured(2) + QLatin1Char(' ') + match.captured(1) + match.captured(3);
+  }
+  return name.simplified();
+}
+
+QString titleFromDisc(const QString& isoPath) {
+  // XGD discs store the title in the UDF volume label region; the primary
+  // volume descriptor sits at sector 16 (offset 0x8000) in both ISO9660 and
+  // XGD2 images. Xenia games commonly carry the readable name there, but the
+  // label is short and sometimes uppercase-abbreviated, so treat it as a hint
+  // and fall back to the file name when it looks unusable.
+  QFile file(isoPath);
+  if (!file.open(QIODevice::ReadOnly)) {
+    return {};
+  }
+  if (!file.seek(0x8000 + 40) || file.size() < 0x8028 + 32) {
+    return {};
+  }
+  const QByteArray label = file.read(32);
+  const int end = label.indexOf('\0');
+  const QString name = QString::fromLatin1(end < 0 ? label : label.left(end))
+                           .simplified();
+  if (name.size() >= 3 && name.contains(QLatin1Char(' '))) {
+    return name;
+  }
+  return {};
+}
+
+QString sidecarCover(const QString& titlePath) {
+  const QFileInfo title(titlePath);
+  const QString stem = title.absolutePath() + QLatin1Char('/') + title.completeBaseName();
+  for (const QString& extension : {QStringLiteral(".png"), QStringLiteral(".jpg"),
+                                   QStringLiteral(".jpeg")}) {
+    if (QFileInfo::exists(stem + extension)) {
+      return stem + extension;
+    }
+  }
+  return {};
+}
+
+QStringList singleQuotedTomlStrings(const QString& text) {
+  QStringList values;
+  static const QRegularExpression quoted(QStringLiteral("'([^']*)'"));
+  QRegularExpressionMatchIterator it = quoted.globalMatch(text);
+  while (it.hasNext()) {
+    const QString value = it.next().captured(1);
+    if (!value.isEmpty()) {
+      values.append(value);
+    }
+  }
+  return values;
+}
+
+void normalizeWindowsPath(QString* path) {
+  if (path->length() >= 2 && path->at(1) == QLatin1Char(':')) {
+    // Wine maps drive letters to Unix roots: "Z:\home\salt\..." is
+    // "/home/salt/..." and "C:\foo" falls back to the C drive prefix used by
+    // some prefixes ("Z" is the standard root mapping; other letters rarely
+    // appear in saved paths). Drive prefix and leading backslash come off,
+    // then separators flip to forward slashes.
+    if (path->length() >= 3 && (*path)[2] == QLatin1Char('\\')) {
+      path->remove(0, 3);
+    } else {
+      path->remove(0, 2);
+    }
+    path->replace(QLatin1Char('\\'), QLatin1Char('/'));
+    path->prepend(QLatin1Char('/'));
+  }
+  *path = QDir::cleanPath(*path);
+}
+
+struct RecentTitle {
+  QString path;
+  QString title;
+};
+
+QVector<RecentTitle> recentTitles(const QString& storageRoot) {
+  QVector<RecentTitle> titles;
+  QFile file(storageRoot + QStringLiteral("/recent.toml"));
+  if (!file.open(QIODevice::ReadOnly | QIODevice::Text) ||
+      file.size() > kMaximumTomlBytes) {
+    return titles;
+  }
+  // Entries look like:
+  // [0]
+  // last_run_time = 1788911947
+  // path = 'Z:\home\salt\Games\Fable II\default.xex'
+  // title_name = 'Fable II'
+  static const QRegularExpression pathValue(
+      QStringLiteral("^\\s*path\\s*=\\s*'([^']*)'"));
+  static const QRegularExpression nameValue(
+      QStringLiteral("^\\s*title_name\\s*=\\s*'([^']*)'"));
+  RecentTitle current;
+  bool pending = false;
+  const QList<QByteArray> lines = file.readAll().split('\n');
+  auto flush = [&]() {
+    if (pending && !current.path.isEmpty()) {
+      titles.append(current);
+    }
+    current = RecentTitle{};
+    pending = false;
+  };
+  for (const QByteArray& raw : lines) {
+    const QString line = QString::fromUtf8(raw);
+    if (line.trimmed().startsWith(QLatin1Char('['))) {
+      flush();
+      continue;
+    }
+    const QRegularExpressionMatch pathMatch = pathValue.match(line);
+    if (pathMatch.hasMatch()) {
+      if (pending) {
+        flush();
+      }
+      pending = true;
+      current.path = pathMatch.captured(1);
+      continue;
+    }
+    const QRegularExpressionMatch nameMatch = nameValue.match(line);
+    if (nameMatch.hasMatch()) {
+      if (pending) {
+        current.title = nameMatch.captured(1);
+      }
+    }
+  }
+  flush();
+  for (RecentTitle& title : titles) {
+    normalizeWindowsPath(&title.path);
+  }
+  return titles;
+}
+
+void collectGames(const QString& directory, int depth, bool flatpak,
+                  const QString& flatpakAppId, QSet<QString>* seenPaths,
+                  QSet<QString>* seenIds, XeniaScanResult* result) {
+  if (depth > kMaximumScanDepth) {
+    return;
+  }
+  const QDir dir(directory);
+  if (!dir.exists()) {
+    return;
+  }
+  if (looksLikeTitleDirectory(dir)) {
+    const QString xex = QDir::cleanPath(dir.filePath(QStringLiteral("default.xex")));
+    if (seenPaths->contains(xex)) {
+      return;
+    }
+    QString title = cleanTitle(dir.dirName());
+    if (title.isEmpty()) {
+      return;
+    }
+    const QString gameId = QStringLiteral("path:%1").arg(xex);
+    if (seenIds->contains(gameId)) {
+      return;
+    }
+    result->games.append(XeniaGameRecord{.gameId = gameId,
+                                         .title = title,
+                                         .path = xex,
+                                         .coverPath = sidecarCover(xex),
+                                         .flatpak = flatpak,
+                                         .flatpakAppId = flatpakAppId});
+    seenPaths->insert(xex);
+    seenIds->insert(gameId);
+    return;
+  }
+  // Disc images are games in their own right; deeper folders may hold more.
+  const QFileInfoList children =
+      dir.entryInfoList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot);
+  for (const QFileInfo& child : children) {
+    if (child.isDir()) {
+      collectGames(child.absoluteFilePath(), depth + 1, flatpak, flatpakAppId, seenPaths,
+                   seenIds, result);
+      continue;
+    }
+    if (!isDiscFile(child.fileName())) {
+      continue;
+    }
+    const QString path = QDir::cleanPath(child.absoluteFilePath());
+    if (seenPaths->contains(path)) {
+      continue;
+    }
+    // ".xex" files that are not named default.xex are standalone titles too.
+    if (child.suffix().compare(QStringLiteral("xex"), Qt::CaseInsensitive) == 0) {
+      QString title = cleanTitle(child.completeBaseName());
+      const QString gameId = QStringLiteral("path:%1").arg(path);
+      if (title.isEmpty() || seenIds->contains(gameId)) {
+        continue;
+      }
+      result->games.append(XeniaGameRecord{.gameId = gameId,
+                                           .title = title,
+                                           .path = path,
+                                           .coverPath = sidecarCover(path),
+                                           .flatpak = flatpak,
+                                           .flatpakAppId = flatpakAppId});
+      seenPaths->insert(path);
+      seenIds->insert(gameId);
+      continue;
+    }
+    // ISO images: prefer the volume label, fall back to the file name.
+    QString title = titleFromDisc(path);
+    if (title.isEmpty()) {
+      title = cleanTitle(child.completeBaseName());
+    }
+    const QString gameId = QStringLiteral("path:%1").arg(path);
+    if (title.isEmpty() || seenIds->contains(gameId)) {
+      continue;
+    }
+    result->games.append(XeniaGameRecord{.gameId = gameId,
+                                         .title = title,
+                                         .path = path,
+                                         .coverPath = sidecarCover(path),
+                                         .flatpak = flatpak,
+                                         .flatpakAppId = flatpakAppId});
+    seenPaths->insert(path);
+    seenIds->insert(gameId);
+  }
+}
+} // namespace
+
+QStringList XeniaScanner::discoverRoots() {
+  const QString home = QDir::homePath();
+  QStringList candidates = {
+      QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) +
+          QStringLiteral("/Xenia"),
+      home + QStringLiteral("/.local/share/Xenia"),
+      home + QStringLiteral("/Xenia"),
+      home + QStringLiteral("/.var/app/org.xenia.xenia/data/Xenia"),
+  };
+  candidates.removeDuplicates();
+
+  QStringList roots;
+  for (const QString& root : candidates) {
+    if (QFileInfo(root + QStringLiteral("/xenia-canary.config.toml")).isFile() ||
+        QFileInfo(root + QStringLiteral("/xenia.config.toml")).isFile() ||
+        QFileInfo(root + QStringLiteral("/recent.toml")).isFile()) {
+      roots.append(root);
+    }
+  }
+  return roots;
+}
+
+XeniaScanResult XeniaScanner::scan(const QStringList& roots) {
+  XeniaScanResult result;
+  QSet<QString> seenPaths;
+  QSet<QString> seenIds;
+
+  for (const QString& root : roots) {
+    const bool hasConfig =
+        QFileInfo(root + QStringLiteral("/xenia-canary.config.toml")).isFile() ||
+        QFileInfo(root + QStringLiteral("/xenia.config.toml")).isFile();
+    if (!hasConfig && !QFileInfo(root + QStringLiteral("/recent.toml")).isFile()) {
+      continue;
+    }
+    result.roots.append(root);
+
+    // Games the emulator has actually run are the highest-confidence entries:
+    // recent.toml records the exact launch path and a display title.
+    for (const RecentTitle& recent : recentTitles(root)) {
+      const QFileInfo info(recent.path);
+      if (!info.isFile() || !info.isReadable()) {
+        continue;
+      }
+      if (seenPaths.contains(recent.path)) {
+        continue;
+      }
+      const QString gameId = QStringLiteral("path:%1").arg(recent.path);
+      if (seenIds.contains(gameId)) {
+        continue;
+      }
+      QString title = recent.title;
+      if (title.isEmpty()) {
+        title = cleanTitle(info.completeBaseName());
+      }
+      if (title.isEmpty()) {
+        continue;
+      }
+      result.games.append(XeniaGameRecord{.gameId = gameId,
+                                          .title = title,
+                                          .path = recent.path,
+                                          .coverPath = sidecarCover(recent.path),
+                                          .flatpak = false,
+                                          .flatpakAppId = QStringLiteral("")});
+      seenPaths.insert(recent.path);
+      seenIds.insert(gameId);
+    }
+
+    // The storage root itself doubles as a game folder: users keep dumps and
+    // ISOs beside the config, and Xenia installs content under
+    // content/<profile>/<title id>/. Scanning the root covers both.
+    collectGames(root, 0, false, QStringLiteral(""), &seenPaths, &seenIds, &result);
+  }
+  return result;
+}

--- a/src/sources/xenia/XeniaScanner.h
+++ b/src/sources/xenia/XeniaScanner.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+struct XeniaGameRecord {
+  QString gameId;      // title id (e.g. "4D5307F1") when known, else "path:<xex>"
+  QString titleId;     // eight-character title id, may be empty
+  QString title;
+  QString path;        // path passed to Xenia: a default.xex, .iso, or .xex file
+  QString coverPath;
+  bool flatpak = false;
+  QString flatpakAppId;
+};
+
+struct XeniaScanResult {
+  QVector<XeniaGameRecord> games;
+  QStringList roots;      // Xenia configuration/storage folders that were read
+  QStringList warnings;
+  bool incomplete = false;
+};
+
+class XeniaScanner final {
+public:
+  [[nodiscard]] static QStringList discoverRoots();
+  [[nodiscard]] static XeniaScanResult scan(const QStringList& roots);
+};

--- a/tests/BackupRecoveryTests.cpp
+++ b/tests/BackupRecoveryTests.cpp
@@ -109,6 +109,8 @@ void BackupRecoveryTests::consoleChoicesSurviveBackupAndRecovery() {
       "INSERT INTO cemu_games VALUES('wiiu',1,1)",
       "CREATE TABLE shadps4_games(game_id TEXT,flatpak_app_id TEXT,favorite INTEGER,hidden INTEGER)",
       "INSERT INTO shadps4_games VALUES('ps4','flatpak-ps4',1,1)",
+      "CREATE TABLE xenia_games(game_id TEXT,favorite INTEGER,hidden INTEGER)",
+      "INSERT INTO xenia_games VALUES('xbox360',1,1)",
       "CREATE TABLE user_game_flags(source TEXT,runner TEXT,app_id TEXT,favorite INTEGER,hidden INTEGER,PRIMARY KEY(source,runner,app_id))",
       "INSERT INTO user_game_flags VALUES('Cemu','','wiiu',0,NULL)"};
     for (const auto& sql : statements) QVERIFY(q.exec(sql));
@@ -117,7 +119,7 @@ void BackupRecoveryTests::consoleChoicesSurviveBackupAndRecovery() {
   BackupPayload snapshot;
   QVERIFY2(BackupSnapshot::capture(p.database, {}, &snapshot, &error), qPrintable(error));
   const auto flags = snapshot.library.value("user_game_flags").toArray();
-  QCOMPARE(flags.size(), 3);
+  QCOMPARE(flags.size(), 4);
   for (const auto& value : flags) {
     const auto row = value.toObject();
     const auto source = row.value("source").toString();

--- a/tests/CoreTests.cpp
+++ b/tests/CoreTests.cpp
@@ -38,6 +38,7 @@
 #include "library/RyujinxGameModel.h"
 #include "library/Shadps4GameModel.h"
 #include "library/CemuGameModel.h"
+#include "library/XeniaGameModel.h"
 #include "library/RetroArchGameModel.h"
 #include "library/SteamGameModel.h"
 #include "library/SteamOwnedGamesApi.h"
@@ -53,6 +54,7 @@
 #include "sources/ryujinx/RyujinxScanner.h"
 #include "sources/shadps4/Shadps4Scanner.h"
 #include "sources/cemu/CemuScanner.h"
+#include "sources/xenia/XeniaScanner.h"
 #include "sources/dolphin/DolphinScanner.h"
 #include "library/DolphinGameModel.h"
 #include "sources/lutris/LutrisScanner.h"
@@ -770,6 +772,10 @@ private slots:
   void cemuModelIsRepeatableAndPreservesLocalState();
   void malformedCemuDataDoesNotReplaceCachedGames();
   void cemuLauncherBuildsSafeCommands();
+  void xeniaScannerImportsRecentTitlesAndDumps();
+  void xeniaScannerNormalizesWinePaths();
+  void xeniaModelIsRepeatableAndPreservesLocalState();
+  void xeniaLauncherBuildsSafeCommands();
   void consolePortalsGroupRetroArchRomsAndCanFlatten();
   void consolePortalsDoNotRebuildTheLibraryWhenCoversChange();
   void consolePortalsDoNotMergeDifferentFiles();
@@ -5813,6 +5819,93 @@ void CoreTests::malformedCemuDataDoesNotReplaceCachedGames() {
   writeFile(root + QStringLiteral("/settings.xml"), "<content><GamePaths/></content>");
   model.refreshFromRoots({root});
   QCOMPARE(model.rowCount(), 0);
+}
+
+void CoreTests::xeniaScannerImportsRecentTitlesAndDumps() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/Xenia");
+  const QString dump =
+      directory.path() + QStringLiteral("/Xenia/content/Fable II/default.xex");
+  QDir().mkpath(directory.path() + QStringLiteral("/Xenia/content/Fable II"));
+  writeFile(dump, "xex");
+  writeFile(directory.path() + QStringLiteral("/Xenia/content/Fable II/default.png"), "cover");
+  writeFile(root + QStringLiteral("/xenia-canary.config.toml"), "storage_root = \"\"\n");
+  writeFile(root + QStringLiteral("/recent.toml"),
+            QStringLiteral("[0]\nlast_run_time = 1788911947\n"
+                           "path = '%1'\n"
+                           "title_name = 'Fable II'\n")
+                .arg(dump)
+                .toUtf8());
+  const QString iso = directory.path() + QStringLiteral("/Xenia/Halo Reach.iso");
+  writeFile(iso, "iso");
+
+  const XeniaScanResult result = XeniaScanner::scan({root});
+  QVERIFY(!result.incomplete);
+  QCOMPARE(result.games.size(), 2);
+  bool sawRecent = false;
+  bool sawIso = false;
+  for (const XeniaGameRecord& game : result.games) {
+    if (game.path == dump) {
+      sawRecent = true;
+      QCOMPARE(game.title, QStringLiteral("Fable II"));
+      QVERIFY(game.coverPath.endsWith(QStringLiteral("default.png")));
+    } else if (game.path == iso) {
+      sawIso = true;
+      QCOMPARE(game.title, QStringLiteral("Halo Reach"));
+    }
+  }
+  QVERIFY(sawRecent);
+  QVERIFY(sawIso);
+}
+
+void CoreTests::xeniaScannerNormalizesWinePaths() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/Xenia");
+  writeFile(root + QStringLiteral("/xenia-canary.config.toml"), "storage_root = \"\"\n");
+  const QString xex = directory.path() + QStringLiteral("/Games/Game/default.xex");
+  writeFile(xex, "xex");
+  // recent.toml as written by Xenia under Proton: Z:\home\<user>\... backslash paths.
+  const QString winePath = QStringLiteral("Z:\\")
+                               + xex.mid(1).replace(QLatin1Char('/'), QLatin1Char('\\'));
+  writeFile(root + QStringLiteral("/recent.toml"),
+            QStringLiteral("[0]\nlast_run_time = 1\npath = '%1'\ntitle_name = 'A Game'\n")
+                .arg(winePath)
+                .toUtf8());
+
+  const XeniaScanResult result = XeniaScanner::scan({root});
+  QCOMPARE(result.games.size(), 1);
+  QCOMPARE(result.games.first().path, xex);
+  QCOMPARE(result.games.first().title, QStringLiteral("A Game"));
+}
+
+void CoreTests::xeniaModelIsRepeatableAndPreservesLocalState() {
+  QTemporaryDir directory;
+  QVERIFY(directory.isValid());
+  const QString root = directory.path() + QStringLiteral("/Xenia");
+  writeFile(root + QStringLiteral("/xenia-canary.config.toml"), "storage_root = \"\"\n");
+  const QString dump =
+      directory.path() + QStringLiteral("/Xenia/content/Game X/default.xex");
+  QDir().mkpath(directory.path() + QStringLiteral("/Xenia/content/Game X"));
+  writeFile(dump, "xex");
+  XeniaGameModel model(directory.path() + QStringLiteral("/omakade.sqlite3"));
+  model.refreshFromRoots({root});
+  QCOMPARE(model.rowCount(), 1);
+  QCOMPARE(model.data(model.index(0), GameRoles::Source).toString(), QStringLiteral("Xenia"));
+  QCOMPARE(model.data(model.index(0), GameRoles::System).toString(), QStringLiteral("xbox360"));
+  model.toggleFavorite(0);
+  model.refreshFromRoots({root});
+  QVERIFY(model.data(model.index(0), GameRoles::Favorite).toBool());
+}
+
+void CoreTests::xeniaLauncherBuildsSafeCommands() {
+  const LaunchCommand command =
+      GameLauncher::xeniaCommand(QStringLiteral("/games/Fable II/default.xex"));
+  QCOMPARE(command.arguments, QStringList({QStringLiteral("/games/Fable II/default.xex")}));
+  QVERIFY(!GameLauncher::xeniaCommand(QStringLiteral("bad;id")).isValid());
+  QVERIFY(!GameLauncher::xeniaCommand(QStringLiteral("/games/notes.txt")).isValid());
+  QVERIFY(!GameLauncher::xeniaCommand(QStringLiteral("/games")).isValid());
 }
 
 void CoreTests::consolePortalsGroupRetroArchRomsAndCanFlatten() {


### PR DESCRIPTION
## Summary

Adds Xbox 360 game discovery and launching through [Xenia Canary](https://github.com/xenia-canary/xenia-canary), following the established emulator source pattern (Cemu, shadPS4, Dolphin).

## What it does

- **Scanner** (`src/sources/xenia/`): reads `recent.toml` from Xenia storage roots (`~/.local/share/Xenia`, `~/Documents/Xenia`, portable installs), normalizes Wine `Z:\...` paths written by Proton-based setups, and scans the storage root for `default.xex` dumps and ISO/XEX images with sidecar cover art.
- **Game model** (`src/library/XeniaGameModel`): SQLite cache (`xenia_games`), async scanning, favorite/hidden persistence, same roles/system taxonomy as the other console sources (`xbox360`).
- **Launcher**: validates `iso`/`xex` targets and resolves `xenia_canary` (plus common aliases) from PATH.
- **UI**: settings panel row with detection status, library filter chip with controller navigation, couch-mode filter, game-details manage button, empty/error states.
- **Backups**: `xenia_games` personal flags captured and restored with the existing round-trip.
- **Auto-detection**: mirrors Cemu/shadPS4 — the source enables itself when Xenia is detected and the user has not made an explicit choice.

## One behavioral note for review

The scanner's highest-confidence source is `recent.toml`, which Xenia only writes for games that have actually been launched at least once. A fresh Xenia install with no runs yet will show no games until the user launches one (or places dumps in the storage root, which is also scanned). If you'd prefer richer discovery (e.g. parsing `title_path`-style config entries or exposing a manual folder picker), happy to iterate.

## Testing

- `omakade_core_tests`: 156 passed, 0 failed
- `omakade_backup_recovery_tests`: 21 passed, 0 failed (includes a new `xenia_games` fixture row in the round-trip test)
- Built clean with `cmake --preset dev && cmake --build --preset dev`

## Checklist

- [x] Pattern-matched against Cemu/shadPS4/Dolphin sources (record structs, scanner API, model lifecycle, launcher validation, QML wiring, backup snapshot)
- [x] Path validation reuses `validLaunchPath` guards (no shell invocation; QProcess argument lists)
- [x] Config keys follow the `*_enabled` / auto-detection convention
- [x] Docs updated (`docs/BACKUP-FORMAT.md`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Xbox 360 game support through Xenia Canary.
  * Discover games from recent titles, storage folders, XEX files, ISO images, and ZAR archives.
  * Browse, favorite, hide, track play sessions, and launch Xenia games.
  * Added Xenia filtering, settings, detection status, error messages, refresh, and rescanning controls.
  * Included Xenia games in library backups and the Emulated source filter.

* **Documentation**
  * Added Xenia support details to the README and unreleased changelog.
  * Documented Xenia backup data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->